### PR TITLE
Improve buildroot.sh functionality

### DIFF
--- a/.github/workflows/standard_checks.yml
+++ b/.github/workflows/standard_checks.yml
@@ -27,3 +27,16 @@ jobs:
       build-targets: bl:1000,1001,1002,1003,1004,1005,1010,1011,1030,1031,1032
       flags: -j32 --package
       artifact-name: artifact-bootloader-updaters
+  validate-workflow: # TODO: Missing macos coverage, we would likely eed our own self
+                     # hosted macos runner todo this however
+    runs-on: self-hosted
+    needs: updaters
+    steps:
+      - name: Clean
+        uses: AutoModality/action-clean@1077775f5ef0022fc3a9d6f93377921ea3701fa7
+      - name: Pull Branch
+        id: pull
+        uses: concordia-fsae/firmware/.github/actions/pull/@master
+      - name: Enter Buildroot and Run Build
+        run: |
+          ./buildroot.sh -r "scons --targets=bmsb -j32"

--- a/buildroot.sh
+++ b/buildroot.sh
@@ -77,5 +77,4 @@ IMAGE_TAG=${IMAGE_TAG} docker-compose run --rm buildroot $RUN_COMMAND
 EXIT_CODE=$?
 if [ $EXIT_CODE != 0 ]; then
     echo "Container exited with error code $EXIT_CODE..."
-    exit $EXIT_CODE;
 fi

--- a/buildroot.sh
+++ b/buildroot.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
 POSITIONAL_ARGS=()
-CONTAINER_NAME="buildroot"
+CURRENT_TAG="v1.0.0"
+IMAGE_TAG=$CURRENT_TAG
+RUN_COMMAND=""
 
 print_help () {
+    echo "Usage 'buildroot.sh [OPTIONS] COMMAND"
     echo "Buildroot help..."
+    echo "Options:"
     echo "  -h --help            Displays this help message"
     echo "  -l --latest          Displays this help message"
+    echo "  -r --run COMMAND     Command to run in the docker container once started"
+    echo "  -t --tag TAG         The tag to use for the buildroot container. Default's to $IMAGE_TAG"
+}
+
+validate_tag_change () {
+    if [ $IMAGE_TAG != $CURRENT_TAG ]; then \
+        echo "Cannot specify tag and latest in the same command. Exiting..." && \
+        exit 1;
+    fi
+
 }
 
 for var in "$@"
@@ -17,8 +31,19 @@ do
             exit 0
             ;;
         -l|--latest)
-            echo "Running latest version of buildroot"
-            CONTAINER_NAME+="-latest"
+            validate_tag_change
+            IMAGE_TAG="latest"
+            ;;
+        -t|--tag)
+            validate_tag_change
+            shift
+            IMAGE_TAG="$1"
+            shift
+            ;;
+        -r|--run)
+            shift
+            RUN_COMMAND="$1"
+            shift
             ;;
         -*|--*) # catch any unknown args and exit
             echo "Unknown option $1"
@@ -26,15 +51,31 @@ do
             exit 1
             ;;
         *)
-        POSITIONAL_ARGS+=("$1") # save positional arg
-        shift # past argument
-        ;;
+            break
+            ;;
+    esac
+done
+
+for var in "$@"
+do
+    case $1 in
+        *)
+            POSITIONAL_ARGS+=("$1") # save positional arg
+            shift # past argument
+            ;;
     esac
 done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # one day we can do things here with positional args or params
 # for now, just always start the container
-docker-compose pull $CONTAINER_NAME
+echo "Pulling buildroot image tag '$IMAGE_TAG'"
+docker-compose pull buildroot
 docker-compose up -d
-docker-compose run --rm $CONTAINER_NAME
+IMAGE_TAG=${IMAGE_TAG} docker-compose run --rm buildroot $RUN_COMMAND
+
+EXIT_CODE=$?
+if [ $EXIT_CODE != 0 ]; then
+    echo "Container exited with error code $EXIT_CODE..."
+    exit $EXIT_CODE;
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-  buildroot: &buildroot
-    image: ghcr.io/concordia-fsae/containers/ubuntu-noble-lts:v1.0.0
+  buildroot:
+    image: ghcr.io/concordia-fsae/containers/ubuntu-noble-lts:${IMAGE_TAG:-latest}
     container_name: buildroot
     hostname: builder
     volumes: # mount pts
@@ -12,6 +12,3 @@ services:
     devices:
       # map host's usb buses to container's buses for st-link programmer
       - "/dev/bus/usb/:/dev/bus/usb/"
-  buildroot-latest:
-    <<: *buildroot
-    image: ghcr.io/concordia-fsae/containers/ubuntu-noble-lts:latest


### PR DESCRIPTION
### Describe changes

1. Buildroot script adds run commands to execute when the container starts
2. The script exits with the same error code as the container to be used in CI
3. Added a self-hosted workflow verification

### Impact

1. Workflow codepaths are impacted

### Test Plan

- [x] Completed and successful workflow build
- [x] Run a check with a command that should fail in scons and make sure it fails
Run: https://github.com/concordia-fsae/firmware/actions/runs/13754667992/job/38460375031
