### PR TITLE
Added ability to skip bootloaders in platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         type: string
       build-type:
         description: "'platform' or 'targets' build"
-        default: "-j32"
+        required: true
         type: string
       artifact-name:
         description: "Artifact name"

--- a/.github/workflows/standard_checks.yml
+++ b/.github/workflows/standard_checks.yml
@@ -13,20 +13,18 @@ jobs:
     with:
       build-type: platform
       build-targets: ${{ matrix.car }}
-      flags: -j32 --flashable-bootloader --package
+      flags: -j32 --skip-bl --package
       artifact-name: artifact-${{ matrix.car }}
   updaters:
-    needs: cfr
     uses: ./.github/workflows/build.yml
     with:
-      build-type: targets
-      build-targets: bl:1000,1001,1002,1003,1004,1005,1010,1011,1030,1031,1032
-      flags: -j32 --package
-      artifact-name: artifact-bootloader-updaters
+      build-type: targets 
+      build-targets: bl
+      flags: -j32 --flashable-bootloader --package
+      artifact-name: artifact-bootloaders
   validate-workflow: # TODO: Missing macos coverage, we would likely eed our own self
                      # hosted macos runner todo this however
     runs-on: self-hosted
-    needs: updaters
     steps:
       - name: Clean
         uses: AutoModality/action-clean@1077775f5ef0022fc3a9d6f93377921ea3701fa7

--- a/components/bootloaders/SConscript
+++ b/components/bootloaders/SConscript
@@ -1,8 +1,15 @@
 #!/usr/bin/python
-from SCons.Script import Import, Return
+from SCons.Script import Import, Return, AddOption, GetOption
 
 Import("*")
 
-artifacts = SConscript("STM/stm32f1/SConscript", exports=["CONFIG_IDS", "PLATFORM_ENV"])
+try:
+    AddOption("--skip-bl", dest="skip-bl", action="store_true")
+except:
+    pass
 
+if not GetOption("skip-bl"):
+    artifacts = SConscript("STM/stm32f1/SConscript", exports=["CONFIG_IDS", "PLATFORM_ENV"])
+else:
+    artifacts = {}
 Return('artifacts')


### PR DESCRIPTION
Build all bootloaders and vehicle controllers in seperate workflows to reduce time
Removed unecessary workflow dependencies. Can all run in parallel

### Describe changes

1. Skip bootloaders in platform builds for standard workflow
2. Build all bootloaders in seperate workflow
3. Remove unnecessary workflow dependencies

### Impact

1. Improved check runtimes

### Test Plan

- [x] Successful checks run
