### PR TITLE
Cockpit Lights (related to #224)

### DIFF
--- a/components/vc/front/SConscript
+++ b/components/vc/front/SConscript
@@ -154,6 +154,7 @@ project_source_files = [
     SRC_DIR.File("torque.c"),
     SHARED_APP.File("app_vehicleState.c"),
     SRC_DIR.File("powerManager.c"),
+    SRC_DIR.File("cockpitLights.c"),
     SRC_DIR.File("brakePressure.c"),
 ]
 

--- a/components/vc/front/include/CANIO_componentSpecific.h
+++ b/components/vc/front/include/CANIO_componentSpecific.h
@@ -25,6 +25,7 @@
 #include "torque.h"
 #include "brakePressure.h"
 #include "drv_tps20xx.h"
+#include "cockpitLights.h"
 
 /******************************************************************************
  *                              D E F I N E S
@@ -72,5 +73,7 @@
 #define set_brakePressure(m,b,n,s) set(m,b,n,s, brakePressure_getBrakePressure())
 #define set_5vCriticalHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_CRITICAL))
 #define set_5vExtHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_EXT))
+#define set_bmsLightState(m,b,n,s) set(m,b,n,s, cockpitLights_bms_getStateCAN())
+#define set_imdLightState(m,b,n,s) set(m,b,n,s, cockpitLights_imd_getStateCAN())
 
 #include "TemporaryStubbing.h"

--- a/components/vc/front/include/Module_componentSpecific.h
+++ b/components/vc/front/include/Module_componentSpecific.h
@@ -24,6 +24,7 @@ extern const ModuleDesc_S apps_desc;
 extern const ModuleDesc_S bppc_desc;
 extern const ModuleDesc_S torque_desc;
 extern const ModuleDesc_S powerManager_desc;
+extern const ModuleDesc_S cockpitLights_desc;
 extern const ModuleDesc_S brakePressure_desc;
 extern const ModuleDesc_S CANIO_tx;
 
@@ -40,7 +41,8 @@ typedef enum
     MODULE_VEHICLESTATE,
     MODULE_TORQUE,
     MODULE_POWERMANAGER,
+    MODULE_COCKPITLIGHTS,
     MODULE_BRAKEPRESSURE,
     MODULE_CANIO_tx,
-    MODULE_CNT
+    MODULE_CNT,
 } Module_tasks_E;

--- a/components/vc/front/include/cockpitLights.h
+++ b/components/vc/front/include/cockpitLights.h
@@ -1,0 +1,20 @@
+/**
+ * @file cockpit_lights.h
+ * @brief Module that manages IMD and BMS lights 
+ */
+
+#pragma once
+
+/******************************************************************************
+ *                             I N C L U D E S
+ ******************************************************************************/
+
+#include "LIB_Types.h"
+#include "CANTypes_generated.h"
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+CAN_digitalStatus_E cockpitLights_imd_getStateCAN(void);
+CAN_digitalStatus_E cockpitLights_bms_getStateCAN(void);

--- a/components/vc/front/src/Module_componentSpecific.c
+++ b/components/vc/front/src/Module_componentSpecific.c
@@ -28,6 +28,7 @@ const ModuleDesc_S* modules[MODULE_CNT] = {
     &app_vehicleState_desc,
     &torque_desc,
     &powerManager_desc,
+    &cockpitLights_desc,
     &brakePressure_desc,
     &CANIO_tx,
 };

--- a/components/vc/front/src/cockpitLights.c
+++ b/components/vc/front/src/cockpitLights.c
@@ -1,0 +1,90 @@
+/**
+* @file cockpitLights.c
+* @brief Module source that manages IMD and BMS lights
+*/
+
+/******************************************************************************
+*                             I N C L U D E S
+******************************************************************************/
+
+#include "cockpitLights.h"
+#include "CANIO_componentSpecific.h"
+#include "Module.h"
+#include "ModuleDesc.h"
+#include "string.h"
+#include "drv_outputAD.h"
+#include "app_vehicleState.h"
+#include "MessageUnpack_generated.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+
+static struct
+{
+    bool imdState;
+    bool bmsState;
+} cockpitLights_data;
+
+/******************************************************************************
+*                       P U B L I C  F U N C T I O N S
+******************************************************************************/
+
+CAN_digitalStatus_E cockpitLights_imd_getStateCAN(void)
+{
+    return cockpitLights_data.imdState ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF;
+}
+
+CAN_digitalStatus_E cockpitLights_bms_getStateCAN(void)
+{
+    return cockpitLights_data.bmsState ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF;
+}
+
+static void cockpitLights_init(void)
+{
+    cockpitLights_data.imdState = true;
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN, DRV_IO_ACTIVE);
+
+    cockpitLights_data.bmsState = true;
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN, DRV_IO_ACTIVE);
+}
+
+
+static void cockpitLights_periodic_10Hz(void)
+{
+    CAN_digitalStatus_E can_imd_status;
+    CAN_digitalStatus_E can_bms_status;
+    const bool imd_light_valid = (CANRX_get_signal(VEH, BMSB_imdStatusMem, &can_imd_status) == CANRX_MESSAGE_VALID);
+    const bool bms_light_valid = (CANRX_get_signal(VEH, BMSB_bmsStatusMem, &can_bms_status) == CANRX_MESSAGE_VALID);
+
+    if (imd_light_valid == true && (can_imd_status == CAN_DIGITALSTATUS_ON))
+    {
+        cockpitLights_data.imdState = false;
+    }
+    else
+    {
+        cockpitLights_data.imdState = true;
+    }
+
+    if (bms_light_valid == true && (can_imd_status == CAN_DIGITALSTATUS_ON))
+    {
+        cockpitLights_data.bmsState = false;
+    }
+    else
+    {
+        cockpitLights_data.bmsState = true;
+    }
+
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_IMD_LIGHT_EN, cockpitLights_data.imdState ? DRV_IO_ACTIVE : DRV_IO_INACTIVE);
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_BMS_LIGHT_EN, cockpitLights_data.bmsState ? DRV_IO_ACTIVE : DRV_IO_INACTIVE);
+}
+
+/******************************************************************************
+*                           P U B L I C  V A R S
+******************************************************************************/
+
+const ModuleDesc_S cockpitLights_desc =
+{
+    .moduleInit = &cockpitLights_init,
+    .periodic10Hz_CLK = &cockpitLights_periodic_10Hz,
+};

--- a/network/definition/data/components/vcfront/vcfront-message.yaml
+++ b/network/definition/data/components/vcfront/vcfront-message.yaml
@@ -46,6 +46,14 @@ messages:
     signals:
       runButtonStatus:
 
+  cockpitLightStatus:
+    description: Status of the cockpit lights
+    id: 0x402
+    cycleTimeMs: 100
+    signals:
+      bmsLightState:
+      imdLightState:
+
   outputState:
     description: Information about the VCFRONT output states
     cycleTimeMs: 100

--- a/network/definition/data/components/vcfront/vcfront-rx.yaml
+++ b/network/definition/data/components/vcfront/vcfront-rx.yaml
@@ -5,3 +5,7 @@ messages:
 signals:
   VCPDU_vehicleState:
     sourceBuses: veh
+  BMSB_bmsStatusMem:
+    sourceBuses: veh
+  BMSB_imdStatusMem:
+    sourceBuses: veh

--- a/network/definition/data/components/vcfront/vcfront-signals.yaml
+++ b/network/definition/data/components/vcfront/vcfront-signals.yaml
@@ -65,3 +65,11 @@ signals:
         max: 150
       resolution: 1
     continuous: true
+
+  bmsLightState:
+    description: "State of the BMS light"
+    discreteValues: digitalStatus
+
+  imdLightState:
+    description: "State of the IMD light"
+    discreteValues: digitalStatus


### PR DESCRIPTION
### Describe changes

1. Bringup cockpit lights on vcfront

### Impact

1. Dash lights will monitor the state of the BMS and IMD

### Test Plan

- [x]  Flash BMSB and VCFRONT
- [x] Power cycle the car - ensure the BMS and IMD lights turn on
- [x] Press the reset button, ensure both lights turn off
