### PR TITLE
added 5v pdu voltage sense and output over CAN

### DIFF
--- a/components/vc/pdu/include/CANIO_componentSpecific.h
+++ b/components/vc/pdu/include/CANIO_componentSpecific.h
@@ -65,6 +65,7 @@
 #define set_bms3Current(m,b,n,s) set(m,b,n,s, drv_tps2hb16ab_getCurrent(DRV_TPS2HB16AB_IC_BMS3_SENSOR, DRV_TPS2HB16AB_OUT_1))
 #define set_sensorCurrent(m,b,n,s) set(m,b,n,s, drv_tps2hb16ab_getCurrent(DRV_TPS2HB16AB_IC_BMS3_SENSOR, DRV_TPS2HB16AB_OUT_2))
 #define set_pduCurrent(m,b,n,s) set(m,b,n,s, powerManager_getPduCurrent())
+#define set_pdu5vVoltage(m,b,n,s) set(m,b,n,s, powerManager_getPdu5vVoltage())
 #define set_vc1Current(m,b,n,s) set(m,b,n,s, drv_tps2hb16ab_getCurrent(DRV_TPS2HB16AB_IC_VC1_VC2, DRV_TPS2HB16AB_OUT_1))
 #define set_vc2Current(m,b,n,s) set(m,b,n,s, drv_tps2hb16ab_getCurrent(DRV_TPS2HB16AB_IC_VC1_VC2, DRV_TPS2HB16AB_OUT_2))
 #define set_mcCurrent(m,b,n,s) set(m,b,n,s, drv_tps2hb16ab_getCurrent(DRV_TPS2HB16AB_IC_MC_VCU3, DRV_TPS2HB16AB_OUT_1))

--- a/components/vc/pdu/include/powerManager.h
+++ b/components/vc/pdu/include/powerManager.h
@@ -18,3 +18,4 @@
 float32_t powerManager_getGLVVoltage(void);
 float32_t powerManager_getGLVCurrent(void);
 float32_t powerManager_getPduCurrent(void);
+float32_t powerManager_getPdu5vVoltage(void);

--- a/network/definition/data/components/vcpdu/vcpdu-message.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-message.yaml
@@ -38,6 +38,7 @@ messages:
         template: shutdownRelayStatus
       tsmsSafetyStatus:
         template: digitalStatus
+      pdu5vVoltage:
 
   hsdState:
     description: Current state of the HSDs

--- a/network/definition/data/components/vcpdu/vcpdu-signals.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-signals.yaml
@@ -102,3 +102,13 @@ signals:
         min: 0
         max: 30
     continuous: true
+    
+  pdu5vVoltage:
+    unit: 'V'
+    description: PDU 5V Rail
+    nativeRepresentation:
+      bitWidth: 8
+      range:
+        min: 0
+        max: 6
+    continuous: true


### PR DESCRIPTION
### Describe changes

1. Implemented 5v pdu voltage sense.
2. Created the CAN signal.

### Impact

1. Allows us to track 5v pdu voltage.

### Test Plan

- [x] Use a multimeter to probe 5v pdu voltage rail and track to see if the software aligns with the results. 