### PR TITLE
buck2: Bringup openocd support

### DIFF
--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -1,6 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//components/shared/code/defs.bzl", "remap_headers", "shared_code_library")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download", "deployable_target")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
@@ -439,6 +440,17 @@ alias(
         src = ":crc-{}".format(variant),
         target_node = APP_NAME,
         visibility = ["PUBLIC"],
+    )
+    for variant in variants
+]
+
+[
+    openocd_run(
+        name = "gdb-{}".format(variant),
+        toolchain = TOOLCHAIN,
+        src = ":elf",
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )
     for variant in variants
 ]

--- a/components/bms_worker/BUCK
+++ b/components/bms_worker/BUCK
@@ -1,6 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//components/shared/code/defs.bzl", "remap_headers", "shared_code_library")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download", "deployable_target")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
@@ -420,6 +421,14 @@ cxx_binary(
         "//embedded/libs/cells:cells",
     ],
 )
+[
+    configured_alias(
+        name = "elf-node-{}".format(i),
+        actual = ":elf",
+        platform = ":cfg0-node-{}".format(i),
+    )
+    for i in range(NUMBER_NODES)
+]
 
 generate_asms(
     name = "asm",
@@ -497,6 +506,17 @@ alias(
         src = ":crc-node-{}".format(node),
         target_node = APP_NAME + "{}".format(node),
         visibility = ["PUBLIC"],
+    )
+    for node in range(NUMBER_NODES)
+]
+
+[
+    openocd_run(
+        name = "gdb-node-{}".format(node),
+        toolchain = TOOLCHAIN,
+        src = ":elf-node-{}".format(node),
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )
     for node in range(NUMBER_NODES)
 ]

--- a/components/bootloaders/STM/stm32f1/defs.bzl
+++ b/components/bootloaders/STM/stm32f1/defs.bzl
@@ -2,6 +2,7 @@ load("@prelude//:rules.bzl", __rules__ = "rules")
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_bootloader_download", "conUDS_download")
 load("//embedded/defs.bzl", "preprocess_linkscript", "produce_bin")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load("//tools/hextools/defs.bzl", "inject_crc")
 
@@ -185,4 +186,12 @@ def _bootloader_impl(
     __rules__["alias"](
         name = name_prefix.format("compdb"),
         actual = ":" + name_prefix.format("elf") + "[full-compilation-database]",
+    )
+
+    openocd_run(
+        name = "gdb-{}-{}".format(config_id, "blu" if is_updater else "bl"),
+        toolchain = toolchain,
+        src = ":" + name_prefix.format("elf"),
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )

--- a/components/steering_wheel/BUCK
+++ b/components/steering_wheel/BUCK
@@ -1,4 +1,5 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//tools/hextools/defs.bzl", "inject_crc")
 
@@ -254,4 +255,12 @@ alias(
 alias(
     name = "stw",
     actual = ":bin",
+)
+
+openocd_run(
+    name = "gdb",
+    toolchain = TOOLCHAIN,
+    src = ":elf",
+    interface = "stlink",
+    mcu = "stm32f103c8",
 )

--- a/components/vc/front/BUCK
+++ b/components/vc/front/BUCK
@@ -1,6 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//components/shared/code/defs.bzl", "remap_headers", "shared_code_library")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download", "deployable_target")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
@@ -422,6 +423,17 @@ alias(
         src = ":crc-{}".format(variant),
         target_node = APP_NAME,
         visibility = ["PUBLIC"],
+    )
+    for variant in variants
+]
+
+[
+    openocd_run(
+        name = "gdb-{}".format(variant),
+        toolchain = TOOLCHAIN,
+        src = ":elf",
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )
     for variant in variants
 ]

--- a/components/vc/pdu/BUCK
+++ b/components/vc/pdu/BUCK
@@ -1,6 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//components/shared/code/defs.bzl", "remap_headers", "shared_code_library")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download", "deployable_target")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
@@ -416,6 +417,17 @@ alias(
         src = ":crc-{}".format(variant),
         target_node = APP_NAME,
         visibility = ["PUBLIC"],
+    )
+    for variant in variants
+]
+
+[
+    openocd_run(
+        name = "gdb-{}".format(variant),
+        toolchain = TOOLCHAIN,
+        src = ":elf",
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )
     for variant in variants
 ]

--- a/components/vc/rear/BUCK
+++ b/components/vc/rear/BUCK
@@ -1,6 +1,7 @@
 load("@toolchains//gcc/defs.bzl", "generate_asms", "generate_stripped_asms")
 load("//components/shared/code/defs.bzl", "remap_headers", "shared_code_library")
 load("//drive-stack/conUDS/defs.bzl", "conUDS_download", "deployable_target")
+load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
 load("//network/NetworkGen/defs.bzl", "generate_code")
 load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
@@ -421,6 +422,17 @@ alias(
         src = ":crc-{}".format(variant),
         target_node = APP_NAME,
         visibility = ["PUBLIC"],
+    )
+    for variant in variants
+]
+
+[
+    openocd_run(
+        name = "gdb-{}".format(variant),
+        toolchain = TOOLCHAIN,
+        src = ":elf",
+        interface = "stlink",
+        mcu = "stm32f103c8",
     )
     for variant in variants
 ]

--- a/embedded/openocd/BUCK
+++ b/embedded/openocd/BUCK
@@ -1,0 +1,14 @@
+load(":defs.bzl", "download_openocd_distribution")
+
+download_openocd_distribution(
+    name = "dist-openocd",
+    version = "0.12.0-6",
+    visibility = ["PUBLIC"],
+)
+
+filegroup(
+    name = "repository",
+    srcs = glob(["interface/*", "mcu/*"]),
+    copy = False,
+    visibility = ["PUBLIC"],
+)

--- a/embedded/openocd/defs.bzl
+++ b/embedded/openocd/defs.bzl
@@ -1,0 +1,158 @@
+load("@prelude//http_archive:http_archive.bzl", "http_archive_impl")
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load("//tools/defs.bzl", "host_arch", "host_os")
+load(":releases.bzl", "releases")
+
+OpenOCDReleaseInfo = provider(
+    # @unsorted-dict-items
+    fields = {
+        "version": provider_field(typing.Any, default = None),
+        "url": provider_field(typing.Any, default = None),
+        "sha256": provider_field(typing.Any, default = None),
+        "strip_prefix": provider_field(str, default = ""),
+    },
+)
+
+OpenOCDDistributionInfo = provider(
+    # @unsorted-dict-items
+    fields = {
+        "version": provider_field(typing.Any, default = None),
+        "arch": provider_field(typing.Any, default = None),
+        "os": provider_field(typing.Any, default = None),
+    },
+)
+
+def get_openocd_release(version: str, target_arch: str, target_os: str) -> OpenOCDReleaseInfo:
+    if not version in releases:
+        fail("Unknown OpenOCD release version '{}'. Available versions: {}".format(
+            version,
+            ", ".join(releases.keys()),
+        ))
+    openocd_version = releases[version]
+
+    platform = "{}-{}".format(host_arch(), host_os())
+    if not platform in openocd_version:
+        fail("Unsupported platform '{}'. Supported platforms: {}".format(
+            platform,
+            ", ".join(openocd_version.keys()),
+        ))
+    openocd_platform = openocd_version[platform]
+
+    return OpenOCDReleaseInfo(
+        version = openocd_version.get("version", version),
+        url = openocd_platform["archive"],
+        sha256 = openocd_platform["sha256sum"],
+        strip_prefix = openocd_platform["strip_prefix"],
+    )
+
+def download_openocd_distribution(
+        name: str,
+        version: str,
+        visibility: list[str],
+        arch: [None, str] = None,
+        os: [None, str] = None):
+    arch = arch or host_arch()
+    os = os or host_os()
+
+    archive_name = name + "-archive"
+    release = get_openocd_release(version, arch, os)
+    native.http_archive(
+        name = archive_name,
+        urls = [release.url],
+        sha256 = release.sha256,
+        strip_prefix = release.strip_prefix,
+    )
+    openocd_distribution(
+        name = name,
+        dist = ":" + archive_name,
+        version = release.version,
+        arch = arch,
+        os = os,
+        visibility = visibility,
+    )
+
+def _openocd_distribution_impl(ctx: AnalysisContext) -> list[Provider]:
+    dest = ctx.actions.declare_output("openocd")
+    src = cmd_args(ctx.attrs.dist[DefaultInfo].default_outputs[0], format = "{}/")
+    ctx.actions.run(
+        ["ln", "-sf", cmd_args(src, relative_to = (dest, 1)), dest.as_output()],
+        category = "debug",
+    )
+    compiler = cmd_args(
+        [dest],
+        hidden = [
+            ctx.attrs.dist[DefaultInfo].default_outputs,
+            ctx.attrs.dist[DefaultInfo].other_outputs,
+        ],
+    )
+
+    return [
+        ctx.attrs.dist[DefaultInfo],
+        RunInfo(args = compiler),
+        OpenOCDDistributionInfo(
+            version = ctx.attrs.version,
+            arch = ctx.attrs.arch or host_arch(),
+            os = ctx.attrs.os or host_os(),
+        ),
+    ]
+
+openocd_distribution = rule(
+    impl = _openocd_distribution_impl,
+    attrs = {
+        "version": attrs.string(),
+        "dist": attrs.dep(providers = [DefaultInfo]),
+        "arch": attrs.option(attrs.string(), default = None),
+        "os": attrs.option(attrs.string(), default = None),
+    },
+)
+
+def _openocd_run_impl(ctx: AnalysisContext) -> list[Provider]:
+    # example command:
+    # gdb {src} -ex 'target extended-remote | 'openocd -s embedded/openocd -f stlink.cfg -f stm32f103c8.cfg -c "gdb_port pipe"' -ex "monitor reset"
+    gdb = ctx.attrs.toolchain[TemplatePlaceholderInfo].unkeyed_variables["gdb"]
+    src = ctx.attrs.src
+    interface = ctx.attrs.interface
+    mcu = ctx.attrs.mcu
+    repo = ctx.attrs.repository[DefaultInfo].default_outputs[0]
+
+    openocd = cmd_args(ctx.attrs.distribution[RunInfo], format = "{}/bin/openocd")
+
+    return [
+        DefaultInfo(),
+        RunInfo(args = cmd_args(
+            gdb,
+            src[DefaultInfo].default_outputs[0],
+            "-ex",
+            cmd_args(
+                "target",
+                "extended-remote",
+                "|",
+                cmd_args(
+                    openocd,
+                    "-s",
+                    repo,
+                    "-f",
+                    "interface/{}.cfg".format(interface),
+                    "-f",
+                    "mcu/{}.cfg".format(mcu),
+                    "-c",
+                    "'gdb_port pipe'",
+                ),
+                delimiter = " ",
+            ),
+            "-ex",
+            "monitor reset",
+        )),
+    ]
+
+openocd_run = rule(
+    impl = _openocd_run_impl,
+    attrs = {
+        "distribution": attrs.exec_dep(providers = [RunInfo, OpenOCDDistributionInfo], default = "//embedded/openocd:dist-openocd"),
+        "src": attrs.exec_dep(providers = [DefaultInfo]),
+        "interface": attrs.string(),
+        "mcu": attrs.string(),
+        "toolchain": attrs.toolchain_dep(providers = [CxxToolchainInfo], default = "@toolchains//:cxx"),
+        "repository": attrs.exec_dep(default = "//embedded/openocd:repository"),
+    },
+)

--- a/embedded/openocd/releases.bzl
+++ b/embedded/openocd/releases.bzl
@@ -1,0 +1,29 @@
+releases = {
+    "0.12.0-6": {
+        "date": "2025-02-07",
+        "aarch64-linux": {
+            "sha256sum": "46cca363793d35b65d815c0b9ddff765a082cfdf226868390eef69132368aa3d",
+            "size": "",
+            "archive": "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-linux-arm64.tar.gz",
+            "strip_prefix": "xpack-openocd-0.12.0-6",
+        },
+        "aarch64-macos": {
+            "sha256sum": "4f458dea82af3529d4dc71544abfd8c8c96ebe6c521868f87c6697b0866c9e99",
+            "size": "",
+            "archive": "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-darwin-arm64.tar.gz",
+            "strip_prefix": "xpack-openocd-0.12.0-6",
+        },
+        "x86_64-linux": {
+            "sha256sum": "7e762af5f9a4f21ac03130ddce36acf996f3e67c4ee1526ed3d4f8ad89e65c77",
+            "size": "",
+            "archive": "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-linux-x64.tar.gz",
+            "strip_prefix": "xpack-openocd-0.12.0-6",
+        },
+        "x86_64-macos": {
+            "sha256sum": "aa5052790b003f18e64691a3b8b7a650d4ce54f72fbbb23f1aed2d26a5795b76",
+            "size": "",
+            "archive": "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-darwin-x64.tar.gz",
+            "strip_prefix": "xpack-openocd-0.12.0-6",
+        },
+    },
+}

--- a/toolchains/gcc/defs.bzl
+++ b/toolchains/gcc/defs.bzl
@@ -317,6 +317,7 @@ def _gcc_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
         "cxxpp": _shell_quote(toolchain_info.cxx_compiler_info.preprocessor),
         "cxxflags": _shell_quote(toolchain_info.cxx_compiler_info.compiler_flags),
         "cxxppflags": _shell_quote(toolchain_info.cxx_compiler_info.preprocessor_flags),
+        "gdb": RunInfo(args = cmd_args(bin, format = "{}gdb")),
         "ld": toolchain_info.linker_info.linker,
         "ldflags-shared": _shell_quote(toolchain_info.linker_info.linker_flags or []),
         "ldflags-static": _shell_quote(toolchain_info.linker_info.linker_flags or []),
@@ -332,7 +333,12 @@ def _gcc_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
 
     placeholders_info = TemplatePlaceholderInfo(unkeyed_variables = unkeyed_variables)
 
-    return [ctx.attrs.distribution[DefaultInfo], toolchain_info, placeholders_info, platform_info]
+    return [
+        ctx.attrs.distribution[DefaultInfo],
+        toolchain_info,
+        placeholders_info,
+        platform_info,
+    ]
 
 gcc_toolchain = rule(
     impl = _gcc_toolchain_impl,

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -6,3 +6,23 @@ def strip_prefix(s, p):
 def remap_files(base: str, files: list[str]):
     remap = { strip_prefix(h, base): h for h in files }
     return remap
+
+def host_arch() -> str:
+    arch = host_info().arch
+    if arch.is_x86_64:
+        return "x86_64"
+    elif host_info().arch.is_aarch64:
+        return "aarch64"
+    else:
+        fail("Unsupported host architecture '{}'.".format(arch))
+
+def host_os() -> str:
+    os = host_info().os
+    if os.is_linux:
+        return "linux"
+    elif os.is_macos:
+        return "macos"
+    elif os.is_windows:
+        return "windows"
+    else:
+        fail("Unsupported host os '{}'.".format(os))


### PR DESCRIPTION
### Describe changes

Adds support for debugging in buck2

### Test Plan

- [x] Build and debug a controller through an stlink
- [x] Execute `b main`, `monitor reset halt`, and then `c` and ensure it halts on the start of the `main` function
