### PR TITLE
drv_tps20xx: Fix typo in OC state progression

### DIFF
--- a/components/shared/code/DRV/drv_tps20xx.c
+++ b/components/shared/code/DRV/drv_tps20xx.c
@@ -120,7 +120,7 @@ void drv_tps20xx_run(void)
             case DRV_TPS20XX_STATE_FAULTED_OT:
                 {
                     drv_tps20xx_private_setICEnabled(channel, false);
-                    if ((drv_tps20xx_data[channel].state != DRV_TPS20XX_STATE_FAULTED_OT) && ic_faulted)
+                    if ((drv_tps20xx_data[channel].state != DRV_TPS20XX_STATE_FAULTED_OC) && ic_faulted)
                     {
                             drv_tps20xx_data[channel].state = DRV_TPS20XX_STATE_FAULTED_OT;
                     }
@@ -134,6 +134,7 @@ void drv_tps20xx_run(void)
                             // idsabling and re-enabling the channel
                             drv_tps20xx_private_setICEnabled(channel, true);
                             drv_tps20xx_data[channel].state = DRV_TPS20XX_STATE_RETRY;
+                            break;
                         }
                     }
 


### PR DESCRIPTION
### Describe changes

TPS20XX driver has a typo wherein it will be terminal in the over current state

### Impact

Allows TPS20XX to recover from a fault.

### Test Plan

- [ ] Flash VCREAR, trip 5V HSD output
- [ ] Ensure HSD turns off and then recovers
