### PR TITLE
Support network manifest generation and integrate into conUDS

### DIFF
--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -1,7 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
-load("//network/NetworkGen/defs.bzl", "network_gen_code")
+load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//components/shared/code/defs.bzl", "shared_code_library", "remap_headers")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
@@ -173,7 +173,7 @@ prebuilt_cxx_library(
 
 compiler_flags += ["-include", "BuildDefines.h"]
 
-network_gen_code(
+generate_code(
     name = "network",
     _cxx_toolchain = TOOLCHAIN,
     compiler_flags = compiler_flags + ["-Wno-float-conversion", "-Wno-sign-conversion"],
@@ -428,6 +428,7 @@ alias(
     conUDS_download(
         name = "download-{}".format(variant),
         binary = ":crc-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = APP_NAME,
     )
     for variant in variants

--- a/components/bms_worker/BUCK
+++ b/components/bms_worker/BUCK
@@ -1,7 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
-load("//network/NetworkGen/defs.bzl", "network_gen_code")
+load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//components/shared/code/defs.bzl", "shared_code_library", "remap_headers")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
@@ -188,7 +188,7 @@ prebuilt_cxx_library(
 compiler_flags += ["-include", "BuildDefines.h"]
 
 [
-    network_gen_code(
+    generate_code(
         name = "network-node-{}".format(int(node)),
         _cxx_toolchain = TOOLCHAIN,
         compiler_flags = compiler_flags + ["-Wno-float-conversion", "-Wno-sign-conversion"],
@@ -466,6 +466,7 @@ alias(
     conUDS_download(
         name = "download-node-{}".format(node),
         binary = ":crc-node-{}".format(node),
+        manifest = "//network:manifest-uds",
         node = APP_NAME + "{}".format(node),
     )
     for node in range(NUMBER_NODES)

--- a/components/bootloaders/STM/stm32f1/BUCK
+++ b/components/bootloaders/STM/stm32f1/BUCK
@@ -383,6 +383,7 @@ alias(
     conUDS_download(
         name = "download-updater-{}".format(variant),
         binary = ":crc-updater-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = node,
     )
     for node, variant, _, _ in variants
@@ -391,6 +392,7 @@ alias(
     conUDS_bootloader_download(
         name = "download-bootloader-{}".format(variant),
         binary = ":crc-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = node,
     )
     for node, variant, has_updater, _ in variants if has_updater

--- a/components/vc/front/BUCK
+++ b/components/vc/front/BUCK
@@ -1,7 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
-load("//network/NetworkGen/defs.bzl", "network_gen_code")
+load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//components/shared/code/defs.bzl", "shared_code_library", "remap_headers")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
@@ -155,7 +155,7 @@ prebuilt_cxx_library(
 
 compiler_flags += ["-include", "BuildDefines.h"]
 
-network_gen_code(
+generate_code(
     name = "network",
     _cxx_toolchain = TOOLCHAIN,
     compiler_flags = compiler_flags + ["-Wno-float-conversion", "-Wno-sign-conversion"],
@@ -406,6 +406,7 @@ alias(
     conUDS_download(
         name = "download-{}".format(variant),
         binary = ":crc-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = APP_NAME,
     )
     for variant in variants

--- a/components/vc/pdu/BUCK
+++ b/components/vc/pdu/BUCK
@@ -1,7 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
-load("//network/NetworkGen/defs.bzl", "network_gen_code")
+load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//components/shared/code/defs.bzl", "shared_code_library", "remap_headers")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
@@ -155,7 +155,7 @@ prebuilt_cxx_library(
 
 compiler_flags += ["-include", "BuildDefines.h"]
 
-network_gen_code(
+generate_code(
     name = "network",
     _cxx_toolchain = TOOLCHAIN,
     compiler_flags = compiler_flags + ["-Wno-float-conversion", "-Wno-sign-conversion"],
@@ -402,6 +402,7 @@ alias(
     conUDS_download(
         name = "download-{}".format(variant),
         binary = ":crc-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = APP_NAME,
     )
     for variant in variants

--- a/components/vc/rear/BUCK
+++ b/components/vc/rear/BUCK
@@ -1,7 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
-load("//network/NetworkGen/defs.bzl", "network_gen_code")
+load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//components/shared/code/defs.bzl", "shared_code_library", "remap_headers")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
@@ -155,7 +155,7 @@ prebuilt_cxx_library(
 
 compiler_flags += ["-include", "BuildDefines.h"]
 
-network_gen_code(
+generate_code(
     name = "network",
     _cxx_toolchain = TOOLCHAIN,
     compiler_flags = compiler_flags + ["-Wno-float-conversion", "-Wno-sign-conversion"],
@@ -405,6 +405,7 @@ alias(
     conUDS_download(
         name = "download-{}".format(variant),
         binary = ":crc-{}".format(variant),
+        manifest = "//network:manifest-uds",
         node = APP_NAME,
     )
     for variant in variants

--- a/drive-stack/conUDS/defs.bzl
+++ b/drive-stack/conUDS/defs.bzl
@@ -3,19 +3,21 @@ load("@prelude//:rules.bzl", __rules__ = "rules")
 def conUDS_download(
         name: str,
         binary: str,
-        node: str):
+        node: str,
+        manifest: str):
     return __rules__["command_alias"](
         name = name,
         exe = "//drive-stack/conUDS:conUDS",
-        args = ["-n", node, "download", "$(location {})".format(binary)],
+        args = ["-m", "$(location {})".format(manifest), "-n", node, "download", "$(location {})".format(binary)],
     )
 
 def conUDS_bootloader_download(
         name: str,
         binary: str,
-        node: str):
+        node: str,
+        manifest: str):
     return __rules__["command_alias"](
         name = name,
         exe = "//drive-stack/conUDS:conUDS",
-        args = ["-n", node, "bootloader-download", "$(location {})".format(binary)],
+        args = ["-m", "$(location {})".format(manifest), "-n", node, "bootloader-download", "$(location {})".format(binary)],
     )

--- a/network/BUCK
+++ b/network/BUCK
@@ -1,18 +1,33 @@
-load("//network/NetworkGen/defs.bzl", "network_build", "network_gen_stats", "network_gen_dbc", "network_gen_code")
+load(
+    "//network/NetworkGen/defs.bzl",
+    "build_network",
+    "generate_code",
+    "generate_dbcs",
+    "generate_manifest",
+    "generate_stats",
+)
 
-network_build(
+build_network(
     name = "network",
     data_dir = "definition/",
     visibility = ["PUBLIC"],
 )
 
-network_gen_dbc(
+generate_dbcs(
     name = "dbc",
     dep = ":network",
     visibility = ["PUBLIC"],
 )
 
-network_gen_stats(
+generate_stats(
     name = "stats",
     dep = ":network",
+)
+
+generate_manifest(
+    name = "manifest-uds",
+    dep = ":network",
+    filters = ["UdsRequest=request_id", "udsResponse=response_id"],
+    ignore_nodes = ["udsClient"],
+    visibility = ["PUBLIC"],
 )

--- a/network/NetworkGen/defs.bzl
+++ b/network/NetworkGen/defs.bzl
@@ -1,5 +1,6 @@
 load("@prelude//:rules.bzl", "cxx_library")
-load("//components/shared/code/defs.bzl", "remap_headers")
+load("//tools/defs.bzl", "remap_files")
+load("@prelude//:rules.bzl", __rules__ = "rules")
 load("//tools/uv/defs.bzl", "uv_genrule", "uv_tool")
 
 def generate_manifest(name: str, dep: str, filters: list[str], ignore_nodes: list[str] | None = None, **kwargs):
@@ -104,10 +105,15 @@ def build_network(
         name: str,
         data_dir: str,
         **kwargs):
+    defs = remap_files(data_dir, glob([data_dir + "**/*.yaml"]))
+    __rules__["filegroup"](
+        name = "network-defs",
+        srcs = defs,
+    )
     uv_genrule(
         name = name,
         tool = "//network/NetworkGen:yamcan",
-        srcs = [data_dir],
+        srcs = [":network-defs"],
         out = "network-cache",
         cmd = "$(python) ${TOOLDIR}/NetworkGen.py --data-dir ${SRCS} --cache-dir ${OUT} --build",
         **kwargs

--- a/network/definition/data/components/stw/stw-rx.yaml
+++ b/network/definition/data/components/stw/stw-rx.yaml
@@ -1,2 +1,4 @@
 messages:
+  UDSCLIENT_stwUdsRequest:
+    sourceBuses: "veh"
 signals:

--- a/tools/uv/defs.bzl
+++ b/tools/uv/defs.bzl
@@ -62,7 +62,7 @@ def _uv_genrule_impl(ctx: AnalysisContext) -> list[Provider]:
     } | {src.short_path: src for src in ctx.attrs.tool[UvTool].srcs}
 
     tooldir = ctx.actions.symlinked_dir("tool", symlinks)
-    env = {"TOOLDIR": cmd_args(tooldir, format = "/".join([".", "{}"]))}
+    env = {"TOOLDIR": cmd_args(tooldir, format = "./{}")}
 
     return process_genrule(ctx, ctx.attrs.out, ctx.attrs.outs, extra_env_vars = env)
 


### PR DESCRIPTION
### Describe changes

conUDS now pulls the network manifest from yamcan

### Impact

1. Better developer workflow
2. conUDS dynamically driven by yamcan

### Test Plan

- [x] Reset VCFRONT, ensure vc resets
- [x] Change vcfront uds id to 0x7ff
- [x] Reset VCFRONT, ensure vcfront does not reset
