### PR TITLE
Implement voltage division handling in analog input driver

### DIFF
--- a/components/bms_boss/HW/drv_inputAD_componentSpecific.c
+++ b/components/bms_boss/HW/drv_inputAD_componentSpecific.c
@@ -71,6 +71,15 @@ drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT]
     },
 };
 
+drv_inputAD_configAnalog_S drv_inputAD_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_CS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CS,
+    },
+    [DRV_INPUTAD_ANALOG_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP,
+    },
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/bms_worker/HW/drv_inputAD_componentSpecific.c
+++ b/components/bms_worker/HW/drv_inputAD_componentSpecific.c
@@ -39,6 +39,144 @@
 void drv_inputAD_private_unpackADCBufferCells(void);
 void drv_inputAD_private_unpackADCBufferTemps(void);
 
+drv_inputAD_configAnalog_S drv_inputAD_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_MUX1_CH1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH1,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH2,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH3,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH4,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH5] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH5,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH6] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH6,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH7] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH7,
+    },
+    [DRV_INPUTAD_ANALOG_MUX1_CH8] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH8,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH1,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH2,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH3,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH4,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH5]  = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH5,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH6] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH6,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH7] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH7,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_CH8] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH8,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH1,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH2,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH3,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH4,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH5] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH5,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH6] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH6,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH7] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH7,
+    },
+    [DRV_INPUTAD_ANALOG_MUX3_CH8] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH8,
+    },
+    [DRV_INPUTAD_ANALOG_CELL1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL1,
+    },
+    [DRV_INPUTAD_ANALOG_CELL2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL2,
+    },
+    [DRV_INPUTAD_ANALOG_CELL3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL3,
+    },
+    [DRV_INPUTAD_ANALOG_CELL4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL4,
+    },
+    [DRV_INPUTAD_ANALOG_CELL5] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL5,
+    },
+    [DRV_INPUTAD_ANALOG_CELL6] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL6,
+    },
+    [DRV_INPUTAD_ANALOG_CELL7] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL7,
+    },
+    [DRV_INPUTAD_ANALOG_CELL8] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL8,
+    },
+    [DRV_INPUTAD_ANALOG_CELL9] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL9,
+    },
+    [DRV_INPUTAD_ANALOG_CELL10] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL10,
+    },
+    [DRV_INPUTAD_ANALOG_CELL11] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL11,
+    },
+    [DRV_INPUTAD_ANALOG_CELL12] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL12,
+    },
+    [DRV_INPUTAD_ANALOG_CELL13] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL13,
+    },
+    [DRV_INPUTAD_ANALOG_CELL14] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL14,
+    },
+    [DRV_INPUTAD_ANALOG_CELL15] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL15,
+    },
+    [DRV_INPUTAD_ANALOG_CELL16] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CELL16,
+    },
+    [DRV_INPUTAD_ANALOG_SEGMENT] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SEGMENT,
+    },
+    [DRV_INPUTAD_ANALOG_BOARD_TEMP1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP1,
+    },
+    [DRV_INPUTAD_ANALOG_BOARD_TEMP2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP2,
+    },
+    [DRV_INPUTAD_ANALOG_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_REF_VOLTAGE] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_REF_VOLTAGE,
+    },
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/
@@ -84,7 +222,7 @@ static void drv_inputAD_1kHz_PRD(void)
         if (current_cell == MAX_CELL1)
         {
             drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CELL1 + current_cell,
-                                                 HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
+                                                 HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP));
             BMS_measurementComplete();
         }
         else
@@ -97,14 +235,14 @@ static void drv_inputAD_1kHz_PRD(void)
             {
                 BMS_setOutputCell(current_cell - 1);
                 drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_CELL1 + current_cell,
-                                                    HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
+                                                    HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP));
             }
         }
     }
     else if (BMS.state == BMS_SAMPLING)
     {
         drv_inputAD_private_setAnalogVoltage(DRV_INPUTAD_ANALOG_SEGMENT,
-                                             HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP) * ADC_VOLTAGE_DIVISION);
+                                             HW_ADC_getVFromBank2Channel(ADC_BANK2_CHANNEL_BMS_CHIP));
     }
 }
 

--- a/components/shared/code/DRV/drv_inputAD.c
+++ b/components/shared/code/DRV/drv_inputAD.c
@@ -19,6 +19,7 @@
  ******************************************************************************/
 
 extern drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT];
+extern drv_inputAD_configAnalog_S drv_inputAD_configAnalog[DRV_INPUTAD_ANALOG_COUNT];
 
 /******************************************************************************
 *                             T Y P E D E F S
@@ -94,8 +95,11 @@ void drv_inputAD_private_runDigital(void)
  * @param voltage Measured voltage
  */
 void drv_inputAD_private_setAnalogVoltage(drv_inputAD_channelAnalog_E channel, float32_t voltage)
+/* void drv_inputAD_private_setRawAnalogVoltage(drv_inputAD_channelAnalog_E channel, float32_t voltage) */
 {
-    inputs.voltages[channel] = voltage;
+    //apply voltage divider multiplier from configuration
+    float32_t divided_voltage = voltage * drv_inputAD_configAnalog[channel].voltage_divider_multiplier;
+    inputs.voltages[channel] = divided_voltage;
 }
 
 /**

--- a/components/shared/code/DRV/drv_inputAD.h
+++ b/components/shared/code/DRV/drv_inputAD.h
@@ -43,6 +43,116 @@ typedef struct
     } config;
 } drv_inputAD_configDigital_S;
 
+typedef struct{
+    drv_inputAD_channelAnalog_E channel; 
+    float32_t voltage_divider_multiplier;
+} drv_inputAD_configAnalog_S;
+
+/******************************************************************************
+ *       V O L T A G E   D I V I D E R   M U L T I P L I E R S
+ ******************************************************************************/
+//BMS boss analog channel multipliers
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CS                       16.0f 
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP                 1.0f
+
+//BMS worker analog channel multipliers
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH1                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH2                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH3                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH4                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH5                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH6                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH7                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX1_CH8                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH1                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH2                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH3                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH4                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH5                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH6                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH7                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_CH8                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH1                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH2                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH3                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH4                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH5                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH6                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH7                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX3_CH8                 1.0f
+// All cell voltages must be sequential and ordered
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL1                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL2                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL3                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL4                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL5                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL6                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL7                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL8                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL9                    1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL10                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL11                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL12                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL13                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL14                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL15                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CELL16                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_SEGMENT                  2.0f     //ADC_VOLTAGE_DIVISION
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP1              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP2              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP                 1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_REF_VOLTAGE              1.0f
+
+//stw switch analog channel multipliers
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN2             1.0f 
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN4             1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN6             1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_MCU_TEMP         1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN1             1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN3             1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN5             1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN7             1.0f
+
+//VC front analog channel multipliers 
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_R_BR_TEMP                1.0f            
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_L_SHK_DISP               1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_PU1                      1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_BR_POT                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE1                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_STR_ANGLE                1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P1                  1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_L_BR_TEMP                1.0f            
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_R_SHK_DISP               1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_PU2                      1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_BR_PR                    1.681f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE3                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE4                   1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P2                  1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP               1.0f
+//VC rear analog channel multipliers
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE2                   1.0f
+
+//VC pdu analog channel multipliers 
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP1_SNS              1.0f            
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP2_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP3_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP4_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_5V_VOLTAGE               PDU_VS_VOLTAGE_MULTIPLIER 
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_UVL_BATT                 6.62f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP5_SNS              1.0f            
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP6_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP7_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP8_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP9_SNS              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_HP_CS               1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_THERMISTORS         1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_PUMP              1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_FAN               1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_5V_SNS            PDU_CS_AMPS_PER_VOLT
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_MCU         1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_HSD1        1.0f
+#define DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_HSD2        1.0f
+
 /******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/

--- a/components/stw_switch/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/stw_switch/src/HW/drv_inputAD_componentSpecific.c
@@ -99,6 +99,33 @@ drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT]
     },
 };
 
+drv_inputAD_configAnalog_S drv_inputAD_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN2,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN4,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN6] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN6,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_MCU_TEMP,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN1,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN3,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN5] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN5,
+    }, 
+    [DRV_INPUTAD_ANALOG_CHANNEL_AIN7] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_CHANNEL_AIN7,
+    },
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/vc/front/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/front/src/HW/drv_inputAD_componentSpecific.c
@@ -78,6 +78,57 @@ drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT]
 	 },
 };
 
+drv_inputAD_configAnalog_S drv_inputAd_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_R_BR_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_R_BR_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_L_SHK_DISP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_L_SHK_DISP,
+    },
+    [DRV_INPUTAD_ANALOG_PU1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_PU1,
+    },
+    [DRV_INPUTAD_ANALOG_BR_POT] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BR_POT,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE1,
+    },
+    [DRV_INPUTAD_ANALOG_STR_ANGLE] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_STR_ANGLE,
+    },
+    [DRV_INPUTAD_ANALOG_APPS_P1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P1,
+    },
+    [DRV_INPUTAD_ANALOG_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_L_BR_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_L_BR_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_R_SHK_DISP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_R_SHK_DISP,
+    },
+    [DRV_INPUTAD_ANALOG_PU2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_PU2,
+    },
+    [DRV_INPUTAD_ANALOG_BR_PR] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BR_PR,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE3,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE4,
+    },
+    [DRV_INPUTAD_ANALOG_APPS_P2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P2,
+    },
+    [DRV_INPUTAD_ANALOG_BOARD_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP,
+    },
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/vc/front/src/brakePressure.c
+++ b/components/vc/front/src/brakePressure.c
@@ -39,8 +39,8 @@ static void brakePressure_init(void)
 
 static void brakePressure_periodic_100Hz(void){
 
-    brakePressure_data.voltage = 1.681f * drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_BR_PR); 
-    /** Voltage division compensation: 1/(681/1k) = 1.681    */
+    brakePressure_data.voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_BR_PR); 
+
     if (brakePressure_data.voltage <= 0.5f)
     {
         brakePressure_data.pressure = 0.0f;

--- a/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/pdu/src/HW/drv_inputAD_componentSpecific.c
@@ -79,6 +79,69 @@ drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT]
     },
 };
 
+drv_inputAD_configAnalog_S drv_inputAD_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_MUX_LP1_SNS] = {    //Bank 1
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP1_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP2_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP2_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP3_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP3_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP4_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP4_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_5V_VOLTAGE] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_5V_VOLTAGE,
+    },
+    [DRV_INPUTAD_ANALOG_UVL_BATT] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_UVL_BATT,
+    },
+    [DRV_INPUTAD_ANALOG_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP5_SNS] = {    //Bank2
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP5_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP6_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP6_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP7_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP7_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP8_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP8_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX_LP9_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX_LP9_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_HP_CS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_HP_CS,
+    },
+    [DRV_INPUTAD_ANALOG_MUX2_THERMISTORS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MUX2_THERMISTORS,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_PUMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_PUMP,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_FAN] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_FAN,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_5V_SNS] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_5V_SNS,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_THERM_MCU] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_MCU,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_THERM_HSD1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_HSD1,
+    },
+    [DRV_INPUTAD_ANALOG_DEMUX2_THERM_HSD2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_DEMUX2_THERM_HSD2,
+    },
+};
+
 struct inputs_data {
     drv_mux_channel_S signal_mux;
 };

--- a/components/vc/pdu/src/powerManager.c
+++ b/components/vc/pdu/src/powerManager.c
@@ -64,7 +64,7 @@ static void powerManager_init(void)
 
 static void powerManager_periodic_10Hz(void)
 {
-    const float32_t glv_voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_UVL_BATT) * 6.62f;
+    const float32_t glv_voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_UVL_BATT);
     float32_t tmp_current = 0.0f;
 
     powerManager_data.glv_voltage = glv_voltage;

--- a/components/vc/rear/src/HW/drv_inputAD_componentSpecific.c
+++ b/components/vc/rear/src/HW/drv_inputAD_componentSpecific.c
@@ -71,6 +71,57 @@ drv_inputAD_configDigital_S drv_inputAD_configDigital[DRV_INPUTAD_DIGITAL_COUNT]
     },
 };
 
+drv_inputAD_configAnalog_S drv_inputAd_configAnalog[DRV_INPUTAD_ANALOG_COUNT] = {
+    [DRV_INPUTAD_ANALOG_R_BR_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_R_BR_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_L_SHK_DISP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_L_SHK_DISP,
+    },
+    [DRV_INPUTAD_ANALOG_PU1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_PU1,
+    },
+    [DRV_INPUTAD_ANALOG_BR_POT] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BR_POT,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE1,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE2,
+    },
+    [DRV_INPUTAD_ANALOG_APPS_P1] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P1,
+    },
+    [DRV_INPUTAD_ANALOG_MCU_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_MCU_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_L_BR_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_L_BR_TEMP,
+    },
+    [DRV_INPUTAD_ANALOG_R_SHK_DISP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_R_SHK_DISP,
+    },
+    [DRV_INPUTAD_ANALOG_PU2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_PU2,
+    },
+    [DRV_INPUTAD_ANALOG_BR_PR] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BR_PR,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE3] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE3,
+    },
+    [DRV_INPUTAD_ANALOG_SPARE4] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_SPARE4,
+    },
+     [DRV_INPUTAD_ANALOG_APPS_P2] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_APPS_P2,
+    },
+     [DRV_INPUTAD_ANALOG_BOARD_TEMP] = {
+        .voltage_divider_multiplier = DRV_INPUTAD_ANALOG_MULTIPLIER_BOARD_TEMP,
+    },
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/vc/rear/src/brakePressure.c
+++ b/components/vc/rear/src/brakePressure.c
@@ -39,8 +39,8 @@ static void brakePressure_init(void)
 
 static void brakePressure_periodic_100Hz(void){
 
-    brakePressure_data.voltage = 1.681f * drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_BR_PR); 
-    /** Voltage division compensation: 1/(681/1k) = 1.681    */
+    brakePressure_data.voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_BR_PR); 
+
     if (brakePressure_data.voltage <= 0.5f)
     {
         brakePressure_data.pressure = 0.0f;


### PR DESCRIPTION
Implementing voltage division handling for analog inputs in the input driver

### Describe changes

1. Added voltage divider multiplier definitions in `drv_inputAD.h` for all analog channels across all components (BMS Boss, BMS Worker, STW Switch, VC Front, VC PDU, VC Rear).
2. Updated all component-specific files (`drv_inputAD_componentSpecific.c`) so each component now defines a `drv_inputAD_configAnalog[]` array mapping analog channels to their voltage divider multipliers.
3. Removed external voltage division multiplication from all `drv_inputAD_getAnalogVoltage()` calls. 

### Impact

1. All voltage divider multipliers are defined in one location. 
2. Applications now receive pre-divided voltages without manual scaling


### Test Plan

- [ ] **Hardware Tests**: Verify analog readings (current sense, cell voltages, pressure sensors) match expected values
- [ ] **Software Tests**: Confirm all components build and run without regression
- [ ] **Integration Tests**: Validate CAN messages contain properly scaled analog values
- [ ] **Configuration Audit**: Check multiplier values against hardware specs
