### PR TITLE
tssi light bringup

### DIFF
--- a/components/vc/rear/SConscript
+++ b/components/vc/rear/SConscript
@@ -152,6 +152,7 @@ project_source_files = [
     SHARED_APP.File("app_vehicleState.c"),
     SRC_DIR.File("horn.c"),
     SRC_DIR.File("powerManager.c"),
+    SRC_DIR.File("tssi.c"),
 ]
 
 project_hw_files = [

--- a/components/vc/rear/include/CANIO_componentSpecific.h
+++ b/components/vc/rear/include/CANIO_componentSpecific.h
@@ -20,6 +20,7 @@
 #include "Module.h"
 #include "brakeLight.h"
 #include "horn.h"
+#include "tssi.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -39,5 +40,5 @@
 #define set_taskUsageIdle(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
 #define set_brakeLightState(m,b,n,s) set(m,b,n,s, brakeLight_getStateCAN())
 #define set_hornState(m,b,n,s) set(m,b,n,s, horn_getStateCAN())
-
+#define set_bmsStatusMEM(m,b,n,s) set(m,b,n,s, BMS_getStatusMemCAN())
 #include "TemporaryStubbing.h"

--- a/components/vc/rear/include/Module_componentSpecific.h
+++ b/components/vc/rear/include/Module_componentSpecific.h
@@ -12,6 +12,7 @@
 // System Includes
 #include "ModuleDesc.h"
 #include "app_vehicleState.h"
+#include "tssi.h"
 
 /******************************************************************************
  *                              E X T E R N S
@@ -23,6 +24,7 @@ extern const ModuleDesc_S UDS_desc;
 extern const ModuleDesc_S powerManager_desc;
 extern const ModuleDesc_S brakeLight_desc;
 extern const ModuleDesc_S horn_desc;
+extern const ModuleDesc_S tssiLights_desc;
 extern const ModuleDesc_S CANIO_tx;
 
 /******************************************************************************
@@ -37,6 +39,7 @@ typedef enum
     MODULE_POWERMANAGER,
     MODULE_BRAKELIGHT,
     MODULE_HORN,
+    MODULE_TSSI_LIGHTS,
     MODULE_CANIO_tx,
     MODULE_CNT
 } Module_tasks_E;

--- a/components/vc/rear/include/tssi.h
+++ b/components/vc/rear/include/tssi.h
@@ -1,0 +1,45 @@
+/**
+ * @file tssi.h
+ * @brief Module for Tractive System Status Indicator (TSSI) Lights Based on Status from the Insulation Monitoring Device (IMD).
+ */
+#pragma once
+// #include "HW_gpio.h"
+// #include "HW_adc.h"
+#include "CANIO_componentSpecific.h"
+// #include "CANTypes_generated.h"
+// #include "drv_outputAD.h"
+#include "MessageUnpack_generated.h"
+// #include "NetworkDefines_generated.h"
+#include "drv_timer.h"
+// #include "HW_can.h"
+
+/******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define TSSI_BLINK_INTERVAL_MS 500U
+
+
+/******************************************************************************
+*                             T Y P E D E F S
+ ******************************************************************************/
+
+typedef enum
+{
+    imdFault_INIT = 0x00U,
+    tssi_RED = 0x01U,
+    tssi_GREEN = 0x02U,
+} IMD_State_E;
+
+
+/******************************************************************************
+ *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
+ ******************************************************************************/
+
+void tssi_init(void);
+// void tssi_update(void);
+void tssi_reset(void);
+// void LEDTimer(void);
+
+IMD_State_E imdFault_getState(void);
+CAN_digitalStatus_E BMS_getStatusMemCAN(void);

--- a/components/vc/rear/src/Module_componentSpecific.c
+++ b/components/vc/rear/src/Module_componentSpecific.c
@@ -11,6 +11,7 @@
 #include "Module.h"
 #include "drv_tps20xx.h"
 #include "drv_inputAD.h"
+#include "tssi.h"
 
 /******************************************************************************
  *                         P R I V A T E  V A R S
@@ -26,6 +27,7 @@ const ModuleDesc_S* modules[MODULE_CNT] = {
     &powerManager_desc,
     &brakeLight_desc,
     &horn_desc,
+    &tssiLights_desc,
     &CANIO_tx,
 };
 

--- a/components/vc/rear/src/tssi.c
+++ b/components/vc/rear/src/tssi.c
@@ -1,0 +1,163 @@
+/**
+ * @file tssibringup.c
+ * @brief Module for Tractive System Status Indicator (TSSI) Lights Based on Status from the Insulation Monitoring Device (IMD).
+ */
+
+#include "tssi.h"
+// #include "HW_gpio.h"
+#include "CANIO_componentSpecific.h"
+#include "drv_outputAD.h"
+// #include "MessageUnpack_generated.h"
+// #include "NetworkDefines_generated.h"
+// #include "FeatureDefines_generated.h"
+// #include "Module.h"
+#include "SystemConfig.h"
+#include "CANTypes_generated.h"
+// #include "ModuleDesc.h"
+// #include "HW_can.h"
+// #include "HW.h"
+// #include "stdint.h"
+#include "CAN/CanTypes.h"
+
+/******************************************************************************
+ *                         P R I V A T E  V A R S
+ ******************************************************************************/
+static drv_timer_S ledTimer;
+static bool tssiRedState = false;
+
+
+static struct
+{
+    IMD_State_E state;
+} tssi_data;
+
+/******************************************************************************
+ *                         P U B L I C  F U N C T I O N S
+ ******************************************************************************/
+
+    IMD_State_E imdFault_getState(void)
+{
+    return tssi_data.state;
+}
+
+CAN_digitalStatus_E BMS_getStatusMemCAN(void)
+{
+    return (tssi_data.state == tssi_GREEN) ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF;
+}
+
+static void TSSI_blinkRED_2Hz(void)
+{
+    //  static bool tssiRedState = false;
+
+    drv_timer_start(&ledTimer, 500U);
+    
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN,
+    tssiRedState ? DRV_IO_ACTIVE : DRV_IO_INACTIVE);
+    
+    switch (drv_timer_getState(&ledTimer))
+    {
+        case DRV_TIMER_EXPIRED:
+        {
+            tssiRedState = !tssiRedState;
+            drv_timer_start(&ledTimer, 500U); //2Hz
+            break;
+        }
+        case DRV_TIMER_RUNNING:
+        {
+            break;
+        }
+        case DRV_TIMER_STOPPED:
+        {
+            //stop the function, assuming stopped is something manual like a reset
+            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN, DRV_IO_INACTIVE);
+            tssiRedState = false; // reset the state
+            break;
+        }
+    }
+}
+
+/******************************************************************************
+ *                         P R I V A T E  F U N C T I O N S
+ ******************************************************************************/
+
+void tssi_init(void)
+{
+    memset(&tssi_data.state, 0, sizeof(tssi_data.state));
+    drv_timer_init(&ledTimer);
+    drv_timer_start(&ledTimer, 500U);
+}
+
+void tssi_reset(void)
+{
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN, DRV_IO_INACTIVE);
+    drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_G_EN, DRV_IO_INACTIVE); 
+}
+
+/******************************************************************************
+ *                             P R I V A T E  F U N C T I O N S
+ ******************************************************************************/
+
+static void tssi_periodic_10Hz(void)
+{
+    // static bool tssiRedState = false;
+
+    float32_t imdStatus = 0U;
+    float32_t bmsStatus = 0U;
+
+    bool imdValid = (CANRX_get_signal(VEH, BMSB_imdStatusMem, &imdStatus) == CANRX_MESSAGE_VALID);
+    bool bmsValid = (CANRX_get_signal(VEH, BMSB_bmsStatusMem, &bmsStatus) == CANRX_MESSAGE_VALID);
+
+    if (VEHICLESTATE_ON_GLV)
+    {
+        if (imdValid && bmsValid && (imdStatus > 0 || bmsStatus > 0))
+        {
+            tssi_data.state = tssi_RED;
+        }
+        
+        else if (imdValid && bmsValid)
+        {
+            tssi_data.state = tssi_GREEN;
+        }
+        
+        else
+        {
+            tssi_data.state = imdFault_INIT;
+        }
+
+
+        if (tssi_data.state == tssi_RED)
+        {
+            TSSI_blinkRED_2Hz();
+            drv_outputAD_setDigitalActiveState(
+            DRV_OUTPUTAD_DIGITAL_TSSI_G_EN, DRV_IO_INACTIVE);
+        }
+        
+        else if (tssi_data.state == tssi_GREEN)
+        {
+            
+            drv_timer_stop(&ledTimer);
+            tssiRedState = false;
+            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN, DRV_IO_INACTIVE);
+            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_G_EN, DRV_IO_ACTIVE);
+        }
+        else
+        {
+            drv_timer_stop(&ledTimer);
+            tssiRedState = false;
+            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN, DRV_IO_INACTIVE);
+            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_G_EN, DRV_IO_INACTIVE);
+        }
+    }
+    else
+    {
+        drv_timer_stop(&ledTimer);
+        tssiRedState = false;
+        drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_R_EN, DRV_IO_INACTIVE);
+        drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_DIGITAL_TSSI_G_EN, DRV_IO_INACTIVE);
+    }
+}
+
+const ModuleDesc_S tssiLights_desc = {
+    .moduleInit = &tssi_init,
+    .periodic10Hz_CLK = &tssi_periodic_10Hz,
+};

--- a/network/definition/data/components/vcrear/vcrear-message.yaml
+++ b/network/definition/data/components/vcrear/vcrear-message.yaml
@@ -20,3 +20,5 @@ messages:
     signals:
       brakeLightState:
       hornState:
+      bmsStatusMEM:
+      imdStatusMEM:

--- a/network/definition/data/components/vcrear/vcrear-signals.yaml
+++ b/network/definition/data/components/vcrear/vcrear-signals.yaml
@@ -6,3 +6,11 @@ signals:
   hornState:
     description: State of the horn
     discreteValues: digitalStatus
+  
+  bmsStatusMEM:
+    description: BMS status memory
+    discreteValues: digitalStatus
+
+  imdStatusMEM:
+    description: IMD status memory
+    discreteValues: digitalStatus


### PR DESCRIPTION
### Describe changes

Implemented tssi light logic for red and green states.

### Impact

Become rule-compliant and have the tractive system lights show triggered faults.

### Test Plan

- [ ] Test for BMS fault
- [ ] Test for IMD fault
- [ ] Test to see if LED turns off when GLV is turned off
- [ ] Test reinitialization of the timer upon rebooting the car
- [ ] Test invalid messages
