### PR TITLE
Bringup pack voltage sense

### DIFF
--- a/components/bms_boss/HW/HW_adc_componentSpecific.c
+++ b/components/bms_boss/HW/HW_adc_componentSpecific.c
@@ -29,8 +29,11 @@
 #define ADC_PRECALIBRATION_DELAY_ADCCLOCKCYCLES 2U
 #define ADC_CALIBRATION_TIMEOUT                 10U
 
-#define ADC_N_CHANNEL ADC_CHANNEL_0
-#define ADC_P_CHANNEL ADC_CHANNEL_1
+#define ADC_CS_N_CHANNEL ADC_CHANNEL_0
+#define ADC_PACK_P_CHANNEL ADC_CHANNEL_12
+
+#define ADC_CS_P_CHANNEL ADC_CHANNEL_1
+#define ADC_PACK_N_CHANNEL ADC_CHANNEL_11
 
 /******************************************************************************
  *                              E X T E R N S
@@ -64,7 +67,11 @@ HW_StatusTypeDef_E HW_ADC_init_componentSpecific(void)
     hadc1.Init.DiscontinuousConvMode = DISABLE;
     hadc1.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
     hadc1.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+#if BMSB_CONFIG_ID == 1U
+    hadc1.Init.NbrOfConversion = 3;
+#else
     hadc1.Init.NbrOfConversion = 2;
+#endif
     if (HAL_ADC_Init(&hadc1) != HAL_OK)
     {
         Error_Handler();
@@ -78,7 +85,7 @@ HW_StatusTypeDef_E HW_ADC_init_componentSpecific(void)
 
     // Configure Regular Channels
 
-    sConfig.Channel      = ADC_N_CHANNEL;
+    sConfig.Channel      = ADC_CS_N_CHANNEL;
     sConfig.Rank         = ADC_REGULAR_RANK_1;
     sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
     if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
@@ -86,8 +93,22 @@ HW_StatusTypeDef_E HW_ADC_init_componentSpecific(void)
         Error_Handler();
     }
 
-    sConfig.Channel      = ADC_CHANNEL_TEMPSENSOR;
+#if BMSB_CONFIG_ID == 1U
+    sConfig.Channel      = ADC_PACK_P_CHANNEL;
     sConfig.Rank         = ADC_REGULAR_RANK_2;
+    sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
+    if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
+    {
+        Error_Handler();
+    }
+#endif
+
+    sConfig.Channel      = ADC_CHANNEL_TEMPSENSOR;
+#if BMSB_CONFIG_ID == 1U
+    sConfig.Rank         = ADC_REGULAR_RANK_3;
+#else
+    sConfig.Rank         = ADC_REGULAR_RANK_2;
+#endif
     sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
     if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
     {
@@ -100,19 +121,40 @@ HW_StatusTypeDef_E HW_ADC_init_componentSpecific(void)
     hadc2.Init.DiscontinuousConvMode = DISABLE;
     hadc2.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
     hadc2.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    hadc2.Init.NbrOfConversion       = 1;
+#if BMSB_CONFIG_ID == 1U
+    hadc1.Init.NbrOfConversion = 3;
+#else
+    hadc1.Init.NbrOfConversion = 1;
+#endif
     if (HAL_ADC_Init(&hadc2) != HAL_OK)
     {
         Error_Handler();
     }
 
-    sConfig.Channel      = ADC_P_CHANNEL;
+    sConfig.Channel      = ADC_CS_P_CHANNEL;
     sConfig.Rank         = ADC_REGULAR_RANK_1;
     sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
     if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK)
     {
         Error_Handler();
     }
+
+#if BMSB_CONFIG_ID == 1U
+    sConfig.Channel      = ADC_PACK_N_CHANNEL;
+    sConfig.Rank         = ADC_REGULAR_RANK_2;
+    sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
+    if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK)
+    {
+        Error_Handler();
+    }
+    sConfig.Channel      = ADC_PACK_N_CHANNEL;
+    sConfig.Rank         = ADC_REGULAR_RANK_3; // Third to ensure both buffers are synchronized
+    sConfig.SamplingTime = ADC_SAMPLETIME_13CYCLES_5;
+    if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK)
+    {
+        Error_Handler();
+    }
+#endif
 
     return HW_OK;
 }

--- a/components/bms_boss/HW/drv_inputAD_componentSpecific.c
+++ b/components/bms_boss/HW/drv_inputAD_componentSpecific.c
@@ -24,6 +24,12 @@
 #include "LIB_simpleFilter.h"
 
 /******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define VPACK_DIVISOR 250
+
+/******************************************************************************
  *                         P R I V A T E  V A R S
  ******************************************************************************/
 
@@ -88,6 +94,13 @@ static void drv_inputAD_1kHz_PRD(void)
     drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_MCU_TEMP, HW_ADC_getVFromBank1Channel(ADC_BANK1_CHANNEL_MCU_TEMP));
 
     drv_inputAD_private_runDigital();
+
+#if BMSB_CONFIG_ID == 1U
+    const float32_t vpack_p = HW_ADC_getVFromBank1Channel(ADC_BANK1_CHANNEL_VPACK_P);
+    const float32_t vpack_n = HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_VPACK_N);
+    const float32_t vpack_diff = vpack_p - vpack_n;
+    drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_VPACK, vpack_diff * VPACK_DIVISOR);
+#endif
 }
 
 /**

--- a/components/bms_boss/HW/include/HW_adc_componentSpecific.h
+++ b/components/bms_boss/HW/include/HW_adc_componentSpecific.h
@@ -25,6 +25,9 @@
 typedef enum
 {
     ADC_BANK1_CHANNEL_CS_N,
+#if BMSB_CONFIG_ID == 1U
+    ADC_BANK1_CHANNEL_VPACK_P,
+#endif
     ADC_BANK1_CHANNEL_MCU_TEMP,
     ADC_BANK1_CHANNEL_COUNT,
 } HW_adcChannels_bank1_E;
@@ -32,6 +35,9 @@ typedef enum
 typedef enum
 {
     ADC_BANK2_CHANNEL_CS_P = 0x00U,
+#if BMSB_CONFIG_ID == 1U
+    ADC_BANK2_CHANNEL_VPACK_N,
+#endif
     // All empty values should be disregarded because of simultaneous current sense sampling
     ADC_BANK2_CHANNEL_COUNT = ADC_BANK1_CHANNEL_COUNT,
 } HW_adcChannels_bank2_E;

--- a/components/bms_boss/HW/include/drv_inputAD_componentSpecific.h
+++ b/components/bms_boss/HW/include/drv_inputAD_componentSpecific.h
@@ -23,5 +23,8 @@ typedef enum
 {
     DRV_INPUTAD_ANALOG_CS,
     DRV_INPUTAD_ANALOG_MCU_TEMP,
+#if BMSB_CONFIG_ID == 1U
+    DRV_INPUTAD_ANALOG_VPACK,
+#endif
     DRV_INPUTAD_ANALOG_COUNT,
 } drv_inputAD_channelAnalog_E;

--- a/components/bms_boss/src/BMS.c
+++ b/components/bms_boss/src/BMS.c
@@ -95,8 +95,14 @@ static void BMS10Hz_PRD(void)
         BMS.pack_discharge_limit = tmp.pack_discharge_limit;
     }
 
+#if (BMSB_CONFIG_ID == 0U)
+    BMS.pack_voltage = tmp.pack_voltage;
+#elif (BMSB_CONFIG_ID == 1U)
+    BMS.pack_voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_VPACK);
+#else
+#error "Unsupported config id."
+#endif
     BMS.fault                = tmp.fault;
-    BMS.pack_voltage         = tmp.pack_voltage;
     BMS.voltages             = tmp.voltages;
     BMS.max_temp             = tmp.max_temp;
 }


### PR DESCRIPTION
### Describe changes

Utilized analog input to implement the voltage pack current sense for use in the precharge circuit.

### Impact

Scales voltage appropriately and improves accuracy of precharge voltage readings.

### Test Plan

- [x] Flash BMSB
- [x] Ensure the pack voltage equals the sum of all segment voltages
- [x] Ensure no BMS faults
