### PR TITLE
Adding support to halt openocd or gdb on startup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,8 @@ AddOption("--cleanbuild", dest="cleanbuild", action="store_true")
 AddOption("--pio_args", dest="pio_args", type="string", action="store", default="")
 # add option to build without debug info
 AddOption("--release", dest="release", action="store_true")
+# add option to halt openocd/gdb on startup
+AddOption("--halt", dest="halt", action="store_true")
 
 
 def pio_build_cmd(source, **_):

--- a/components/steering_wheel/SConscript
+++ b/components/steering_wheel/SConscript
@@ -241,12 +241,30 @@ env.Alias("cdb", env.CompilationDatabase())
 env.Alias("upload", env.flash(source="build/steering_wheel.bin"))
 env.Alias("openocd", env.openocd_srv(interface=OPENOCD_INTERFACE, board=OPENOCD_BOARD))
 
+# give support for halting on gdb/openocd start
+mon_reset_cmd = '-ex "monitor reset'
+if GetOption("halt"):
+    mon_reset_cmd += 'halt"'
+else:
+    mon_reset_cmd += '"'
+
+env.Alias(
+    "flash-debug",
+    [env.flash_dbg(source="build/steering_wheel.bin"),
+    env.launch_gdb(
+        "build/steering_wheel.elf",
+        f"-ex 'target extended-remote | {env.openocd_cmd(interface=OPENOCD_INTERFACE, board=OPENOCD_BOARD)}'",
+        '-ex "monitor reset halt"',
+        '-ex load',
+    ),]
+)
 env.Alias(
     "openocd-gdb",
     env.launch_gdb(
         "build/steering_wheel.elf",
         f"-ex 'target extended-remote | {env.openocd_cmd(interface=OPENOCD_INTERFACE, board=OPENOCD_BOARD)}'",
-        '-ex "monitor reset"',
+        mon_reset_cmd,
+        '-ex load',
     ),
 )
 env.Alias(
@@ -254,6 +272,7 @@ env.Alias(
     env.launch_gdb(
         "build/steering_wheel.elf",
         '-ex "target extended-remote localhost:3333"',
-        '-ex "monitor reset"',
+        mon_reset_cmd,
+        '-ex load',
     ),
 )

--- a/site_scons/site_tools/st-flash.py
+++ b/site_scons/site_tools/st-flash.py
@@ -14,6 +14,11 @@ def generate(env):
             "st-flash write $SOURCE 0x08000000"
         )
     )
+    env['BUILDERS']['flash_dbg'] = SCons.Builder.Builder(
+        action = SCons.Action.Action(
+            "st-flash --hot-plug write $SOURCE 0x08000000"
+        )
+    )
 
 
 def exists():


### PR DESCRIPTION
As spoken with @rickyelopez, this gives the option to append --halt to openocd or gdb to break upon startup