### PR TITLE
Add 5V HSD states onto CAN for VCFRONT/REAR

### DIFF
--- a/components/shared/code/DRV/drv_tps20xx.c
+++ b/components/shared/code/DRV/drv_tps20xx.c
@@ -204,6 +204,38 @@ drv_tps20xx_state_E drv_tps20xx_getState(drv_tps20xx_channel_E channel)
     return ret;
 }
 
+CAN_hsdState_E drv_tps20xx_getStateCAN(drv_tps20xx_channel_E channel)
+{
+    CAN_hsdState_E ret = CAN_HSDSTATE_SNA;
+
+    switch (drv_tps20xx_data[channel].state)
+    {
+        case DRV_TPS20XX_STATE_OFF:
+            ret = CAN_HSDSTATE_OFF;
+            break;
+        case DRV_TPS20XX_STATE_ENABLED:
+            ret = CAN_HSDSTATE_ON;
+            break;
+        case DRV_TPS20XX_STATE_FAULTED_OC:
+            ret = CAN_HSDSTATE_OVERCURRENT;
+            break;
+        case DRV_TPS20XX_STATE_FAULTED_OT:
+            ret = CAN_HSDSTATE_OVERTEMP;
+            break;
+        case DRV_TPS20XX_STATE_RETRY:
+            ret = CAN_HSDSTATE_RETRY;
+            break;
+        case DRV_TPS20XX_STATE_ERROR:
+            ret = CAN_HSDSTATE_FAULT;
+            break;
+        case DRV_TPS20XX_STATE_INIT:
+        default:
+            break;
+    }
+
+    return ret;
+}
+
 /**
  * @brief Set the state of a channel. 
  * @note If a channel is off and it is set to on, the driver will enable

--- a/components/shared/code/DRV/drv_tps20xx.h
+++ b/components/shared/code/DRV/drv_tps20xx.h
@@ -84,4 +84,5 @@ HW_StatusTypeDef_E  drv_tps20xx_deInit(void);
 void                drv_tps20xx_run(void);
 
 drv_tps20xx_state_E drv_tps20xx_getState(drv_tps20xx_channel_E channel);
+CAN_hsdState_E      drv_tps20xx_getStateCAN(drv_tps20xx_channel_E channel);
 void                drv_tps20xx_setEnabled(drv_tps20xx_channel_E channel, bool enabled);

--- a/components/vc/front/include/CANIO_componentSpecific.h
+++ b/components/vc/front/include/CANIO_componentSpecific.h
@@ -24,6 +24,7 @@
 #include "bppc.h"
 #include "torque.h"
 #include "brakePressure.h"
+#include "drv_tps20xx.h"
 
 /******************************************************************************
  *                              D E F I N E S
@@ -69,5 +70,7 @@
 #define set_runButtonStatus(m,b,n,s) set(m,b,n,s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_RUN_BUTTON) == DRV_IO_ACTIVE) ? \
                                                    CAN_DIGITALSTATUS_ON: CAN_DIGITALSTATUS_OFF)
 #define set_brakePressure(m,b,n,s) set(m,b,n,s, brakePressure_getBrakePressure())
+#define set_5vCriticalHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_CRITICAL))
+#define set_5vExtHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_EXT))
 
 #include "TemporaryStubbing.h"

--- a/components/vc/pdu/include/CANIO_componentSpecific.h
+++ b/components/vc/pdu/include/CANIO_componentSpecific.h
@@ -61,5 +61,6 @@
 #define set_bms5HsdState(m,b,n,s) set(m,b,n,s, drv_hsd_getCANState(drv_tps2hb16ab_getState(DRV_TPS2HB16AB_IC_BMS5_BMS6, DRV_TPS2HB16AB_OUT_1)))
 #define set_bms6HsdState(m,b,n,s) set(m,b,n,s, drv_hsd_getCANState(drv_tps2hb16ab_getState(DRV_TPS2HB16AB_IC_BMS5_BMS6, DRV_TPS2HB16AB_OUT_2)))
 #define set_glvVoltage(m,b,n,s) set(m,b,n,s, powerManager_getGLVVoltage())
+#define set_glvCurrent(m,b,n,s) set(m,b,n,s, powerManager_getGLVCurrent())
 
 #include "TemporaryStubbing.h"

--- a/components/vc/pdu/include/powerManager.h
+++ b/components/vc/pdu/include/powerManager.h
@@ -16,3 +16,4 @@
  ******************************************************************************/
 
 float32_t powerManager_getGLVVoltage(void);
+float32_t powerManager_getGLVCurrent(void);

--- a/components/vc/rear/include/CANIO_componentSpecific.h
+++ b/components/vc/rear/include/CANIO_componentSpecific.h
@@ -22,6 +22,7 @@
 #include "brakePressure.h"
 #include "horn.h"
 #include "tssi.h"
+#include "drv_tps20xx.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -43,5 +44,7 @@
 #define set_hornState(m,b,n,s) set(m,b,n,s, horn_getStateCAN())
 #define set_tssiState(m,b,n,s) set(m,b,n,s, tssi_getStateCAN())
 #define set_brakePressure(m,b,n,s) set(m,b,n,s, brakePressure_getBrakePressure())
+#define set_5vCriticalHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_CRITICAL))
+#define set_5vExtHsdState(m,b,n,s) set(m,b,n,s, drv_tps20xx_getStateCAN(DRV_TPS20XX_CHANNEL_5V_EXT))
 
 #include "TemporaryStubbing.h"

--- a/network/definition/data/components/vcfront/vcfront-message.yaml
+++ b/network/definition/data/components/vcfront/vcfront-message.yaml
@@ -45,3 +45,12 @@ messages:
     cycleTimeMs: 50
     signals:
       runButtonStatus:
+
+  outputState:
+    description: Information about the VCFRONT output states
+    cycleTimeMs: 100
+    id: 0x401
+    sourceBuses: veh
+    signals:
+      5vCriticalHsdState:
+      5vExtHsdState:

--- a/network/definition/data/components/vcfront/vcfront-signals.yaml
+++ b/network/definition/data/components/vcfront/vcfront-signals.yaml
@@ -47,6 +47,14 @@ signals:
     description: Status of the run button switch
     discreteValues: digitalStatus
 
+  5vCriticalHsdState:
+    description: "Current state of the 5V HSD for critical loads"
+    discreteValues: hsdState
+
+  5vExtHsdState:
+    description: "Current state of the 5V HSD for external loads"
+    discreteValues: hsdState
+
   torqueRequest:
     description: Torque request from the torque manager
     unit: Nm

--- a/network/definition/data/components/vcpdu/vcpdu-message.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-message.yaml
@@ -19,6 +19,7 @@ messages:
     signals:
       vehicleState:
       glvVoltage:
+      glvCurrent:
 
   hsdState:
     description: Current state of the HSDs

--- a/network/definition/data/components/vcpdu/vcpdu-signals.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-signals.yaml
@@ -92,3 +92,13 @@ signals:
         min: 0
         max: 16
     continuous: true
+
+  glvCurrent:
+    unit: 'A'
+    description: GLV Battery Current
+    nativeRepresentation:
+      bitWidth: 8
+      range:
+        min: 0
+        max: 30
+    continuous: true

--- a/network/definition/data/components/vcrear/vcrear-message.yaml
+++ b/network/definition/data/components/vcrear/vcrear-message.yaml
@@ -21,6 +21,8 @@ messages:
       brakeLightState:
       hornState:
       tssiState:
+      5vCriticalHsdState:
+      5vExtHsdState:
 
   rearBrakePressure:
     description: Rear Brake Pressure

--- a/network/definition/data/components/vcrear/vcrear-signals.yaml
+++ b/network/definition/data/components/vcrear/vcrear-signals.yaml
@@ -10,3 +10,11 @@ signals:
   tssiState:
     description: State of the tssi light
     discreteValues: tssiState
+
+  5vCriticalHsdState:
+    description: "Current state of the 5V HSD for critical loads"
+    discreteValues: hsdState
+
+  5vExtHsdState:
+    description: "Current state of the 5V HSD for external loads"
+    discreteValues: hsdState


### PR DESCRIPTION
### Describe changes

1. VCFRONT/REAR output their 5V hsd states onto CAN

### Impact

1. No functional impact

### Test Plan

- [x] Flash VCFRONT/REAR
- [x] Ensure the states are outputting ON
