### PR TITLE
Have the order of CAN message tables ascending based on cycle time

### DIFF
--- a/network/NetworkGen/classes/Can.py
+++ b/network/NetworkGen/classes/Can.py
@@ -549,7 +549,7 @@ class CanNode(CanObject):
                 ret.update({msg.cycle_time_ms: [msg]})
         for _, msgs in ret.items():
             msgs.sort(key=lambda entry: entry.id)
-        return ret
+        return dict(sorted(ret.items()))
 
 
 class CanBus(CanObject):


### PR DESCRIPTION
### Describe changes

1. Corrects ordering of CAN bus message cycle times for TX

### Impact

1. Improvement

### Test Plan

- [x] Verify code ordering
