### PR TITLE
Bringup output driver in VCs

### DIFF
--- a/components/shared/code/DRV/drv_tps20xx.c
+++ b/components/shared/code/DRV/drv_tps20xx.c
@@ -8,6 +8,8 @@
  ******************************************************************************/
 
 #include "drv_tps20xx.h"
+#include "drv_io.h"
+#include "drv_outputAD.h"
 #include "string.h"
 #include "drv_timer.h"
 
@@ -236,18 +238,8 @@ void drv_tps20xx_setEnabled(drv_tps20xx_channel_E channel, bool enabled)
  */
 static void drv_tps20xx_private_setICEnabled(drv_tps20xx_channel_E channel, bool enabled)
 {
-    // Set the pin to what logic level the software wants
-    bool pin_state = (drv_tps20xx_channels[channel].inverted_enable_logic) ? enabled == false : enabled;
-
-    // If the output is a push pull and a set pin is a digital high output. keep it the same
-    // Otherwise, invert the logic for an open drain so that a low level triggers it being set
-    bool state_to_set = (HW_GPIO_pinmux[drv_tps20xx_channels[channel].enable].mode == GPIO_MODE_OUTPUT_PP) ?
-                    pin_state :
-                    pin_state == false;
-
-    // The different TI chips in the family have different input polarities. This in turn with the gpio
-    // firmware we can set the correct pin state while only considering the hsd as on/off in the application
-    HW_GPIO_writePin(drv_tps20xx_channels[channel].enable, state_to_set);
+    const drv_io_activeState_E state_to_set = (enabled) ? DRV_IO_ACTIVE : DRV_IO_INACTIVE;
+    drv_outputAD_setDigitalActiveState(drv_tps20xx_channels[channel].enable, state_to_set);
 }
 
 /**

--- a/components/shared/code/DRV/drv_tps20xx.h
+++ b/components/shared/code/DRV/drv_tps20xx.h
@@ -47,7 +47,7 @@
 
 #include "drv_tps20xx_componentSpecific.h"
 #include "drv_inputAD.h"
-#include "HW_gpio.h"
+#include "drv_outputAD.h"
 #include "stdbool.h"
 
 /******************************************************************************
@@ -56,11 +56,10 @@
 
 typedef struct
 {
-    const HW_GPIO_pinmux_E             enable;
-    const bool                         inverted_enable_logic;
-    const drv_inputAD_channelDigital_E fault;
-    bool                               auto_reset;
-    uint16_t                           retry_wait_ms;
+    const drv_outputAD_channelDigital_E enable;
+    const drv_inputAD_channelDigital_E  fault;
+    bool                                auto_reset;
+    uint16_t                            retry_wait_ms;
 } drv_tps20xx_channelConfig_S;
 
 extern drv_tps20xx_channelConfig_S drv_tps20xx_channels[DRV_TPS20XX_CHANNEL_COUNT];

--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -168,6 +168,9 @@ project_hw_files = [
     SHARED_DRV.File("drv_timer.c"),
     SHARED_DRV.File("drv_inputAD.c"),
     HW_DIR.File("drv_inputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_outputAD.c"),
+    HW_DIR.File("drv_outputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_io.c"),
 ]
 
 project_source_files += project_hw_files

--- a/components/vc/front/include/HW/drv_outputAD_componentSpecific.h
+++ b/components/vc/front/include/HW/drv_outputAD_componentSpecific.h
@@ -1,0 +1,34 @@
+/**
+ * @file drv_outputAD_componentSpecific.h
+ * @brief Header file for the component specific output driver
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    DRV_OUTPUTAD_ANALOG_COUNT,
+} drv_outputAD_channelAnalog_E;
+
+typedef enum
+{
+    DRV_OUTPUTAD_DIGITAL_5V_EN1 = 0x00U,
+    DRV_OUTPUTAD_DIGITAL_5V_EN2,
+    DRV_OUTPUTAD_DIGITAL_MUX_SEL1,
+    DRV_OUTPUTAD_DIGITAL_MUX_SEL2,
+    DRV_OUTPUTAD_DIGITAL_HORN_EN,
+    DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_TSSI_G_EN,
+    DRV_OUTPUTAD_DIGITAL_TSSI_R_EN,
+    DRV_OUTPUTAD_DIGITAL_BR_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_MCU_UART_EN,
+    DRV_OUTPUTAD_DIGITAL_CS_IMU,
+    DRV_OUTPUTAD_DIGITAL_CS_SD,
+    DRV_OUTPUTAD_DIGITAL_LED,
+    DRV_OUTPUTAD_DIGITAL_COUNT,
+} drv_outputAD_channelDigital_E;

--- a/components/vc/front/src/HW/drv_outputAD_componentSpecific.c
+++ b/components/vc/front/src/HW/drv_outputAD_componentSpecific.c
@@ -1,0 +1,115 @@
+/**
+ * @file drv_outputAD_componentSpecific.c
+ * @brief Source file for the component specific output driver
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_outputAD.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+drv_outputAD_configDigital_S drv_outputAD_configDigital[DRV_OUTPUTAD_DIGITAL_COUNT] = {
+    [DRV_OUTPUTAD_DIGITAL_5V_EN1] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_5V_EN1,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_5V_EN2] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_5V_EN2,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MUX_SEL1] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MUX_SEL1,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MUX_SEL2] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MUX_SEL2,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_HORN_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_HORN_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_BMS_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_IMD_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_TSSI_G_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_TSSI_G_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_TSSI_R_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_TSSI_R_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_BR_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_BR_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MCU_UART_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MCU_UART_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_CS_IMU] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_SPI_CS_IMU,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_CS_SD] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_SPI_CS_SD,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_LED] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_LED,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+};

--- a/components/vc/front/src/HW/drv_tps20xx_componentSpecific.c
+++ b/components/vc/front/src/HW/drv_tps20xx_componentSpecific.c
@@ -15,15 +15,13 @@
 
 drv_tps20xx_channelConfig_S drv_tps20xx_channels[DRV_TPS20XX_CHANNEL_COUNT] = {
     [DRV_TPS20XX_CHANNEL_5V_CRITICAL] = {
-        .enable = HW_GPIO_5V_EN1,
-        .inverted_enable_logic = true, // Using the TPS2062
+        .enable = DRV_OUTPUTAD_DIGITAL_5V_EN1,
         .fault = DRV_INPUTAD_DIGITAL_5V_FLT1,
         .auto_reset = false,
         .retry_wait_ms = 1U, // We want this line to come back on as soon as possible
     },
     [DRV_TPS20XX_CHANNEL_5V_EXT] = {
-        .enable = HW_GPIO_5V_EN2,
-        .inverted_enable_logic = true, // Using the TPS2062
+        .enable = DRV_OUTPUTAD_DIGITAL_5V_EN2,
         .fault = DRV_INPUTAD_DIGITAL_5V_FLT2,
         .auto_reset = false,
         .retry_wait_ms = 1000U,

--- a/components/vc/pdu/SConscript
+++ b/components/vc/pdu/SConscript
@@ -165,6 +165,9 @@ project_hw_files = [
     SHARED_HW.File("HW_gpio.c"),
     SHARED_DRV.File("drv_inputAD.c"),
     HW_DIR.File("drv_inputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_outputAD.c"),
+    HW_DIR.File("drv_outputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_io.c"),
 ]
 
 project_source_files += project_hw_files

--- a/components/vc/pdu/include/HW/drv_outputAD_componentSpecific.h
+++ b/components/vc/pdu/include/HW/drv_outputAD_componentSpecific.h
@@ -1,0 +1,21 @@
+/**
+ * @file drv_outputAD_componentSpecific.h
+ * @brief Header file for the component specific output driver
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    DRV_OUTPUTAD_ANALOG_COUNT,
+} drv_outputAD_channelAnalog_E;
+
+typedef enum
+{
+    DRV_OUTPUTAD_DIGITAL_LED,
+    DRV_OUTPUTAD_DIGITAL_COUNT,
+} drv_outputAD_channelDigital_E;

--- a/components/vc/pdu/src/HW/drv_outputAD_componentSpecific.c
+++ b/components/vc/pdu/src/HW/drv_outputAD_componentSpecific.c
@@ -1,0 +1,24 @@
+/**
+ * @file drv_outputAD_componentSpecific.c
+ * @brief Source file for the component specific output driver
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_outputAD.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+drv_outputAD_configDigital_S drv_outputAD_configDigital[DRV_OUTPUTAD_DIGITAL_COUNT] = {
+    [DRV_OUTPUTAD_DIGITAL_LED] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_LED,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+};

--- a/components/vc/rear/SConscript
+++ b/components/vc/rear/SConscript
@@ -168,6 +168,9 @@ project_hw_files = [
     SHARED_DRV.File("drv_timer.c"),
     SHARED_DRV.File("drv_inputAD.c"),
     HW_DIR.File("drv_inputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_outputAD.c"),
+    HW_DIR.File("drv_outputAD_componentSpecific.c"),
+    SHARED_DRV.File("drv_io.c"),
 ]
 
 project_source_files += project_hw_files

--- a/components/vc/rear/include/HW/drv_outputAD_componentSpecific.h
+++ b/components/vc/rear/include/HW/drv_outputAD_componentSpecific.h
@@ -1,0 +1,34 @@
+/**
+ * @file drv_outputAD_componentSpecific.h
+ * @brief Header file for the component specific output driver
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    DRV_OUTPUTAD_ANALOG_COUNT,
+} drv_outputAD_channelAnalog_E;
+
+typedef enum
+{
+    DRV_OUTPUTAD_DIGITAL_5V_EN1 = 0x00U,
+    DRV_OUTPUTAD_DIGITAL_5V_EN2,
+    DRV_OUTPUTAD_DIGITAL_MUX_SEL1,
+    DRV_OUTPUTAD_DIGITAL_MUX_SEL2,
+    DRV_OUTPUTAD_DIGITAL_HORN_EN,
+    DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_TSSI_G_EN,
+    DRV_OUTPUTAD_DIGITAL_TSSI_R_EN,
+    DRV_OUTPUTAD_DIGITAL_BR_LIGHT_EN,
+    DRV_OUTPUTAD_DIGITAL_MCU_UART_EN,
+    DRV_OUTPUTAD_DIGITAL_CS_IMU,
+    DRV_OUTPUTAD_DIGITAL_CS_SD,
+    DRV_OUTPUTAD_DIGITAL_LED,
+    DRV_OUTPUTAD_DIGITAL_COUNT,
+} drv_outputAD_channelDigital_E;

--- a/components/vc/rear/src/HW/drv_outputAD_componentSpecific.c
+++ b/components/vc/rear/src/HW/drv_outputAD_componentSpecific.c
@@ -1,0 +1,115 @@
+/**
+ * @file drv_outputAD_componentSpecific.c
+ * @brief Source file for the component specific output driver
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "drv_outputAD.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+drv_outputAD_configDigital_S drv_outputAD_configDigital[DRV_OUTPUTAD_DIGITAL_COUNT] = {
+    [DRV_OUTPUTAD_DIGITAL_5V_EN1] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_5V_EN1,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_5V_EN2] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_5V_EN2,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MUX_SEL1] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MUX_SEL1,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MUX_SEL2] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MUX_SEL2,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_HORN_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_HORN_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_BMS_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_IMD_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_TSSI_G_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_TSSI_G_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_TSSI_R_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_TSSI_R_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_BR_LIGHT_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_BR_LIGHT_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_MCU_UART_EN] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_MCU_UART_EN,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_CS_IMU] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_SPI_CS_IMU,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_CS_SD] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_SPI_CS_SD,
+            .active_level = DRV_IO_LOGIC_LOW,
+        },
+    },
+    [DRV_OUTPUTAD_DIGITAL_LED] = {
+        .type = OUTPUT_DIGITAL,
+        .config.gpio = {
+            .pin = HW_GPIO_LED,
+            .active_level = DRV_IO_LOGIC_HIGH,
+        },
+    },
+};

--- a/components/vc/rear/src/HW/drv_tps20xx_componentSpecific.c
+++ b/components/vc/rear/src/HW/drv_tps20xx_componentSpecific.c
@@ -15,15 +15,13 @@
 
 drv_tps20xx_channelConfig_S drv_tps20xx_channels[DRV_TPS20XX_CHANNEL_COUNT] = {
     [DRV_TPS20XX_CHANNEL_5V_CRITICAL] = {
-        .enable = HW_GPIO_5V_EN1,
-        .inverted_enable_logic = true, // Using the TPS2062
+        .enable = DRV_OUTPUTAD_DIGITAL_5V_EN1,
         .fault = DRV_INPUTAD_DIGITAL_5V_FLT1,
         .auto_reset = false,
         .retry_wait_ms = 1U, // We want this line to come back on as soon as possible
     },
     [DRV_TPS20XX_CHANNEL_5V_EXT] = {
-        .enable = HW_GPIO_5V_EN2,
-        .inverted_enable_logic = true, // Using the TPS2062
+        .enable = DRV_OUTPUTAD_DIGITAL_5V_EN2,
         .fault = DRV_INPUTAD_DIGITAL_5V_FLT2,
         .auto_reset = false,
         .retry_wait_ms = 1000U,


### PR DESCRIPTION
### Describe changes

1. Bringup output driver in VCs

### Impact

1. TPS20XX driver now uses the output driver

### Test Plan

- [x] No hardware to test
