### PR TITLE
Bringup Pedal Monitor and APPS/BPPC

### DIFF
--- a/components/shared/code/DRV/drv_pedalMonitor.c
+++ b/components/shared/code/DRV/drv_pedalMonitor.c
@@ -116,13 +116,37 @@ float32_t drv_pedalMonitor_getPedalPosition(drv_pedalMonitor_channel_E channel)
 }
 
 /**
- * @brief Get the pedal position of a channel
+ * @brief Get the pedal state of a channel
  * @param channel The channel to retrieve
  * @return The current state of the pedal channel 
  */
 drv_pedalMonitor_state_E drv_pedalMonitor_getPedalState(drv_pedalMonitor_channel_E channel)
 {
     return pedals[channel].state;
+}
+
+/**
+ * @brief Get the pedal CAN state of a channel
+ * @param channel The channel to retrieve
+ * @return The current state of the pedal channel 
+ */
+CAN_pedalState_E drv_pedalMonitor_getPedalStateCAN(drv_pedalMonitor_channel_E channel)
+{
+    CAN_pedalState_E ret = CAN_PEDALSTATE_SNA;
+
+    switch (pedals[channel].state)
+    {
+        case DRV_PEDALMONITOR_OK:
+            ret = CAN_PEDALSTATE_OK;
+            break;
+        case DRV_PEDALMONITOR_FAULT:
+            ret = CAN_PEDALSTATE_FAULT;
+            break;
+        default:
+            break;
+    }
+
+    return ret;
 }
 
 /**

--- a/components/shared/code/DRV/drv_pedalMonitor.c
+++ b/components/shared/code/DRV/drv_pedalMonitor.c
@@ -1,0 +1,136 @@
+/**
+ * @file drv_pedalMonitor.c
+ * @brief Source file for pedal monitor
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_pedalMonitor.h"
+#include "drv_inputAD.h"
+#include "lib_utility.h"
+
+/******************************************************************************
+ *                              E X T E R N S
+ ******************************************************************************/
+
+extern drv_pedalMonitor_channelConfig_S drv_pedalMonitor_channels[DRV_PEDALMONITOR_CHANNEL_COUNT];
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef struct
+{
+    float32_t                voltage;
+    float32_t                percentage;
+    drv_pedalMonitor_state_E state;
+} drv_pedalMonitor_channelData_S;
+
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+static drv_pedalMonitor_channelData_S pedals[DRV_PEDALMONITOR_CHANNEL_COUNT];
+
+/******************************************************************************
+ *                       P U B L I C  F U N C T I O N S
+ ******************************************************************************/
+
+/**
+ * @brief Initialize all pedal monitor channels
+ * @note All channels initialize to INIT and 0% pedal position
+ */
+void drv_pedalMonitor_init(void)
+{
+    for (uint8_t i = 0U; i < DRV_PEDALMONITOR_CHANNEL_COUNT; i++)
+    {
+        switch (drv_pedalMonitor_channels[i].type)
+        {
+            case DRV_PEDALMONITOR_TYPE_ANALOG:
+                lib_interpolation_init(&drv_pedalMonitor_channels[i].input.analog.pedal_map,
+                                       0.0f);
+                break;
+            default:
+                break;
+        }
+
+        pedals[i].percentage = 0.0f;
+        pedals[i].state = DRV_PEDALMONITOR_INIT;
+    }
+}
+
+/**
+ * @brief Run the pedal monitor on all pedal monitor channels
+ */
+void drv_pedalMonitor_run(void)
+{
+    for (uint8_t i = 0U; i < DRV_PEDALMONITOR_CHANNEL_COUNT; i++)
+    {
+        drv_pedalMonitor_state_E state = DRV_PEDALMONITOR_FAULT;
+        float32_t percentage = 0.0f;
+
+        switch (drv_pedalMonitor_channels[i].type)
+        {
+            case DRV_PEDALMONITOR_TYPE_ANALOG:
+                {
+                    pedals[i].voltage = drv_inputAD_getAnalogVoltage(drv_pedalMonitor_channels[i].input.analog.channel);
+                    if ((pedals[i].voltage <= drv_pedalMonitor_channels[i].input.analog.fault_high) &&
+                        (pedals[i].voltage >= drv_pedalMonitor_channels[i].input.analog.fault_low))
+                    {
+                        state = DRV_PEDALMONITOR_OK;
+                        percentage = lib_interpolation_interpolate(&drv_pedalMonitor_channels[i].input.analog.pedal_map,
+                                                                   pedals[i].voltage);
+                    }
+                }
+                break;
+            case DRV_PEDALMONITOR_TYPE_CAN:
+                {
+                    float32_t percentage_temp = 0.0f; // CAN percentages are 0-100
+                    if (drv_pedalMonitor_channels[i].input.canrx_getPedalPosition(&percentage_temp) == CANRX_MESSAGE_VALID)
+                    {
+                        state = DRV_PEDALMONITOR_OK;
+                        percentage = percentage_temp / 100.0f;
+                    }
+                }
+                break;
+        }
+
+        pedals[i].state = state;
+        pedals[i].percentage = SATURATE(0.0f, percentage, 1.0f);
+    }
+}
+
+/**
+ * @brief Get the pedal position of a channel
+ * @param channel The channel to retrieve
+ * @return The pedal position mapped from 0.0f to 1.0f where 0.0f is 0% and 1.0f is 100%
+ */
+float32_t drv_pedalMonitor_getPedalPosition(drv_pedalMonitor_channel_E channel)
+{
+    return (pedals[channel].state == DRV_PEDALMONITOR_OK) ? pedals[channel].percentage : 0.0f;
+}
+
+/**
+ * @brief Get the pedal position of a channel
+ * @param channel The channel to retrieve
+ * @return The current state of the pedal channel 
+ */
+drv_pedalMonitor_state_E drv_pedalMonitor_getPedalState(drv_pedalMonitor_channel_E channel)
+{
+    return pedals[channel].state;
+}
+
+/**
+ * @brief Get the pedal sensor voltage
+ * @param channel The channel to retrieve
+ * @return The voltage of the sensor
+ */
+float32_t drv_pedalMonitor_getPedalVoltage(drv_pedalMonitor_channel_E channel)
+{
+    return pedals[channel].voltage;
+}

--- a/components/shared/code/DRV/drv_pedalMonitor.h
+++ b/components/shared/code/DRV/drv_pedalMonitor.h
@@ -1,0 +1,73 @@
+/**
+ * @file drv_pedalMonitor.h
+ * @brief Header file for pedal monitor
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+ *
+ * Setup
+ * 1. Define the pedal monitor channels in drv_pedalMonitor_componentSpecific.h
+ *    and name it drv_pedalMonitor_channel_E
+ * 2. Declare and configure the pedal channels in drv_pedalMonitor_componentSpecific.c
+ *    and name it drv_pedalMonitor_channels
+ * 3. Initialize the pedal monitor driver with drv_pedalMonitor_init
+ *
+ * Usage
+ * - Periodically (at the desired frequency) call the drv_pedalMonitor_run function
+ * - Get the current pedal position with the drv_pedalMonitor_getPedalPosition function
+ *   Note: Read the note attached at the top of this file for pedal percentage mapping
+ * - The pedal_map of an analog channel must saturate left and saturate right, with a
+ *   min value of 0.0f and a max value of 1.0f
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_pedalMonitor_componentSpecific.h"
+#include "LIB_Types.h"
+#include "drv_inputAD.h"
+#include "lib_interpolation.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    DRV_PEDALMONITOR_INIT = 0x00,
+    DRV_PEDALMONITOR_OK,
+    DRV_PEDALMONITOR_FAULT,
+} drv_pedalMonitor_state_E;
+
+typedef struct
+{
+    enum
+    {
+        DRV_PEDALMONITOR_TYPE_ANALOG = 0x00U,
+        DRV_PEDALMONITOR_TYPE_CAN,
+    } type;
+    union
+    {
+        struct
+        {
+            drv_inputAD_channelAnalog_E channel;
+            float32_t                   fault_high; // When the measured voltage is above this, fault
+            float32_t                   fault_low; // When the voltage is below this, fault
+            lib_interpolation_mapping_S pedal_map;
+        } analog;
+        CANRX_MESSAGE_health_E (*canrx_getPedalPosition)(float32_t* percentage);
+    } input;
+} drv_pedalMonitor_channelConfig_S;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+void                     drv_pedalMonitor_init(void);
+void                     drv_pedalMonitor_run(void);
+float32_t                drv_pedalMonitor_getPedalPosition(drv_pedalMonitor_channel_E channel);
+drv_pedalMonitor_state_E drv_pedalMonitor_getPedalState(drv_pedalMonitor_channel_E channel);
+float32_t                drv_pedalMonitor_getPedalVoltage(drv_pedalMonitor_channel_E channel);

--- a/components/shared/code/DRV/drv_pedalMonitor.h
+++ b/components/shared/code/DRV/drv_pedalMonitor.h
@@ -70,4 +70,5 @@ void                     drv_pedalMonitor_init(void);
 void                     drv_pedalMonitor_run(void);
 float32_t                drv_pedalMonitor_getPedalPosition(drv_pedalMonitor_channel_E channel);
 drv_pedalMonitor_state_E drv_pedalMonitor_getPedalState(drv_pedalMonitor_channel_E channel);
+CAN_pedalState_E         drv_pedalMonitor_getPedalStateCAN(drv_pedalMonitor_channel_E channel);
 float32_t                drv_pedalMonitor_getPedalVoltage(drv_pedalMonitor_channel_E channel);

--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -148,6 +148,7 @@ project_source_files = [
     SRC_DIR.File("UDS.c"),
     SHARED_LIBS.File("LIB_app.c"),
     SHARED_LIBS.File("LIB_simpleFilter.c"),
+    SHARED_LIBS.File("lib_interpolation.c"),
 ]
 
 project_hw_files = [
@@ -171,6 +172,8 @@ project_hw_files = [
     SHARED_DRV.File("drv_outputAD.c"),
     HW_DIR.File("drv_outputAD_componentSpecific.c"),
     SHARED_DRV.File("drv_io.c"),
+    SHARED_DRV.File("drv_pedalMonitor.c"),
+    HW_DIR.File("drv_pedalMonitor_componentSpecific.c"),
 ]
 
 project_source_files += project_hw_files

--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -149,6 +149,9 @@ project_source_files = [
     SHARED_LIBS.File("LIB_app.c"),
     SHARED_LIBS.File("LIB_simpleFilter.c"),
     SHARED_LIBS.File("lib_interpolation.c"),
+    SRC_DIR.File("apps.c"),
+    SRC_DIR.File("bppc.c"),
+    SRC_DIR.File("torque.c"),
 ]
 
 project_hw_files = [

--- a/components/vc/front/include/CANIO_componentSpecific.h
+++ b/components/vc/front/include/CANIO_componentSpecific.h
@@ -20,6 +20,9 @@
 #include "Module.h"
 #include "drv_pedalMonitor.h"
 #include "drv_inputAD.h"
+#include "apps.h"
+#include "bppc.h"
+#include "torque.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -47,5 +50,9 @@
 #define set_apps1Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS1))
 #define set_apps2Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS2))
 #define set_brakeVoltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_BRAKE_POT))
+#define set_acceleratorState(m,b,n,s) set(m,b,n,s, apps_getStateCAN())
+#define set_bppcState(m,b,n,s) set(m,b,n,s, bppc_getStateCAN())
+#define set_torqueRequest(m,b,n,s) set(m,b,n,s, torque_getTorqueRequest())
+#define set_torqueManagerState(m,b,n,s) set(m,b,n,s, torque_getStateCAN())
 
 #include "TemporaryStubbing.h"

--- a/components/vc/front/include/CANIO_componentSpecific.h
+++ b/components/vc/front/include/CANIO_componentSpecific.h
@@ -18,6 +18,8 @@
 
 // imports for data access
 #include "Module.h"
+#include "drv_pedalMonitor.h"
+#include "drv_inputAD.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -35,5 +37,15 @@
 #define set_taskUsage10Hz(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_10Hz_TASK));
 #define set_taskUsage1Hz(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_1Hz_TASK));
 #define set_taskUsageIdle(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
+#define set_apps1(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_APPS1) * 100)
+#define set_apps2(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_APPS2) * 100)
+#define set_brakePosition(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_BRAKE_POT) * 100)
+#define set_acceleratorPosition(m,b,n,s) set(m,b,n,s, apps_getPedalPosition() * 100)
+#define set_apps1State(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_APPS1))
+#define set_apps2State(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_APPS2))
+#define set_brakeState(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_BRAKE_POT))
+#define set_apps1Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS1))
+#define set_apps2Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS2))
+#define set_brakeVoltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_BRAKE_POT))
 
 #include "TemporaryStubbing.h"

--- a/components/vc/front/include/HW/drv_pedalMonitor_componentSpecific.h
+++ b/components/vc/front/include/HW/drv_pedalMonitor_componentSpecific.h
@@ -1,0 +1,26 @@
+/**
+ * @file drv_pedalMonitor_componentSpecific.h
+ * @brief Header file for the VCFRONT component specific pedal monitor
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_pedalMonitor.h"
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    DRV_PEDALMONITOR_APPS1 = 0x00,
+    DRV_PEDALMONITOR_APPS2,
+    DRV_PEDALMONITOR_BRAKE_POT,
+    DRV_PEDALMONITOR_CHANNEL_COUNT
+} drv_pedalMonitor_channel_E;

--- a/components/vc/front/include/Module_componentSpecific.h
+++ b/components/vc/front/include/Module_componentSpecific.h
@@ -19,6 +19,9 @@
 /**< Modules */
 extern const ModuleDesc_S CANIO_rx;
 extern const ModuleDesc_S UDS_desc;
+extern const ModuleDesc_S apps_desc;
+extern const ModuleDesc_S bppc_desc;
+extern const ModuleDesc_S torque_desc;
 extern const ModuleDesc_S CANIO_tx;
 
 /******************************************************************************
@@ -29,6 +32,9 @@ typedef enum
 {
     MODULE_CANIO_rx = 0x00U,
     MODULE_UDS,
+    MODULE_APPS,
+    MODULE_BPPC,
+    MODULE_TORQUE,
     MODULE_CANIO_tx,
     MODULE_CNT
 } Module_tasks_E;

--- a/components/vc/front/include/apps.h
+++ b/components/vc/front/include/apps.h
@@ -1,0 +1,35 @@
+/**
+ * @file apps.h
+ * @brief Module header for the Accelerator Pedal Position Sensor
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+*/
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "LIB_Types.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    APPS_INIT = 0x00U,
+    APPS_OK,
+    APPS_FAULT,
+    APPS_ERROR, // Sensor failure
+} apps_state_E;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+float32_t       apps_getPedalPosition(void);
+apps_state_E    apps_getState(void);
+CAN_appsState_E apps_getStateCAN(void);

--- a/components/vc/front/include/bppc.h
+++ b/components/vc/front/include/bppc.h
@@ -1,0 +1,37 @@
+/**
+* @file bppc.h
+* @brief Module header for the Brake Pedal Plsuibility Check
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+*/
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "LIB_Types.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    BPPC_INIT = 0x00U,
+    BPPC_OK,
+    BPPC_FAULT,
+    BPPC_FAULT_LATCHED,
+    BPPC_ERROR, // Sensor failure
+} bppc_state_E;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+float32_t       bppc_getPedalPosition(void);
+bppc_state_E    bppc_getState(void);
+CAN_bppcState_E bppc_getStateCAN(void);
+

--- a/components/vc/front/include/torque.h
+++ b/components/vc/front/include/torque.h
@@ -1,0 +1,34 @@
+/**
+ * @file torque.h
+ * @brief Torque manager for vehicle control
+ * @note Units for torque are in Nm
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "LIB_Types.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    TORQUE_INIT = 0x00U,
+    TORQUE_INACTIVE,
+    TORQUE_ACTIVE,
+    TORQUE_ERROR,
+} torque_state_E;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+float32_t                torque_getTorqueRequest(void);
+torque_state_E           torque_getState(void);
+CAN_torqueManagerState_E torque_getStateCAN(void);

--- a/components/vc/front/src/HW/drv_pedalMonitor_componentSpecific.c
+++ b/components/vc/front/src/HW/drv_pedalMonitor_componentSpecific.c
@@ -1,0 +1,104 @@
+/**
+ * @file drv_pedalMonitor_componentSpecific.c
+ * @brief Header file for pedal monitor
+ * @note Pedal positon is a float percentage between 0.0f and 1.0f where 
+ *       0.0f is 0% and 1.0f is 100%
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_pedalMonitor.h"
+#include "Utility.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+/**
+ * @member x [V] Pedal pot voltage
+ * @member y [%] Pedal position 0.0f-1.0f | 0.0f = 0%, 1.0f = 100%
+ */
+lib_interpolation_point_S mapping_apps1[] = {
+    { .x = 0.528f, .y = 1.0f,  },
+    { .x = 0.689f, .y = 0.8f,  },
+    { .x = 0.857f, .y = 0.65f, },
+    { .x = 1.010f, .y = 0.5f,  },
+    { .x = 1.172f, .y = 0.35f, },
+    { .x = 1.333f, .y = 0.2f,  },
+    { .x = 1.494f, .y = 0.1f,  },
+    { .x = 1.654f, .y = 0.05f, },
+    { .x = 1.815f, .y = 0.0f,  },
+};
+
+/**
+ * @member x [V] Pedal pot voltage
+ * @member y [%] Pedal position 0.0f-1.0f | 0.0f = 0%, 1.0f = 100%
+ */
+lib_interpolation_point_S mapping_apps2[] = {
+    { .x = 0.937f, .y = 1.0f,  },
+    { .x = 1.059f, .y = 0.8f,  },
+    { .x = 1.181f, .y = 0.65f, },
+    { .x = 1.316f, .y = 0.5f,  },
+    { .x = 1.436f, .y = 0.35f, },
+    { .x = 1.562f, .y = 0.2f,  },
+    { .x = 1.685f, .y = 0.1f,  },
+    { .x = 1.808f, .y = 0.05f, },
+    { .x = 1.931f, .y = 0.0f,  },
+};
+
+// TODO: Calibrate
+/**
+ * @member x [V] Pedal pot voltage
+ * @member y [%] Pedal position 0.0f-1.0f | 0.0f = 0%, 1.0f = 100%
+ */
+lib_interpolation_point_S mapping_brake_pot[] = {
+    { .x = 0.5f,   .y = 0.0f,  },
+    { .x = 1.5f,   .y = 1.0f,  },
+};
+
+drv_pedalMonitor_channelConfig_S drv_pedalMonitor_channels[DRV_PEDALMONITOR_CHANNEL_COUNT] = {
+    [DRV_PEDALMONITOR_APPS1] = {
+        .type = DRV_PEDALMONITOR_TYPE_ANALOG,
+        .input.analog = {
+            .channel = DRV_INPUTAD_ANALOG_APPS_P1,
+            .fault_high = 1.9f,
+            .fault_low = 0.4f,
+            .pedal_map = {
+                .points = (lib_interpolation_point_S*)&mapping_apps1,
+                .number_points = COUNTOF(mapping_apps1),
+                .saturate_left = true,
+                .saturate_right = true,
+            },
+        }
+    },
+    [DRV_PEDALMONITOR_APPS2] = {
+        .type = DRV_PEDALMONITOR_TYPE_ANALOG,
+        .input.analog = {
+            .channel = DRV_INPUTAD_ANALOG_APPS_P2,
+            .fault_high = 2.05f,
+            .fault_low = 0.8f,
+            .pedal_map = {
+                .points = (lib_interpolation_point_S*)&mapping_apps2,
+                .number_points = COUNTOF(mapping_apps2),
+                .saturate_left = true,
+                .saturate_right = true,
+            },
+        }
+    },
+    [DRV_PEDALMONITOR_BRAKE_POT] = {
+        .type = DRV_PEDALMONITOR_TYPE_ANALOG,
+        .input.analog = {
+            .channel = DRV_INPUTAD_ANALOG_BR_POT,
+            .fault_high = 0.0f,
+            .fault_low = 0.0f,
+            .pedal_map = {
+                .points = (lib_interpolation_point_S*)&mapping_brake_pot,
+                .number_points = COUNTOF(mapping_brake_pot),
+                .saturate_left = true,
+                .saturate_right = true,
+            },
+        }
+    },
+};

--- a/components/vc/front/src/Module_componentSpecific.c
+++ b/components/vc/front/src/Module_componentSpecific.c
@@ -11,6 +11,7 @@
 #include "Module.h"
 #include "drv_tps20xx.h"
 #include "drv_inputAD.h"
+#include "drv_pedalMonitor.h"
 
 /******************************************************************************
  *                         P R I V A T E  V A R S
@@ -34,7 +35,7 @@ void Module_componentSpecific_Init(void)
     // Initialize drivers prior to application runtime
     drv_inputAD_init_componentSpecific();
     drv_tps20xx_init();
-
+    drv_pedalMonitor_init();
 }
 
 /**
@@ -44,6 +45,15 @@ void Module_componentSpecific_Init(void)
 void Module_componentSpecific_10Hz(void)
 {
     drv_tps20xx_run();
+}
+
+/**
+ * #brief Run the pre 100Hz task functions
+ * @note typically reserved for drivers
+ */
+void Module_componentSpecific_100Hz(void)
+{
+    drv_pedalMonitor_run();
 }
 
 /**

--- a/components/vc/front/src/Module_componentSpecific.c
+++ b/components/vc/front/src/Module_componentSpecific.c
@@ -23,6 +23,9 @@
 const ModuleDesc_S* modules[MODULE_CNT] = {
     &CANIO_rx,
     &UDS_desc,
+    &apps_desc,
+    &bppc_desc,
+    &torque_desc,
     &CANIO_tx,
 };
 

--- a/components/vc/front/src/bppc.c
+++ b/components/vc/front/src/bppc.c
@@ -1,0 +1,98 @@
+/**
+* @file bppc.c
+* @brief Module source for the Brake Pedal Plausibility Check
+*/
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "bppc.h"
+#include "apps.h"
+#include "drv_pedalMonitor.h"
+#include "Module.h"
+#include "ModuleDesc.h"
+#include "string.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+static struct
+{
+    bppc_state_E state;
+} bppc_data;
+
+/******************************************************************************
+ *                       P U B L I C  F U N C T I O N S
+ ******************************************************************************/
+
+bppc_state_E bppc_getState(void)
+{
+    return bppc_data.state;
+}
+
+CAN_bppcState_E bppc_getStateCAN(void)
+{
+    CAN_bppcState_E ret = CAN_BPPCSTATE_SNA;
+
+    switch (bppc_data.state)
+    {
+        case BPPC_OK:
+            ret = CAN_BPPCSTATE_OK;
+            break;
+        case BPPC_FAULT:
+            ret = CAN_BPPCSTATE_FAULT;
+            break;
+        case BPPC_FAULT_LATCHED:
+            ret = CAN_BPPCSTATE_FAULT_LATCHED;
+            break;
+        case BPPC_ERROR:
+            ret = CAN_BPPCSTATE_ERROR;
+            break;
+        default:
+            break;
+    }
+
+    return ret;
+}
+
+static void bppc_init(void)
+{
+    memset(&bppc_data, 0x00U, sizeof(bppc_data));
+}
+
+static void bppc_periodic_100Hz(void)
+{
+    bppc_state_E state = BPPC_ERROR;
+
+    if (drv_pedalMonitor_getPedalState(DRV_PEDALMONITOR_BRAKE_POT) == DRV_PEDALMONITOR_OK)
+    {
+        const float32_t brake_pos = drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_BRAKE_POT);
+        const float32_t accelerator_pos = apps_getPedalPosition();
+
+        if ((accelerator_pos > 0.25f) && (brake_pos > 0.10f))
+        {
+            state = BPPC_FAULT;
+        }
+        else if ((bppc_data.state == BPPC_FAULT) && (brake_pos <= 0.10f))
+        {
+            state = BPPC_FAULT_LATCHED;
+        }
+        else if ((accelerator_pos < 0.05f) || (bppc_data.state == BPPC_OK))
+        {
+            state = BPPC_OK;
+        }
+    }
+
+    bppc_data.state = state;
+}
+
+/******************************************************************************
+ *                           P U B L I C  V A R S
+ ******************************************************************************/
+
+const ModuleDesc_S bppc_desc = {
+    .moduleInit = &bppc_init,
+    .periodic100Hz_CLK = &bppc_periodic_100Hz,
+};

--- a/components/vc/front/src/torque.c
+++ b/components/vc/front/src/torque.c
@@ -1,0 +1,127 @@
+/**
+ * @file torque.c
+ * @brief Torque manager source code for vehicle control
+ * @note Units for torque are in Nm
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "torque.h"
+#include "apps.h"
+#include "bppc.h"
+#include "Module.h"
+#include "ModuleDesc.h"
+#include "string.h"
+#include "lib_utility.h"
+
+/******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define DEFAULT_TORQUE_PITS 10.0f // 10Nm on boot
+#define DEFAULT_TORQUE_DRIVE 90.0f
+
+#define ABSOLUTE_MAX_TORQUE 150.0f
+#define ABSOLUTE_MIN_TORQUE 0.0f
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+static struct
+{
+    torque_state_E state;
+    float32_t      torque;
+    float32_t      torque_request_max;
+} torque_data;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+/**
+ * @brief Get the current torque request
+ * @return Current torque request in Nm
+ */
+float32_t torque_getTorqueRequest(void)
+{
+    return (torque_data.state == TORQUE_ACTIVE) ? torque_data.torque : 0.0f;
+}
+
+/**
+ * @brief Get current torque manager state
+ * @return CAN state of the torque manager
+ */
+torque_state_E torque_getState(void)
+{
+    return torque_data.state;
+}
+
+/**
+ * @brief Translate torque state to CAN
+ * @return CAN state of the torque manager
+ */
+CAN_torqueManagerState_E torque_getStateCAN(void)
+{
+    CAN_torqueManagerState_E ret = CAN_TORQUEMANAGERSTATE_SNA;
+
+    switch (torque_data.state)
+    {
+        case TORQUE_INACTIVE:
+            ret = CAN_TORQUEMANAGERSTATE_INACTIVE;
+            break;
+        case TORQUE_ACTIVE:
+            ret = CAN_TORQUEMANAGERSTATE_ACTIVE;
+            break;
+        default:
+            break;
+    }
+
+    return ret;
+}
+
+static void torque_init(void)
+{
+    memset(&torque_data, 0x00U, sizeof(torque_data));
+
+    torque_data.state = TORQUE_INACTIVE;
+    torque_data.torque_request_max = DEFAULT_TORQUE_PITS;
+}
+
+static void torque_periodic_100Hz(void)
+{
+    float32_t torque = 0.0f;
+
+    switch (torque_data.state)
+    {
+        case TORQUE_INACTIVE:
+            // TODO: Add vehicle power state transition for run mode
+            // Tracked in Issue #189
+            torque = 0.0f;
+            break;
+        case TORQUE_ACTIVE:
+            // TODO: Add vehicle power state transition after exiting run mode
+            // Tracked in Issue #189
+            torque = (bppc_getState() == BPPC_OK) ?
+                      apps_getPedalPosition() * torque_data.torque_request_max :
+                      0.0f;
+            break;
+        case TORQUE_ERROR:
+        default:
+            torque = 0.0f;
+            break;
+    }
+
+    torque_data.torque = SATURATE(ABSOLUTE_MIN_TORQUE, torque, ABSOLUTE_MAX_TORQUE);
+}
+
+/******************************************************************************
+ *                           P U B L I C  V A R S
+ ******************************************************************************/
+
+const ModuleDesc_S torque_desc = {
+    .moduleInit = &torque_init,
+    .periodic100Hz_CLK = &torque_periodic_100Hz,
+};

--- a/network/NetworkGen/NetworkGen.py
+++ b/network/NetworkGen/NetworkGen.py
@@ -312,6 +312,10 @@ def process_node(node: CanNode):
         for sig, definition in signals_dict.items():
             try:
                 SIGNAL_SCHEMA.validate(definition)
+                if "template" in definition:
+                    if definition["template"] not in templates["signals"]:
+                        raise Exception(f"Signal '{sig}' has template signal '{definition["template"]}' which can not be found in the template signals")
+                    definition.update(templates["signals"][definition["template"]])
                 if "nativeRepresentation" not in definition and "discreteValues" not in definition:
                     raise Exception(f"Signal '{sig}' in '{node.name}' has neither a discreteValues or nativeRepresentation.")
                 if "unit" in definition:

--- a/network/definition/data/components/vcfront/vcfront-message.yaml
+++ b/network/definition/data/components/vcfront/vcfront-message.yaml
@@ -11,3 +11,15 @@ messages:
     id: 0x551
     sourceBuses: veh
     template: rtosTaskInfo
+
+  pedalPosition:
+    description: Pedal position
+    id: 0x50
+    cycleTimeMs: 10
+    signals:
+      apps1:
+      apps2:
+      brakePosition:
+      apps1Voltage:
+      apps2Voltage:
+      brakeVoltage:

--- a/network/definition/data/components/vcfront/vcfront-message.yaml
+++ b/network/definition/data/components/vcfront/vcfront-message.yaml
@@ -19,7 +19,18 @@ messages:
     signals:
       apps1:
       apps2:
+      acceleratorPosition:
       brakePosition:
+      acceleratorState:
+      bppcState:
+      torqueRequest:
+      torqueManagerState:
+
+  pedalInformation:
+    description: Information of the pedal sensors
+    id: 0x51
+    cycleTimeMs: 100
+    signals:
       apps1Voltage:
       apps2Voltage:
       brakeVoltage:

--- a/network/definition/data/components/vcfront/vcfront-signals.yaml
+++ b/network/definition/data/components/vcfront/vcfront-signals.yaml
@@ -22,3 +22,30 @@ signals:
   brakeVoltage:
     description: "Voltage of the brake pedal"
     template: voltsPrecise
+
+  acceleratorPosition:
+    description: "Accelerator pedal position"
+    template: percentage
+
+  acceleratorState:
+    description: "State of the accelerator sensor"
+    discreteValues: appsState
+
+  bppcState:
+    description: "State of the accelerator sensor"
+    discreteValues: bppcState
+
+  torqueManagerState:
+    description: "State of the torque manager"
+    discreteValues: torqueManagerState
+
+  torqueRequest:
+    description: Torque request from the torque manager
+    unit: Nm
+    nativeRepresentation:
+      bitWidth: 8
+      range:
+        min: -100
+        max: 150
+      resolution: 1
+    continuous: true

--- a/network/definition/data/components/vcfront/vcfront-signals.yaml
+++ b/network/definition/data/components/vcfront/vcfront-signals.yaml
@@ -1,1 +1,24 @@
 signals:
+  apps1:
+    description: "Accelerator pedal 1 position"
+    template: percentage
+
+  apps2:
+    description: "Accelerator pedal 2 position"
+    template: percentage
+
+  brakePosition:
+    description: "Brake pedal position"
+    template: percentage
+
+  apps1Voltage:
+    description: "Voltage of the accelerator pedal 1"
+    template: voltsPrecise
+
+  apps2Voltage:
+    description: "Voltage of the accelerator pedal 2"
+    template: voltsPrecise
+
+  brakeVoltage:
+    description: "Voltage of the brake pedal"
+    template: voltsPrecise

--- a/network/definition/data/templates/signals.yaml
+++ b/network/definition/data/templates/signals.yaml
@@ -25,3 +25,12 @@ signals:
       range:
         min: 0
         max: 18446744073709551615
+  voltsPrecise:
+    unit: 'V'
+    nativeRepresentation:
+      resolution: 0.001
+      bitWidth: 13
+      range:
+        min: 0
+        max: 8
+    continuous: true

--- a/network/definition/discrete_values.yaml
+++ b/network/definition/discrete_values.yaml
@@ -96,3 +96,8 @@ pm100dxIsLimited:
 pm100dxFaultStatus:
   "OK": 0
   "FAULT": 1
+
+pedalState:
+  SNA: 0
+  OK: 1
+  FAULT: 2

--- a/network/definition/discrete_values.yaml
+++ b/network/definition/discrete_values.yaml
@@ -101,3 +101,22 @@ pedalState:
   SNA: 0
   OK: 1
   FAULT: 2
+
+appsState:
+  "SNA": 0
+  "OK": 1
+  "FAULT": 5
+  "ERROR": 6
+
+bppcState:
+  "SNA": 0
+  "OK": 1
+  "FAULT": 2
+  "FAULT_LATCHED": 3
+  "ERROR": 4
+
+torqueManagerState:
+  SNA: 0
+  INACTIVE: 1
+  ACTIVE: 2
+  ERROR: 3


### PR DESCRIPTION
### Describe changes

1. Adds a pedal monitor which interpolates a sensed voltage into a pedal position
2. Pedal monitor has short to gnd and vbatt protection
3. Bringup APPS application on vcfront
4. Bringup BPPC application on vcfront
5. Bringup torque manager on vcfront

### Impact

1. VCFRONT can use the front accelerator and brake pedal sensors
2. VCFRONT can specify a torque to request. Note the manager does not yet command the motor controller


### Test Plan

- [ ] Describe tests needed to validate the software changes
