### PR TITLE
Pin container version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   buildroot:
-    image: ghcr.io/concordia-fsae/containers/ubuntu-jammy-2022.04.21
+    image: ghcr.io/concordia-fsae/containers/ubuntu-jammy-2022.04.21:v0.1.0
     container_name: buildroot
     hostname: builder
     volumes: # mount pts


### PR DESCRIPTION
This is super important. Without this, changes to the container that correspond to changes in the firmware repo will make it so that older hashes of the firmware repo can't be built anymore.