### PR TITLE
HW_tim improvement and BMSW set duty cycle integration

### DIFF
--- a/components/bms_boss/HW/HW_tim_componentSpecific.c
+++ b/components/bms_boss/HW/HW_tim_componentSpecific.c
@@ -133,21 +133,21 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* tim)
 /**
  * @brief  HAL callback called once an input capture has triggered
  *
- * @param htim TIM peripheral
+ * @param tim TIM peripheral
  */
-void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef* htim)
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef* tim)
 {
-    if (htim->Channel == HAL_TIM_ACTIVE_CHANNEL_2)    // If the interrupt is triggered by channel 1
+    if (tim->Channel == HAL_TIM_ACTIVE_CHANNEL_2)    // If the interrupt is triggered by channel 1
     {
         uint32_t ICValue, Duty, Frequency;
         // Read the IC value
-        ICValue = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_2);
+        ICValue = HAL_TIM_ReadCapturedValue(tim, TIM_CHANNEL_2);
 
         if (ICValue != 0)
         {
 
             // calculate the Duty Cycle
-            Duty = (HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_1) * 100) / ICValue;
+            Duty = (HAL_TIM_ReadCapturedValue(tim, TIM_CHANNEL_1) * 100) / ICValue;
 
 
             //Weird black magic? Has todo with counter and etc

--- a/components/bms_worker/HW/HW_Fans.c
+++ b/components/bms_worker/HW/HW_Fans.c
@@ -16,6 +16,7 @@
 
 // Other Inlcudes
 #include "Cooling.h"
+#include "include/HW_tim_componentSpecific.h"
 
 
 /******************************************************************************
@@ -96,8 +97,8 @@ void FANS_setPower(uint8_t* fan)
         }
     }
 
-    HW_TIM4_setDutyCH1(fans.percentage[FAN1]);
-    HW_TIM4_setDutyCH2(fans.percentage[FAN2]);
+    HW_TIM_setDuty(HW_TIM_PORT_PWM, HW_TIM_CHANNEL_1, ((float32_t)fans.percentage[FAN1]) / 100.0f);
+    HW_TIM_setDuty(HW_TIM_PORT_PWM, HW_TIM_CHANNEL_2, ((float32_t)fans.percentage[FAN2]) / 100.0f);
 }
 
 /**

--- a/components/bms_worker/HW/HW_intc.c
+++ b/components/bms_worker/HW/HW_intc.c
@@ -11,22 +11,16 @@
 #include "HW_intc.h"
 #include "stm32f1xx.h"
 #include "FeatureDefines_generated.h"
-
+#include "HW_tim.h"
 
 /******************************************************************************
  *                              E X T E R N S
  ******************************************************************************/
+
 extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;
 extern DMA_HandleTypeDef hdma_adc1;
-extern TIM_HandleTypeDef htim1;
-extern TIM_HandleTypeDef htim4;
-#if FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
-extern TIM_HandleTypeDef htim3;
-#endif // FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
-extern TIM_HandleTypeDef htim_tick;
 extern CAN_HandleTypeDef hcan;
-
 
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
@@ -106,13 +100,13 @@ void ADC1_2_IRQHandler(void)
  */
 void TIM4_IRQHandler(void)
 {
-    HAL_TIM_IRQHandler(&htim4);
+    HAL_TIM_IRQHandler(&htim[HW_TIM_PORT_PWM]);
 }
 
 void TIM3_IRQHandler(void)
 {
 #if FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
-    HAL_TIM_IRQHandler(&htim3);
+    HAL_TIM_IRQHandler(&htim[HW_TIM_PORT_HS_INTERRUPT]);
 #endif // FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
 }
 
@@ -123,12 +117,12 @@ void TIM2_IRQHandler(void)
 
 void TIM1_TRG_COM_IRQHandler(void)
 {
-    HAL_TIM_IRQHandler(&htim1);
+    HAL_TIM_IRQHandler(&htim[HW_TIM_PORT_TACH]);
 }
 
 void TIM1_CC_IRQHandler(void)
 {
-    HAL_TIM_IRQHandler(&htim1);
+    HAL_TIM_IRQHandler(&htim[HW_TIM_PORT_TACH]);
 }
 
 // CAN interrupts

--- a/components/bms_worker/HW/include/HW_tim_componentSpecific.h
+++ b/components/bms_worker/HW/include/HW_tim_componentSpecific.h
@@ -27,6 +27,11 @@
 
 typedef enum
 {
+    HW_TIM_PORT_TACH,
+#if FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
+    HW_TIM_PORT_HS_INTERRUPT,
+#endif
+    HW_TIM_PORT_PWM,
     HW_TIM_PORT_COUNT,
 } HW_TIM_port_E;
 
@@ -35,9 +40,7 @@ typedef enum
  ******************************************************************************/
 
 #if FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK == FEATURE_DISABLED
-void               HW_TIM_10kHz_timerStart(void);
+void     HW_TIM_10kHz_timerStart(void);
 #endif // FEATURE_HIGH_FREQUENCY_CELL_MEASUREMENT_TASK
-void               HW_TIM4_setDutyCH1(uint8_t);
-void               HW_TIM4_setDutyCH2(uint8_t);
-uint16_t           HW_TIM1_getFreqCH1(void);
-uint16_t           HW_TIM1_getFreqCH2(void);
+uint16_t HW_TIM1_getFreqCH1(void);
+uint16_t HW_TIM1_getFreqCH2(void);

--- a/components/shared/code/HW/HW_tim.c
+++ b/components/shared/code/HW/HW_tim.c
@@ -19,14 +19,16 @@
  ******************************************************************************/
 
 TIM_HandleTypeDef htim_tick;
-extern TIM_HandleTypeDef htim[HW_TIM_PORT_COUNT];
 
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/
 
-/* @brief  Set duty cycle of TIM4 CH2 output
- * @param percentage2 Duty cycle percentage. Unit: 1%
+/**
+ * @brief  Set duty cycle of output
+ * @param port Port to interact with
+ * @param channel Channel to set the duty cycle of
+ * @param percentage Duty cycle percentage
  */
 void HW_TIM_setDuty(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t percentage)
 {
@@ -48,11 +50,40 @@ void HW_TIM_setDuty(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t perc
 }
 
 /**
+ * @brief  Set duty cycle of output
+ * @param port Port to interact with
+ * @param channel Channel to set the duty cycle of
+ * @return Duty cycle percentage
+ */
+float32_t HW_TIM_getDuty(HW_TIM_port_E port, HW_TIM_channel_E channel)
+{
+    float32_t ret = 0.0f;
+
+    switch (channel)
+    {
+        case HW_TIM_CHANNEL_1:
+            ret = (((float32_t)htim[port].Instance->CCR1) / ((float32_t)htim[port].Init.Period));
+            break;
+        case HW_TIM_CHANNEL_2:
+            ret = (((float32_t)htim[port].Instance->CCR2) / ((float32_t)htim[port].Init.Period));
+            break;
+        case HW_TIM_CHANNEL_3:
+            ret = (((float32_t)htim[port].Instance->CCR3) / ((float32_t)htim[port].Init.Period));
+            break;
+        case HW_TIM_CHANNEL_4:
+            ret = (((float32_t)htim[port].Instance->CCR4) / ((float32_t)htim[port].Init.Period));
+            break;
+    }
+
+    return ret;
+}
+
+/**
  * @brief  Period elapsed callback in non blocking mode
  * @note   This function is called  when TIM4 interrupt took place, inside
  * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
  * a global variable "uwTick" used as application time base.
- * @param  htim : TIM handle
+ * @param  tim : TIM handle
  */
 __weak void HW_TIM_periodElapsedCb(TIM_HandleTypeDef* tim)
 {
@@ -64,7 +95,7 @@ __weak void HW_TIM_periodElapsedCb(TIM_HandleTypeDef* tim)
  * @note   This function is called TIMx interrupt took place, inside
  * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
  * a global variable "uwTick" used as application time base.
- * @param  htim : TIM handle
+ * @param  tim : TIM handle
  */
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* tim)
 {

--- a/components/shared/code/HW/HW_tim.h
+++ b/components/shared/code/HW/HW_tim.h
@@ -26,6 +26,13 @@ typedef enum
 } HW_TIM_channel_E;
 
 /******************************************************************************
+ *                              E X T E R N S
+ ******************************************************************************/
+
+extern TIM_HandleTypeDef htim[HW_TIM_PORT_COUNT];
+extern TIM_HandleTypeDef htim_tick;
+
+/******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/
 
@@ -41,3 +48,6 @@ void               HW_TIM_delayUS(uint8_t us);
 
 void               HW_TIM_periodElapsedCb(TIM_HandleTypeDef* tim);
 void               HW_TIM_setDuty(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t percentage);
+void               HW_TIM_setFreqHz(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t hz);
+float32_t          HW_TIM_getDuty(HW_TIM_port_E port, HW_TIM_channel_E channel);
+float32_t          HW_TIM_getFreqHz(HW_TIM_port_E port, HW_TIM_channel_E channel);


### PR DESCRIPTION
Partial integration of BMSW
Support legacy BMSB

### Describe changes

1. Improve the shared interface for setting PWM duty cycle
2. Integrate into bmsw

### Impact

1. Impacts BMS fan control

### Test Plan

- [ ] Flash bmsw
- [ ] On boot, ensure the fan speed ramps up and down to ~9000rpm and both fan1 and fan2 channels
