### PR TITLE
Im an idiot - Fix DMA interrupt being kept enabled in VCPDU

### DIFF
--- a/components/vc/pdu/src/HW/HW_dma_componentSpecific.c
+++ b/components/vc/pdu/src/HW/HW_dma_componentSpecific.c
@@ -21,9 +21,4 @@ void HW_DMA_init(void)
 {
     // DMA controller clock enable
     __HAL_RCC_DMA1_CLK_ENABLE();
-
-    // DMA interrupt init
-    // DMA1_Channel1_IRQn interrupt configuration
-    HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, DMA_IRQ_PRIO, 0U);
-    HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
 }


### PR DESCRIPTION
### Describe changes

1. Im ret

### Impact

1. Fix VCPDU

### Test Plan

- [x] Test on VCPDU and ensure the RTOS runs
