### PR TITLE
Cockpit light set BMS light when BMS status is OFF

### DIFF
--- a/components/vc/front/src/cockpitLights.c
+++ b/components/vc/front/src/cockpitLights.c
@@ -66,7 +66,7 @@ static void cockpitLights_periodic_10Hz(void)
         cockpitLights_data.imdState = true;
     }
 
-    if (bms_light_valid == true && (can_imd_status == CAN_DIGITALSTATUS_ON))
+    if (bms_light_valid == true && (can_bms_status == CAN_DIGITALSTATUS_ON))
     {
         cockpitLights_data.bmsState = false;
     }


### PR DESCRIPTION
### Describe changes

1. BMS light will set when the BMS is faulted

### Impact

1. Correct cockpitlight function

### Test Plan

- [ ] Flash VCFRONT
- [ ] Trigger isolation failure
- [ ] Ensure only the BMS light is faulted
