### PR TITLE
Fix file naming for docker on macOS

### DIFF
--- a/components/bms_boss/HW/HW_can_componentSpecific.c
+++ b/components/bms_boss/HW/HW_can_componentSpecific.c
@@ -22,7 +22,7 @@
 
 #include "NetworkDefines_generated.h"
 #include "MessageUnpack_generated.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "uds_componentSpecific.h"
 #include "LIB_app.h"
 

--- a/components/bms_boss/SConscript
+++ b/components/bms_boss/SConscript
@@ -183,7 +183,7 @@ rtos_source_files = [
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
 ]
 
 def render_generated_files(options, renderer, output_dir):

--- a/components/bms_boss/src/UDS.c
+++ b/components/bms_boss/src/UDS.c
@@ -25,7 +25,7 @@
 #include "HW_can.h"
 #include "ModuleDesc.h"
 #include "task.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "LIB_app.h"
 #include "Utility.h"
 

--- a/components/bms_worker/HW/HW_can_componentSpecific.c
+++ b/components/bms_worker/HW/HW_can_componentSpecific.c
@@ -17,7 +17,7 @@
 #include "stm32f1xx_hal_can.h"
 
 #include "MessageUnpack_generated.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "uds_componentSpecific.h"
 #include "Cooling.h"
 

--- a/components/bms_worker/SConscript
+++ b/components/bms_worker/SConscript
@@ -208,7 +208,7 @@ platform_src_files.extend(
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
 ]
 
 def render_generated_files(options, renderer, output_dir):

--- a/components/bms_worker/src/UDS.c
+++ b/components/bms_worker/src/UDS.c
@@ -25,7 +25,7 @@
 #include "HW_can.h"
 #include "ModuleDesc.h"
 #include "task.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "Utility.h"
 #include "LIB_app.h"
 

--- a/components/bootloaders/STM/stm32f1/SConscript
+++ b/components/bootloaders/STM/stm32f1/SConscript
@@ -120,7 +120,7 @@ src_files = [
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
     LIBS_DIR.File("libcrc/libcrc.c"),
 ]
 

--- a/components/bootloaders/STM/stm32f1/src/CAN.c
+++ b/components/bootloaders/STM/stm32f1/src/CAN.c
@@ -9,8 +9,7 @@
 
 // module include
 #include "CAN.h"
-#include "uds.h"
-#include "uds_componentSpecific.h"
+#include "lib_uds.h"
 
 #include "HW_NVIC.h"
 #include "Utilities.h"

--- a/components/bootloaders/STM/stm32f1/src/UDS.c
+++ b/components/bootloaders/STM/stm32f1/src/UDS.c
@@ -16,7 +16,7 @@
 #include "HW_FLASH.h"
 #include "libcrc.h"
 #include "Types.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "Utilities.h"
 
 // system includes

--- a/components/bootloaders/STM/stm32f1/src/main.c
+++ b/components/bootloaders/STM/stm32f1/src/main.c
@@ -9,7 +9,7 @@
 
 #include "CAN.h"
 #include "HW.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "UDS.h"
 #include "Utilities.h"
 

--- a/components/shared/code/HW/HW_can.c
+++ b/components/shared/code/HW/HW_can.c
@@ -13,7 +13,7 @@
 
 #include "CAN/CAN.h"
 #include "CAN/CanTypes.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "uds_componentSpecific.h"
 
 #include "NetworkDefines_generated.h"

--- a/components/shared/code/app/CAN/CANIO-rx.c
+++ b/components/shared/code/app/CAN/CANIO-rx.c
@@ -16,7 +16,7 @@
 #include "ModuleDesc.h"
 #include "Utility.h"
 #include "string.h"
-#include "uds.h"
+#include "lib_uds.h"
 
 #include "MessageUnpack_generated.h"
 #include "FeatureDefines_generated.h"

--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -179,7 +179,7 @@ rtos_source_files = [
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
 ]
 
 def render_generated_files(options, renderer, output_dir):

--- a/components/vc/front/src/HW/HW_can_componentSpecific.c
+++ b/components/vc/front/src/HW/HW_can_componentSpecific.c
@@ -19,8 +19,6 @@
 
 #include "NetworkDefines_generated.h"
 #include "MessageUnpack_generated.h"
-#include "uds.h"
-#include "uds_componentSpecific.h"
 #include "LIB_app.h"
 
 /******************************************************************************

--- a/components/vc/front/src/UDS.c
+++ b/components/vc/front/src/UDS.c
@@ -25,7 +25,7 @@
 #include "HW_can.h"
 #include "ModuleDesc.h"
 #include "task.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "LIB_app.h"
 #include "Utility.h"
 

--- a/components/vc/pdu/SConscript
+++ b/components/vc/pdu/SConscript
@@ -179,7 +179,7 @@ rtos_source_files = [
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
 ]
 
 def render_generated_files(options, renderer, output_dir):

--- a/components/vc/pdu/src/HW/HW_can_componentSpecific.c
+++ b/components/vc/pdu/src/HW/HW_can_componentSpecific.c
@@ -19,8 +19,6 @@
 
 #include "NetworkDefines_generated.h"
 #include "MessageUnpack_generated.h"
-#include "uds.h"
-#include "uds_componentSpecific.h"
 #include "LIB_app.h"
 
 /******************************************************************************

--- a/components/vc/pdu/src/UDS.c
+++ b/components/vc/pdu/src/UDS.c
@@ -25,7 +25,7 @@
 #include "HW_can.h"
 #include "ModuleDesc.h"
 #include "task.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "LIB_app.h"
 #include "Utility.h"
 

--- a/components/vc/rear/SConscript
+++ b/components/vc/rear/SConscript
@@ -179,7 +179,7 @@ rtos_source_files = [
 
 uds_srcs = [
     ISOTP_DIR.File("isotp.c"),
-    UDS_DIR.File("src/udsServer.c"),
+    UDS_DIR.File("src/lib_udsServer.c"),
 ]
 
 def render_generated_files(options, renderer, output_dir):

--- a/components/vc/rear/src/HW/HW_can_componentSpecific.c
+++ b/components/vc/rear/src/HW/HW_can_componentSpecific.c
@@ -19,8 +19,6 @@
 
 #include "NetworkDefines_generated.h"
 #include "MessageUnpack_generated.h"
-#include "uds.h"
-#include "uds_componentSpecific.h"
 #include "LIB_app.h"
 
 /******************************************************************************

--- a/components/vc/rear/src/UDS.c
+++ b/components/vc/rear/src/UDS.c
@@ -25,7 +25,7 @@
 #include "HW_can.h"
 #include "ModuleDesc.h"
 #include "task.h"
-#include "uds.h"
+#include "lib_uds.h"
 #include "LIB_app.h"
 #include "Utility.h"
 

--- a/embedded/libs/uds/include/lib_uds.h
+++ b/embedded/libs/uds/include/lib_uds.h
@@ -1,5 +1,5 @@
 /*
- * uds.h
+ * lib_uds.h
  * UDS implementation header
  */
 
@@ -11,7 +11,6 @@
 
 #include "uds_componentSpecific.h"
 
-#if UDS_ENABLE_LIB
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -277,4 +276,3 @@ void uds_cb_transferPayload(uint8_t *payload, uint8_t payloadLengthBytes);
  * @brief callback for a data ID read
  */
 void uds_cb_DIDRead(uint8_t *payload, uint8_t payloadLengthBytes);
-#endif // UDS_ENABLE_LIB

--- a/embedded/libs/uds/src/lib_udsServer.c
+++ b/embedded/libs/uds/src/lib_udsServer.c
@@ -10,7 +10,7 @@
  ******************************************************************************/
 
 // module include
-#include "uds.h"
+#include "lib_uds.h"
 
 #if UDS_ENABLE_LIB
 #include "isotp.h"


### PR DESCRIPTION
Issue is due to case-insensitivity of macOS (also impacts windows) leaking into linux docker container which does have a case-sensitive file system