### PR TITLE
Default mcManager getDirectionCommand to reverse

### DIFF
--- a/components/vc/rear/src/mcManager.c
+++ b/components/vc/rear/src/mcManager.c
@@ -50,7 +50,7 @@ CAN_pm100dxDirectionCommand_E mcManager_getDirectionCommand(void)
     switch (mcManager_data.direction)
     {
         default:
-            return CAN_PM100DXDIRECTIONCOMMAND_FORWARD;
+            return CAN_PM100DXDIRECTIONCOMMAND_REVERSE;
     }
 }
 


### PR DESCRIPTION
### Describe changes

1. Default mcManager getDirectionCommand to reverse (forward on car)

### Impact

1. Motor will now spin the wheels in the forward direction

### Test Plan

- [x] Enable HV and TS on car
- [x] Press accelerator slowly and ensure that wheels spin in the forward direction
