### PR TITLE
Fix ADC unpacking in VC

### DIFF
--- a/components/bms_boss/HW/HW_adc_componentSpecific.c
+++ b/components/bms_boss/HW/HW_adc_componentSpecific.c
@@ -145,9 +145,6 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
         }
 
         __HAL_LINKDMA(adcHandle, DMA_Handle, hdma_adc1);
-
-        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
     }
     else if (adcHandle->Instance == ADC2)
     {

--- a/components/bms_boss/HW/drv_inputAD_componentSpecific.c
+++ b/components/bms_boss/HW/drv_inputAD_componentSpecific.c
@@ -80,6 +80,8 @@ static void drv_inputAD_init_componentSpecific(void)
 
 static void drv_inputAD_1kHz_PRD(void)
 {
+    HW_ADC_unpackADCBuffer();
+
     const float32_t differential = HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_CS_P) - HW_ADC_getVFromBank1Channel(ADC_BANK1_CHANNEL_CS_N);
 
     drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CS, differential);

--- a/components/shared/code/HW/HW_adc.c
+++ b/components/shared/code/HW/HW_adc.c
@@ -61,38 +61,6 @@ static float32_t HW_ADC_private_getVFromCount(uint16_t cnt)
 }
 
 /**
- * @brief  Unpack ADC buffer
- */
-static void HW_ADC_private_unpackADCBuffer(void)
-{
-    for (uint8_t i = 0; i < ADC_BANK1_CHANNEL_COUNT; i++)
-    {
-        LIB_simpleFilter_clear(&inputs.adcData_bank1[i]);
-    }
-    for (uint8_t i = 0; i < ADC_BANK2_CHANNEL_COUNT; i++)
-    {
-        LIB_simpleFilter_clear(&inputs.adcData_bank2[i]);
-    }
-
-    for (uint16_t i = 0; i < HW_ADC_BUF_LEN; i++)
-    {
-        LIB_simpleFilter_increment(&inputs.adcData_bank1[i % ADC_BANK1_CHANNEL_COUNT], (inputs.adcBuffer[i] & 0xffff));
-        LIB_simpleFilter_increment(&inputs.adcData_bank2[i % ADC_BANK2_CHANNEL_COUNT], (inputs.adcBuffer[i] >> 16U));
-    }
-
-    for (uint8_t i = 0; i < ADC_BANK1_CHANNEL_COUNT; i++)
-    {
-        LIB_simpleFilter_average(&inputs.adcData_bank1[i]);
-        inputs.voltages1[i] = HW_ADC_private_getVFromCount((uint16_t)inputs.adcData_bank1[i].value);
-    }
-    for (uint8_t i = 0; i < ADC_BANK2_CHANNEL_COUNT; i++)
-    {
-        LIB_simpleFilter_average(&inputs.adcData_bank2[i]);
-        inputs.voltages2[i] = HW_ADC_private_getVFromCount((uint16_t)inputs.adcData_bank2[i].value);
-    }
-}
-
-/**
  * @brief Firmware functinputsn to initiate ADC calibraton.
  *
  * @param hadc Pointer to ADC peripheral
@@ -136,6 +104,38 @@ HW_StatusTypeDef_E HW_ADC_init(void)
 }
 
 /**
+ * @brief  Unpack ADC buffer
+ */
+void HW_ADC_unpackADCBuffer(void)
+{
+    for (uint8_t i = 0; i < ADC_BANK1_CHANNEL_COUNT; i++)
+    {
+        LIB_simpleFilter_clear(&inputs.adcData_bank1[i]);
+    }
+    for (uint8_t i = 0; i < ADC_BANK2_CHANNEL_COUNT; i++)
+    {
+        LIB_simpleFilter_clear(&inputs.adcData_bank2[i]);
+    }
+
+    for (uint16_t i = 0; i < HW_ADC_BUF_LEN; i++)
+    {
+        LIB_simpleFilter_increment(&inputs.adcData_bank1[i % ADC_BANK1_CHANNEL_COUNT], (inputs.adcBuffer[i] & 0xffff));
+        LIB_simpleFilter_increment(&inputs.adcData_bank2[i % ADC_BANK2_CHANNEL_COUNT], (inputs.adcBuffer[i] >> 16U));
+    }
+
+    for (uint8_t i = 0; i < ADC_BANK1_CHANNEL_COUNT; i++)
+    {
+        LIB_simpleFilter_average(&inputs.adcData_bank1[i]);
+        inputs.voltages1[i] = HW_ADC_private_getVFromCount((uint16_t)inputs.adcData_bank1[i].value);
+    }
+    for (uint8_t i = 0; i < ADC_BANK2_CHANNEL_COUNT; i++)
+    {
+        LIB_simpleFilter_average(&inputs.adcData_bank2[i]);
+        inputs.voltages2[i] = HW_ADC_private_getVFromCount((uint16_t)inputs.adcData_bank2[i].value);
+    }
+}
+
+/**
  * @brief  STM32 HAL callback. Called when DMA transfer is half complete.
  * @param hadc Pointer to ADC peripheral
  */
@@ -153,7 +153,7 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
 {
     if (hadc->Instance == ADC1)
     {
-        HW_ADC_private_unpackADCBuffer();
+        HW_ADC_unpackADCBuffer();
     }
 }
 

--- a/components/shared/code/HW/HW_adc.h
+++ b/components/shared/code/HW/HW_adc.h
@@ -45,5 +45,6 @@ typedef enum
 
 HW_StatusTypeDef_E HW_ADC_init(void);
 HW_StatusTypeDef_E HW_ADC_deInit(void);
+void               HW_ADC_unpackADCBuffer(void);
 float32_t          HW_ADC_getVFromBank1Channel(HW_adcChannels_bank1_E channel);
 float32_t          HW_ADC_getVFromBank2Channel(HW_adcChannels_bank2_E channel);

--- a/components/stw_switch/src/HW/HW_adc_componentSpecific.c
+++ b/components/stw_switch/src/HW/HW_adc_componentSpecific.c
@@ -184,9 +184,6 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
         }
 
         __HAL_LINKDMA(adcHandle, DMA_Handle, hdma_adc1);
-
-        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
     }
     else if (adcHandle->Instance == ADC2)
     {

--- a/components/stw_switch/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/stw_switch/src/HW/drv_inputAD_componentSpecific.c
@@ -114,6 +114,8 @@ void drv_inputAD_init_componentSpecific(void)
 
 void drv_inputAD_1kHz_componentSpecific(void)
 {
+    HW_ADC_unpackADCBuffer();
+
     // This method only works since there is a 1:1 mapping from adc input to inputAD output
     for (uint8_t i = 0U; i < ADC_BANK1_CHANNEL_COUNT; i++)
     {

--- a/components/vc/front/src/HW/HW_adc_componentSpecific.c
+++ b/components/vc/front/src/HW/HW_adc_componentSpecific.c
@@ -248,9 +248,6 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
         }
 
         __HAL_LINKDMA(adcHandle, DMA_Handle, hdma_adc1);
-
-        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
     }
     else if (adcHandle->Instance == ADC2)
     {

--- a/components/vc/front/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/front/src/HW/drv_inputAD_componentSpecific.c
@@ -93,6 +93,8 @@ void drv_inputAD_init_componentSpecific(void)
 
 void drv_inputAD_1kHz_componentSpecific(void)
 {
+    HW_ADC_unpackADCBuffer();
+
     // This method only works since there is a 1:1 mapping from adc input to inputAD output
     for (uint8_t i = 0U; i < ADC_BANK1_CHANNEL_COUNT; i++)
     {

--- a/components/vc/pdu/src/HW/HW_adc_componentSpecific.c
+++ b/components/vc/pdu/src/HW/HW_adc_componentSpecific.c
@@ -234,9 +234,6 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
         }
 
         __HAL_LINKDMA(adcHandle, DMA_Handle, hdma_adc1);
-
-        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
     }
     else if (adcHandle->Instance == ADC2)
     {

--- a/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
@@ -101,6 +101,8 @@ void drv_inputAD_init_componentSpecific(void)
 
 void drv_inputAD_1kHz_componentSpecific(void)
 {
+    HW_ADC_unpackADCBuffer();
+
     // This method only works since there is a 1:1 mapping from adc input to inputAD output
     for (uint8_t i = 0U; i < ADC_BANK1_CHANNEL_COUNT; i++)
     {

--- a/components/vc/rear/src/HW/HW_adc_componentSpecific.c
+++ b/components/vc/rear/src/HW/HW_adc_componentSpecific.c
@@ -248,9 +248,6 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
         }
 
         __HAL_LINKDMA(adcHandle, DMA_Handle, hdma_adc1);
-
-        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
     }
     else if (adcHandle->Instance == ADC2)
     {

--- a/components/vc/rear/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/rear/src/HW/drv_inputAD_componentSpecific.c
@@ -86,6 +86,8 @@ void drv_inputAD_init_componentSpecific(void)
 
 void drv_inputAD_1kHz_componentSpecific(void)
 {
+    HW_ADC_unpackADCBuffer();
+
     // This method only works since there is a 1:1 mapping from adc input to inputAD output
     for (uint8_t i = 0U; i < ADC_BANK1_CHANNEL_COUNT; i++)
     {


### PR DESCRIPTION
### Describe changes

ADC unpacking was still driven by the DMA buffer. This caused an unnecessary unpacking of the buffer, as well as race conditions within the memory which could significantly impact the way that "simultaneous measurements" were taken by the firmware. This change improves the interface and allows the application to unpack the buffer if it wants to manually.

### Impact

1. This will fix the "simultaneous" measurement read by the applications and ensure they are measured properly at the same time
2. Propogate all fixes to BMSB, SWS, VCFRONT, REAR, and PDU - This does not diff BMSW which will take some more figuring out with the 10kHz + normal codepath
### Test Plan

- [x] The original measurement methodology impacted how the apps were reading the measured voltages. Make sure the apps are properly reading the in sync values