### PR TITLE
bmsb: Use calculated pack voltage to report

### DIFF
--- a/components/bms_boss/src/BMS.c
+++ b/components/bms_boss/src/BMS.c
@@ -97,16 +97,10 @@ static void BMS10Hz_PRD(void)
         BMS.pack_discharge_limit = tmp.pack_discharge_limit;
     }
 
-#if (BMSB_CONFIG_ID == 0U)
     BMS.pack_voltage = tmp.pack_voltage;
-#elif (BMSB_CONFIG_ID == 1U)
-    BMS.pack_voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_VPACK);
-#else
-#error "Unsupported config id."
-#endif
-    BMS.fault                = tmp.fault;
-    BMS.voltages             = tmp.voltages;
-    BMS.max_temp             = tmp.max_temp;
+    BMS.fault        = tmp.fault;
+    BMS.voltages     = tmp.voltages;
+    BMS.max_temp     = tmp.max_temp;
 }
 
 static void BMS100Hz_PRD(void)


### PR DESCRIPTION
### Describe changes

1. Fixes bad pack voltage sense on bmsb

### Impact

1. Corrects pre-charge and pack voltage functionality

### Test Plan

- [ ] Ensure bmsb reports pack voltage correctly
