### PR TITLE
Bug fix in bus load calculations and removal of compiler defines from command line

### DIFF
--- a/embedded/platforms/stm32/f1/stm32f103xb.yaml
+++ b/embedded/platforms/stm32/f1/stm32f103xb.yaml
@@ -1,6 +1,4 @@
 name: stm32f103
-defines:
-  NUM_CAN_BUSES: 1U
 extraSources:
   - "f103/startup_stm32f103xb.S"
   - "system_stm32f1xx.c"

--- a/embedded/platforms/stm32/f1/stm32f105.yaml
+++ b/embedded/platforms/stm32/f1/stm32f105.yaml
@@ -1,6 +1,4 @@
 name: stm32f105
-defines:
-  NUM_CAN_BUSES: 2U
 extraSources:
   - "f105/startup_stm32f105vc.S"
   - "system_stm32f1xx.c"


### PR DESCRIPTION
### Describe changes
1. Bugfix in yamcan calculation of busload. The issue was that messages from all buses were considered for a given node.
2. Removal of NUM_CAN_BUSES definition in chip config files
### Impact
1. Corrects bus load calculation for each individual bus ore accurately
2. Changes build command of every file, but no compiler directive gated off this define flag
### Test Plan
1. Not applicable
2. No hex diff, no test required