### PR TITLE
BMSW Improvements

### DIFF
--- a/components/bms_worker/FeatureSels.yaml
+++ b/components/bms_worker/FeatureSels.yaml
@@ -3,4 +3,4 @@ features:
   feature_max14921_calibrate:
   feature_cantx_swi:
   feature_canrx_swi:
-  feature_cell_diagnostics:
+  feature_cell_diagnostics: false

--- a/components/bms_worker/HW/drv_inputAD_componentSpecific.c
+++ b/components/bms_worker/HW/drv_inputAD_componentSpecific.c
@@ -81,16 +81,24 @@ static void drv_inputAD_1kHz_PRD(void)
     {
         const MAX_selectedCell_E current_cell = BMS_getCurrentOutputCell();
 
-        drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CELL1 + current_cell,
-                                             HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
-
         if (current_cell == MAX_CELL1)
         {
+            drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CELL1 + current_cell,
+                                                 HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
             BMS_measurementComplete();
         }
         else
         {
-            BMS_setOutputCell(current_cell - 1);
+            if (BMS.delayed_measurement)
+            {
+                BMS.delayed_measurement = false;
+            }
+            else
+            {
+                BMS_setOutputCell(current_cell - 1);
+                drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CELL1 + current_cell,
+                                                    HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
+            }
         }
     }
     else if (BMS.state == BMS_SAMPLING)

--- a/components/bms_worker/include/BatteryMonitoring.h
+++ b/components/bms_worker/include/BatteryMonitoring.h
@@ -73,6 +73,7 @@ typedef struct
 typedef struct
 {
     BMS_State_E state;
+    bool        delayed_measurement;
     bool        fault;
     uint16_t    balancing_cells;
     BMS_Cell_S  cells[MAX_CELL_COUNT];      // [V], precision 1V

--- a/components/bms_worker/src/BatteryMonitoring.c
+++ b/components/bms_worker/src/BatteryMonitoring.c
@@ -483,7 +483,9 @@ void BMS_measurementComplete(void)
     MAX_readWriteToChip();
 
     BMS.state = BMS_CALIBRATING;
-    while (!max_chip.state.ready) MAX_readWriteToChip();
+    MAX_readWriteToChip();
+    if (!max_chip.state.ready) return;
+
     BMS.state                          = BMS_WAITING;
 #endif // FEATURE_MAX14921_CALIBRATE
 #if FEATURE_CELL_DIAGNOSTICS


### PR DESCRIPTION
### Describe changes

Remove blocking code from bmsw and add delay to the first cell measurement.

### Impact

1. Adds delay before Cell 13 voltage measurement
2. Handles calibrating the bms chip asynchronously
3. Disable diagnostics

### Test Plan

- [x] Flash workers - ensure cell 13 is within 100mV or the measure voltage
- [x] Ensure all cell voltages are present and as expected
- [x] Ensure cell voltages are continuously updating