### PR TITLE
Fix brake pedal position output

### DIFF
--- a/components/vc/front/include/CANIO_componentSpecific.h
+++ b/components/vc/front/include/CANIO_componentSpecific.h
@@ -26,6 +26,16 @@
 #include "brakePressure.h"
 
 /******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#if FEATURE_IS_ENABLED(FEATURE_BRAKEPEDAL_FROM_PRESSURE)
+#define BRAKE_CHANNEL DRV_PEDALMONITOR_BRAKE_PR
+#else
+#define BRAKE_CHANNEL DRV_PEDALMONITOR_BRAKE_POT
+#endif
+
+/******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/
 
@@ -43,11 +53,11 @@
 #define set_taskUsageIdle(m,b,n,s) set(m,b,n,s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
 #define set_apps1(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_APPS1) * 100)
 #define set_apps2(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_APPS2) * 100)
-#define set_brakePosition(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalPosition(DRV_PEDALMONITOR_BRAKE_POT) * 100)
+#define set_brakePosition(m,b,n,s) set(m,b,n,s, bppc_getPedalPosition() * 100)
 #define set_acceleratorPosition(m,b,n,s) set(m,b,n,s, apps_getPedalPosition() * 100)
 #define set_apps1State(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_APPS1))
 #define set_apps2State(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_APPS2))
-#define set_brakeState(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(DRV_PEDALMONITOR_BRAKE_POT))
+#define set_brakeState(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalStateCAN(BRAKE_CHANNEL))
 #define set_apps1Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS1))
 #define set_apps2Voltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_APPS2))
 #define set_brakePotVoltage(m,b,n,s) set(m,b,n,s, drv_pedalMonitor_getPedalVoltage(DRV_PEDALMONITOR_BRAKE_POT))

--- a/components/vc/front/src/bppc.c
+++ b/components/vc/front/src/bppc.c
@@ -31,11 +31,17 @@
 static struct
 {
     bppc_state_E state;
+    float32_t position;
 } bppc_data;
 
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/
+
+float32_t bppc_getPedalPosition(void)
+{
+    return bppc_data.position;
+}
 
 bppc_state_E bppc_getState(void)
 {
@@ -80,6 +86,7 @@ static void bppc_periodic_100Hz(void)
     {
         const float32_t brake_pos = drv_pedalMonitor_getPedalPosition(BRAKE_CHANNEL);
         const float32_t accelerator_pos = apps_getPedalPosition();
+        bppc_data.position = brake_pos;
 
         if ((accelerator_pos > 0.25f) && (brake_pos > 0.10f))
         {


### PR DESCRIPTION
Allow feature brake pedal from pressure to drive pedal position

### Describe changes

1. Gate the channel used for the brake pedal based upon the feature flag

### Impact

1. Will allow the brake pedal output to be set by the brake pressure

### Test Plan

- [ ] Flash VCFRONT
- [ ] Press brake pedal
- [ ] Ensure brake light turns on
