### PR TITLE
Bringup vehicle state on VCPDU and VCFRONT

### DIFF
--- a/components/shared/code/SharedApp_FeatureDefs.yaml
+++ b/components/shared/code/SharedApp_FeatureDefs.yaml
@@ -1,0 +1,10 @@
+config:
+  prefix: feature
+  description: General definitions for applications and bootloaders
+defs:
+  vehicleState_mode:
+    discreteValue: mode
+discreteValues:
+  mode:
+    - leader
+    - follower

--- a/components/shared/code/app/app_vehicleState.c
+++ b/components/shared/code/app/app_vehicleState.c
@@ -1,0 +1,196 @@
+/**
+ * @file app_vehicleState.c
+ * @brief Source file for the vehicle state application
+ */
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "app_vehicleState.h"
+#include "string.h"
+#include "MessageUnpack_generated.h"
+#include "drv_timer.h"
+#include "drv_inputAD.h"
+
+/******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define BOOT_TIME_MS 100U
+#define VEHICLESTATE_TIMEOUT_MS 1000U
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+struct
+{
+    app_vehicleState_state_E state;
+    drv_timer_S              timer;
+} vehicleState_data;
+
+/******************************************************************************
+ *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+/**
+ * @brief Translate the app_vehicleState_state_E to CAN_vehicleState_E
+ * @param state the vehicle state
+ * @return The equivalent CAN state
+ */
+static CAN_vehicleState_E translateToCANState(app_vehicleState_state_E state)
+{
+    CAN_vehicleState_E ret = CAN_VEHICLESTATE_INIT;
+
+    switch (state)
+    {
+        case VEHICLESTATE_ON_GLV:
+            ret = CAN_VEHICLESTATE_ON_GLV;
+            break;
+        case VEHICLESTATE_ON_HV:
+            ret = CAN_VEHICLESTATE_ON_HV;
+            break;
+        case VEHICLESTATE_TS_RUN:
+            ret = CAN_VEHICLESTATE_TS_RUN;
+            break;
+        default:
+            break;
+    }
+
+    return ret;
+}
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+/**
+ * @brief Initialize the vehicle power state
+ */
+void app_vehicleState_init(void)
+{
+    memset(&vehicleState_data, 0x00U, sizeof(vehicleState_data));
+
+    vehicleState_data.state = VEHICLESTATE_INIT;
+    drv_timer_init(&vehicleState_data.timer);
+#if FEATURE_VEHICLESTATE_MODE == FDEFS_MODE_LEADER
+    drv_timer_start(&vehicleState_data.timer, BOOT_TIME_MS);
+#endif
+}
+
+/**
+ * @brief Run the periodic 100Hz task
+ */
+void app_vehicleState_run100Hz(void)
+{
+#if FEATURE_VEHICLESTATE_MODE == FDEFS_MODE_LEADER
+    switch (vehicleState_data.state)
+    {
+        case VEHICLESTATE_INIT:
+            if (drv_timer_getState(&vehicleState_data.timer) == DRV_TIMER_EXPIRED)
+            {
+                vehicleState_data.state = VEHICLESTATE_ON_GLV;
+                drv_timer_stop(&vehicleState_data.timer);
+            }
+            break;
+        case VEHICLESTATE_ON_GLV:
+            if (drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_TSMS) == DRV_IO_ACTIVE)
+            {
+                vehicleState_data.state = VEHICLESTATE_ON_HV;
+            }
+            break;
+        case VEHICLESTATE_ON_HV:
+            {
+                CAN_prechargeContactorState_E contacts = CAN_PRECHARGECONTACTORSTATE_OPEN;
+
+                if (drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_TSMS) == DRV_IO_INACTIVE)
+                {
+                    vehicleState_data.state = VEHICLESTATE_ON_GLV;
+                }
+                else if ((VEHICLESTATE_CANRX_CONTACTORSTATE(&contacts) != CANRX_MESSAGE_VALID) ||
+                         (contacts != CAN_PRECHARGECONTACTORSTATE_HVP_CLOSED))
+                {
+                    break;
+                }
+                else if (drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_RUN_BUTTON) == DRV_IO_ACTIVE)
+                {
+                    vehicleState_data.state = VEHICLESTATE_TS_RUN;
+                }
+            }
+            break;
+        case VEHICLESTATE_TS_RUN:
+            if (drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_TSMS) == DRV_IO_INACTIVE)
+            {
+                vehicleState_data.state = VEHICLESTATE_ON_GLV;
+            }
+            else if (drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_RUN_BUTTON) == DRV_IO_ACTIVE)
+            {
+                vehicleState_data.state = VEHICLESTATE_ON_HV;
+            }
+            break;
+    }
+#else
+    CAN_vehicleState_E state = translateToCANState(vehicleState_data.state);
+
+    if (VEHICLESTATE_CANRX_SIGNAL(&state) == CANRX_MESSAGE_VALID)
+    {
+        drv_timer_stop(&vehicleState_data.timer);
+
+        switch (state)
+        {
+            case CAN_VEHICLESTATE_INIT:
+                vehicleState_data.state = VEHICLESTATE_INIT;
+                break;
+            case CAN_VEHICLESTATE_ON_GLV:
+                vehicleState_data.state = VEHICLESTATE_ON_GLV;
+                break;
+            case CAN_VEHICLESTATE_ON_HV:
+                vehicleState_data.state = VEHICLESTATE_ON_HV;
+                break;
+            case CAN_VEHICLESTATE_TS_RUN:
+                vehicleState_data.state = VEHICLESTATE_TS_RUN;
+                break;
+        }
+    }
+    else if (drv_timer_getState(&vehicleState_data.timer) == DRV_TIMER_STOPPED)
+    {
+        drv_timer_start(&vehicleState_data.timer, VEHICLESTATE_TIMEOUT_MS);
+    }
+    else if (drv_timer_getState(&vehicleState_data.timer) == DRV_TIMER_EXPIRED)
+    {
+        vehicleState_data.state = VEHICLESTATE_ON_GLV;
+        drv_timer_stop(&vehicleState_data.timer);
+    }
+#endif
+}
+
+/**
+ * @brief Get current vehicle state
+ * @return the current vehicle state
+ */
+app_vehicleState_state_E app_vehicleState_getState(void)
+{
+    return vehicleState_data.state;
+}
+
+#if FEATURE_VEHICLESTATE_MODE == FDEFS_MODE_LEADER
+/**
+ * @brief Get current vehicle state
+ * @note Only the leader should be able to transmit messages over CAN
+ * @return the current vehicle state
+ */
+CAN_vehicleState_E app_vehicleState_getStateCAN(void)
+{
+    return translateToCANState(vehicleState_data.state);
+}
+#endif
+
+/******************************************************************************
+ *                           P U B L I C  V A R S
+ ******************************************************************************/
+
+const ModuleDesc_S app_vehicleState_desc = {
+    .moduleInit = &app_vehicleState_init,
+    .periodic100Hz_CLK = &app_vehicleState_run100Hz,
+};

--- a/components/shared/code/app/app_vehicleState.h
+++ b/components/shared/code/app/app_vehicleState.h
@@ -1,0 +1,95 @@
+/**
+ * @file app_vehicleState.h
+ * @brief Header file for the vehicle state application
+ * @note This application controls the vehicle wide power and drive state transitions
+ *       as ensuring their functionality
+ *
+ * Setup - Leader
+ * 1. Define the `VEHICLESTATE_INPUTAD_TSMS` channel
+ * 2. Define the `VEHICLESTATE_INPUTAD_RUN_BUTTON` channel
+ * 3. Define the `VEHICLESTATE_CANRX_CONTACTORSTATE` signal
+ * 4. Update the module manager with the app_vehicleState_desc
+ *
+ * Setup - Follower
+ * 1. Define the `VEHICLESTATE_CANRX_SIGNAL` channel
+ * 2. Update the module manager with the app_vehicleState_desc
+ *
+ * Usage
+ * - The module shall be call periodically at 100Hz
+ * - The module provides the app_vehicleState_getState for all applications
+ *   to have the state correctly tracke irregardless of leader/follower
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "app_vehicleState_componentSpecific.h"
+#include "LIB_Types.h"
+#include "Module.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#if FEATURE_VEHICLESTATE_MODE == FDEFS_MODE_LEADER
+ #ifndef VEHICLESTATE_INPUTAD_TSMS
+ #error "User must define 'VEHICLESTATE_INPUTAD_TSMS' in app_vehicleState_componentSpecific.h"
+ #endif
+ #ifndef VEHICLESTATE_INPUTAD_RUN_BUTTON
+ #error "User must define 'VEHICLESTATE_INPUTAD_RUN_BUTTON' in app_vehicleState_componentSpecific.h"
+ #endif
+ #ifndef VEHICLESTATE_CANRX_CONTACTORSTATE
+ #error "User must define 'VEHICLESTATE_CANRX_CONTACTORSTATE' in app_vehicleState_componentSpecific.h"
+ #endif
+#else
+ #ifndef VEHICLESTATE_CANRX_SIGNAL
+ #error "User must define 'VEHICLESTATE_CANRX_SIGNAL' in app_vehicleState_componentSpecific.h"
+ #endif
+#endif
+
+/******************************************************************************
+ *                              E X T E R N S
+ ******************************************************************************/
+
+extern const ModuleDesc_S app_vehicleState_desc;
+
+/******************************************************************************
+ *                             T Y P E D E F S
+ ******************************************************************************/
+
+/**
+ * @brief Tracks the vehicle wide power state
+ * @value VEHICLE_STATE_ON_GLV Only GLV power is presently turned on. HV is down,
+ *        however the vehicle may be ready for HV to be turned on at any point.
+ * @value VEHICLE_STATE_ON_HV HV has been energized. All critical systems shall be
+ *        on and in a nominal state. Only critical faults and user input can force
+ *        a state transition.
+ * @value VEHICLE_STATE_TS_RUN The vehicle can respond to driver input. The motor
+ *        controller has been enabled and will respond to torque requests. Only
+ *        critical faults and exiting 'DRIVE' can result in a state transition.
+ */
+typedef enum
+{
+    VEHICLESTATE_INIT = 0x00,
+    VEHICLESTATE_ON_GLV,
+    VEHICLESTATE_ON_HV,
+    VEHICLESTATE_TS_RUN,
+} app_vehicleState_state_E;
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+// Functionality
+void app_vehicleState_init(void);
+void app_vehicleState_run100Hz(void);
+
+// Accessors
+app_vehicleState_state_E app_vehicleState_getState(void);
+#if FEATURE_VEHICLESTATE_MODE == FDEFS_MODE_LEADER
+CAN_vehicleState_E       app_vehicleState_getStateCAN(void);
+#endif

--- a/components/vc/front/FeatureSels.yaml
+++ b/components/vc/front/FeatureSels.yaml
@@ -1,6 +1,9 @@
-featureDefs: "#/components/bms_boss/FeatureDefs.yaml"
+featureDefs:
+  - "#/components/bms_boss/FeatureDefs.yaml"
+  - "#/components/shared/code/SharedApp_FeatureDefs.yaml"
 features:
   feature_cantx_swi: true
   feature_canrx_swi: true
   app_component_id: vcfront
   app_uds: true
+  feature_vehicleState_mode: follower

--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -152,6 +152,7 @@ project_source_files = [
     SRC_DIR.File("apps.c"),
     SRC_DIR.File("bppc.c"),
     SRC_DIR.File("torque.c"),
+    SHARED_APP.File("app_vehicleState.c"),
 ]
 
 project_hw_files = [

--- a/components/vc/front/include/Module_componentSpecific.h
+++ b/components/vc/front/include/Module_componentSpecific.h
@@ -11,6 +11,7 @@
 
 // System Includes
 #include "ModuleDesc.h"
+#include "app_vehicleState.h"
 
 /******************************************************************************
  *                              E X T E R N S
@@ -34,6 +35,7 @@ typedef enum
     MODULE_UDS,
     MODULE_APPS,
     MODULE_BPPC,
+    MODULE_VEHICLESTATE,
     MODULE_TORQUE,
     MODULE_CANIO_tx,
     MODULE_CNT

--- a/components/vc/front/include/app_vehicleState_componentSpecific.h
+++ b/components/vc/front/include/app_vehicleState_componentSpecific.h
@@ -1,0 +1,12 @@
+/**
+ * @file app_vehicleState_componentSpecific.h
+ * @brief Header file for the component specific vehicle state application
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#define VEHICLESTATE_CANRX_SIGNAL CANRX_get_signal_func(VEH, VCPDU_vehicleState)

--- a/components/vc/front/src/Module_componentSpecific.c
+++ b/components/vc/front/src/Module_componentSpecific.c
@@ -25,6 +25,7 @@ const ModuleDesc_S* modules[MODULE_CNT] = {
     &UDS_desc,
     &apps_desc,
     &bppc_desc,
+    &app_vehicleState_desc,
     &torque_desc,
     &CANIO_tx,
 };

--- a/components/vc/pdu/FeatureSels.yaml
+++ b/components/vc/pdu/FeatureSels.yaml
@@ -1,6 +1,9 @@
-featureDefs: "#/components/bms_boss/FeatureDefs.yaml"
+featureDefs: 
+  - "#/components/bms_boss/FeatureDefs.yaml"
+  - "#/components/shared/code/SharedApp_FeatureDefs.yaml"
 features:
   feature_cantx_swi: true
   feature_canrx_swi: true
   app_component_id: vcpdu
   app_uds: true
+  feature_vehicleState_mode: leader

--- a/components/vc/pdu/SConscript
+++ b/components/vc/pdu/SConscript
@@ -148,6 +148,7 @@ project_source_files = [
     SRC_DIR.File("UDS.c"),
     SHARED_LIBS.File("LIB_app.c"),
     SHARED_LIBS.File("LIB_simpleFilter.c"),
+    SHARED_APP.File("app_vehicleState.c"),
 ]
 
 project_hw_files = [
@@ -168,6 +169,7 @@ project_hw_files = [
     SHARED_DRV.File("drv_outputAD.c"),
     HW_DIR.File("drv_outputAD_componentSpecific.c"),
     SHARED_DRV.File("drv_io.c"),
+    SHARED_DRV.File("drv_timer.c"),
 ]
 
 project_source_files += project_hw_files

--- a/components/vc/pdu/include/CANIO_componentSpecific.h
+++ b/components/vc/pdu/include/CANIO_componentSpecific.h
@@ -18,6 +18,7 @@
 
 // imports for data access
 #include "Module.h"
+#include "app_vehicleState.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -35,5 +36,6 @@
 #define set_taskUsage10Hz(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_10Hz_TASK));
 #define set_taskUsage1Hz(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_1Hz_TASK));
 #define set_taskUsageIdle(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
+#define set_vehicleState(m,b,n,s) set(m,b,n,s, app_vehicleState_getStateCAN())
 
 #include "TemporaryStubbing.h"

--- a/components/vc/pdu/include/HW/drv_inputAD_componentSpecific.h
+++ b/components/vc/pdu/include/HW/drv_inputAD_componentSpecific.h
@@ -11,6 +11,8 @@
 
 typedef enum
 {
+    DRV_INPUTAD_TSCHG_MS = 0x00,
+    DRV_INPUTAD_RUN_BUTTON,
     DRV_INPUTAD_DIGITAL_COUNT,
 } drv_inputAD_channelDigital_E;
 

--- a/components/vc/pdu/include/Module_componentSpecific.h
+++ b/components/vc/pdu/include/Module_componentSpecific.h
@@ -11,6 +11,7 @@
 
 // System Includes
 #include "ModuleDesc.h"
+#include "app_vehicleState.h"
 
 /******************************************************************************
  *                              E X T E R N S
@@ -29,6 +30,7 @@ typedef enum
 {
     MODULE_CANIO_rx = 0x00U,
     MODULE_UDS,
+    MODULE_VEHICLESTATE,
     MODULE_CANIO_tx,
     MODULE_CNT
 } Module_tasks_E;

--- a/components/vc/pdu/include/app_vehicleState_componentSpecific.h
+++ b/components/vc/pdu/include/app_vehicleState_componentSpecific.h
@@ -1,0 +1,14 @@
+/**
+ * @file app_vehicleState_componentSpecific.h
+ * @brief Header file for the component specific vehicle state application
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define VEHICLESTATE_INPUTAD_TSMS DRV_INPUTAD_TSCHG_MS
+#define VEHICLESTATE_INPUTAD_RUN_BUTTON DRV_INPUTAD_RUN_BUTTON
+#define VEHICLESTATE_CANRX_CONTACTORSTATE CANRX_get_signal_func(VEH, BMSB_packContactorState)

--- a/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
@@ -21,12 +21,21 @@
 
 /**< Other Includes */
 #include "ModuleDesc.h"
+#include "MessageUnpack_generated.h"
 
 /******************************************************************************
  *                         P R I V A T E  V A R S
  ******************************************************************************/
 
 drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT] = {
+    [DRV_INPUTAD_TSCHG_MS] = {
+        .type = INPUT_DIGITAL_CAN,
+        .config.canrx_digitalStatus = &CANRX_get_signal_func(VEH, BMSB_tsmsChg),
+    },
+    [DRV_INPUTAD_RUN_BUTTON] = {
+        .type = INPUT_DIGITAL_CAN,
+        .config.canrx_digitalStatus = &CANRX_get_signal_func(VEH, VCFRONT_runButtonStatus),
+    },
 };
 
 /******************************************************************************

--- a/components/vc/pdu/src/Module_componentSpecific.c
+++ b/components/vc/pdu/src/Module_componentSpecific.c
@@ -21,6 +21,7 @@
 const ModuleDesc_S* modules[MODULE_CNT] = {
     &CANIO_rx,
     &UDS_desc,
+    &app_vehicleState_desc,
     &CANIO_tx,
 };
 

--- a/network/definition/data/components/vcfront/vcfront-rx.yaml
+++ b/network/definition/data/components/vcfront/vcfront-rx.yaml
@@ -3,3 +3,5 @@ messages:
     sourceBuses: veh
     unrecorded: true
 signals:
+  VCPDU_vehicleState:
+    sourceBuses: veh

--- a/network/definition/data/components/vcpdu/vcpdu-message.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-message.yaml
@@ -10,3 +10,11 @@ messages:
     id: 0x553
     sourceBuses: veh
     template: rtosTaskInfo
+
+  vehicleState:
+    description: Current state of the vehicle
+    id: 0x110
+    sourceBuses: veh
+    cycleTimeMs: 10
+    signals:
+      vehicleState:

--- a/network/definition/data/components/vcpdu/vcpdu-rx.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-rx.yaml
@@ -3,3 +3,9 @@ messages:
     sourceBuses: veh
     unrecorded: true
 signals:
+  BMSB_packContactorState:
+    sourceBuses: veh
+  BMSB_tsmsChg:
+    sourceBuses: veh
+  VCFRONT_runButtonStatus:
+    sourceBuses: veh

--- a/network/definition/data/components/vcpdu/vcpdu-signals.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-signals.yaml
@@ -1,1 +1,4 @@
 signals:
+  vehicleState:
+    description: "Current state of the vehicle"
+    discreteValues: vehicleState

--- a/network/definition/discrete_values.yaml
+++ b/network/definition/discrete_values.yaml
@@ -126,3 +126,9 @@ brakeLightState:
   "OFF": 1
   "ON": 2
   "FAULT": 3
+
+vehicleState:
+  "INIT": 0
+  "ON_GLV": 1
+  "ON_HV": 2
+  "TS_RUN": 3


### PR DESCRIPTION
### Describe changes

1. Add vehicle power state shared application
2. Bringup leader follower architecture to vehicle state
3. All systems can utilize vehicle state for `ON_HV` and `TS_RUN` state progressions
4. VCPDU vehicle state leader. Handles power on and tracking vehicle state
5. VCFRONT is a vehicle state follower

### Impact

1. Networked vehicle state progressio now tracked
2. No changes to current apps which gates any behaviours off of vehicle state

### Test Plan

- [x] NA
