### PR TITLE
bmsb: Add pack current sense offset

### DIFF
--- a/components/bms_boss/include/CANIO_componentSpecific.h
+++ b/components/bms_boss/include/CANIO_componentSpecific.h
@@ -83,5 +83,5 @@ CAN_prechargeContactorState_E CANIO_tx_getContactorState(void);
                                              CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_imdStatus(m,b,n,s) set(m,b,n,s, (drv_outputAD_getDigitalActiveState(DRV_OUTPUTAD_DIGITAL_STATUS_IMD) == DRV_IO_ACTIVE) ?\
                                              CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-
+#define set_packCSVoltage(m,b,n,s) set(m,b,n,s, drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_CS))
 #include "TemporaryStubbing.h"

--- a/components/bms_boss/src/BMS.c
+++ b/components/bms_boss/src/BMS.c
@@ -23,6 +23,8 @@
 #define CURRENT_SENSE_V_per_A 0.005f
 #define PRECHARGE_MIN_TIME_MS 1320U
 
+#define PACK_CS_0_OFFSET 0.269531f
+
 BMSB_S BMS;
 
 static drv_timer_S precharge_timer;
@@ -109,7 +111,7 @@ static void BMS10Hz_PRD(void)
 
 static void BMS100Hz_PRD(void)
 {
-    BMS.pack_current = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_CS) / CURRENT_SENSE_V_per_A;
+    BMS.pack_current = (drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_CS) - PACK_CS_0_OFFSET) / CURRENT_SENSE_V_per_A;
 
     if (BMS.fault || (SYS_SFT_checkMCTimeout() && SYS_SFT_checkElconChargerTimeout() && SYS_SFT_checkBrusaChargerTimeout()))
     {

--- a/network/definition/data/components/bmsb/bmsb-message.yaml
+++ b/network/definition/data/components/bmsb/bmsb-message.yaml
@@ -21,6 +21,7 @@ messages:
       packContactorState:
       packRH:
       packAmbient:
+      packCSVoltage:
 
   brusaChargeCommand:
     description: Brusa Charge Command

--- a/network/definition/data/components/bmsb/bmsb-signals.yaml
+++ b/network/definition/data/components/bmsb/bmsb-signals.yaml
@@ -89,6 +89,16 @@ signals:
         max: 400
     continuous: true
 
+  packCSVoltage:
+    unit: 'V'
+    description: BMS Boss Pack Current Sensor Voltage
+    nativeRepresentation:
+      bitWidth: 10
+      range:
+        min: -2
+        max: 2
+    continuous: true
+
   packContactorState:
     description: Pack Contactor Status
     discreteValues: prechargeContactorState


### PR DESCRIPTION
### Describe changes

1. Calibrate away 0 A pack current sense

### Impact

1. Pack reports ~0 Amps when sitting

### Test Plan

- [ ] Flash BMSB, ensure ~0 A
