### PR TITLE
detect vn9008 overcurrent#353

### DIFF
--- a/components/shared/code/DRV/drv_vn9008.c
+++ b/components/shared/code/DRV/drv_vn9008.c
@@ -11,10 +11,10 @@
  *                             I N C L U D E S
  ******************************************************************************/
 
-#include "drv_vn9008.h"
 #include "drv_io.h"
-#include "string.h"
+#include "drv_vn9008.h"
 #include "HW_adc.h"
+#include "string.h"
 
 /******************************************************************************
  *                         P R I V A T E  V A R S
@@ -25,6 +25,7 @@ struct
     bool            request_enabled[DRV_VN9008_CHANNEL_COUNT];
     drv_hsd_state_E state[DRV_VN9008_CHANNEL_COUNT];
     float32_t       current[DRV_VN9008_CHANNEL_COUNT];
+    drv_timer_S     oc_timer[DRV_VN9008_CHANNEL_COUNT];
 } drv_vn9008_data;
 
 /******************************************************************************
@@ -37,10 +38,10 @@ void drv_vn9008_init(void)
 
     for (uint8_t i = 0U; i < DRV_VN9008_CHANNEL_COUNT; i++)
     {
-        drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
+        drv_vn9008_data.state[i]           = DRV_HSD_STATE_OFF;
         drv_vn9008_data.request_enabled[i] = false;
-        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].enable, DRV_IO_INACTIVE);
-        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].enable_cs, DRV_IO_INACTIVE);
+        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].enable,      DRV_IO_INACTIVE);
+        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].enable_cs,   DRV_IO_INACTIVE);
         drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].fault_reset, DRV_IO_INACTIVE);
     }
 }
@@ -49,14 +50,27 @@ void drv_vn9008_run(void)
 {
     for (uint8_t i = 0U; i < DRV_VN9008_CHANNEL_COUNT; i++)
     {
-        const float32_t cs_voltage = drv_inputAD_getAnalogVoltage(drv_vn9008_channels[i].cs_channel);
-        const float32_t current =  cs_voltage * drv_vn9008_channels[i].cs_amp_per_volt;
-        const bool diagnostic = drv_outputAD_getDigitalActiveState(drv_vn9008_channels[i].enable_cs) == DRV_IO_ACTIVE;
-        drv_vn9008_data.current[i] = diagnostic ? current : drv_vn9008_data.current[i];
+        const float32_t cs_voltage     = drv_inputAD_getAnalogVoltage(drv_vn9008_channels[i].cs_channel);
+        const float32_t current        = cs_voltage * drv_vn9008_channels[i].cs_amp_per_volt;
+        const bool      diagnostic     = drv_outputAD_getDigitalActiveState(drv_vn9008_channels[i].enable_cs) == DRV_IO_ACTIVE;
+        drv_vn9008_data.current[i]     = diagnostic ? current : drv_vn9008_data.current[i];
+        const bool      is_overcurrent = drv_vn9008_data.current[i] > drv_vn9008_channels[i].current_limit_amp;
+
+        if (is_overcurrent)
+        {
+            const drv_timer_state_E state = drv_timer_getState(&drv_vn9008_data.oc_timer[i]);
+            if (state == DRV_TIMER_STOPPED)
+            {
+                drv_timer_start(&drv_vn9008_data.oc_timer[i], drv_vn9008_channels[i].oc_timeout_ms);
+            }
+        }
+        else
+        {
+            drv_timer_stop(&drv_vn9008_data.oc_timer[i]);
+        }
 
         switch (drv_vn9008_data.state[i])
         {
-            // TODO: Handle state transitions
             case DRV_HSD_STATE_OFF:
                 if (drv_vn9008_data.request_enabled[i])
                 {
@@ -64,19 +78,49 @@ void drv_vn9008_run(void)
                     drv_vn9008_data.state[i] = DRV_HSD_STATE_ON;
                 }
                 break;
+
             case DRV_HSD_STATE_ON:
+                const drv_timer_state_E state = drv_timer_getState(&drv_vn9008_data.oc_timer[i]);
                 if (drv_vn9008_data.request_enabled[i] == false)
                 {
                     drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
+                }
+                else if (state == DRV_TIMER_EXPIRED)
+                {
+                    drv_vn9008_data.state[i] = DRV_HSD_STATE_OVERCURRENT;
+                    drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].fault_reset, DRV_IO_ACTIVE);
+                    drv_timer_stop(&drv_vn9008_data.oc_timer[i]);
                 }
                 break;
-            default:
-                // FIXME: This should only occur if it is safe to reset
+
+            case DRV_HSD_STATE_OVERCURRENT:
                 if (drv_vn9008_data.request_enabled[i] == false)
                 {
-                    drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
-                    drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].fault_reset, DRV_IO_ACTIVE);
+                    if (is_overcurrent)
+                    {
+                        drv_vn9008_data.state[i] = DRV_HSD_STATE_OVERTEMP;
+                    }
+                    else if (is_overcurrent == false)
+                    {
+                        drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
+                        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].fault_reset, DRV_IO_INACTIVE);
+                    }
                 }
+                break;
+
+            case DRV_HSD_STATE_OVERTEMP:
+                if (drv_vn9008_data.request_enabled[i] == false)
+                {
+                    if (is_overcurrent == false)
+                    {
+                        drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
+                        drv_outputAD_setDigitalActiveState(drv_vn9008_channels[i].fault_reset, DRV_IO_INACTIVE);
+                    }
+                }
+                break;
+
+            default:
+                drv_vn9008_data.state[i] = DRV_HSD_STATE_OFF;
                 break;
         }
 
@@ -109,5 +153,6 @@ void drv_vn9008_setEnabled(drv_vn9008_E ic, bool enabled)
 void drv_vn9008_setCSEnabled(drv_vn9008_E ic, bool enabled)
 {
     const drv_io_activeState_E state = enabled ? DRV_IO_ACTIVE : DRV_IO_INACTIVE;
+
     drv_outputAD_setDigitalActiveState(drv_vn9008_channels[ic].enable_cs, state);
 }

--- a/components/shared/code/DRV/drv_vn9008.h
+++ b/components/shared/code/DRV/drv_vn9008.h
@@ -16,9 +16,9 @@
 #include "drv_hsd.h"
 #include "drv_inputAD.h"
 #include "drv_outputAD.h"
-#include "LIB_Types.h"
-#include "lib_swFuse.h"
 #include "drv_vn9008_componentSpecific.h"
+#include "lib_swFuse.h"
+#include "LIB_Types.h"
 
 /******************************************************************************
  *                             T Y P E D E F S
@@ -31,6 +31,8 @@ typedef struct
     drv_outputAD_channelDigital_E fault_reset;
     drv_outputAD_channelDigital_E enable;
     drv_outputAD_channelDigital_E enable_cs;
+    float32_t                     current_limit_amp;
+    uint16_t                      oc_timeout_ms;
 } drv_vn9008_channelConfig_S;
 
 extern const drv_vn9008_channelConfig_S drv_vn9008_channels[DRV_VN9008_CHANNEL_COUNT];

--- a/components/vc/pdu/src/HW/drv_vn9008_componentSpecific.c
+++ b/components/vc/pdu/src/HW/drv_vn9008_componentSpecific.c
@@ -19,6 +19,8 @@ const drv_vn9008_channelConfig_S drv_vn9008_channels[DRV_VN9008_CHANNEL_COUNT] =
         .fault_reset = DRV_OUTPUTAD_PUMP_FAULT,
         .enable = DRV_OUTPUTAD_PUMP_EN,
         .enable_cs = DRV_OUTPUTAD_HP_SNS_EN,
+        .current_limit_amp = 10.0f,
+        .oc_timeout_ms = 250,
     },
     [DRV_VN9008_CHANNEL_FAN] = {
         .cs_amp_per_volt = 7.518f,
@@ -26,5 +28,7 @@ const drv_vn9008_channelConfig_S drv_vn9008_channels[DRV_VN9008_CHANNEL_COUNT] =
         .fault_reset = DRV_OUTPUTAD_FAN_FAULT,
         .enable = DRV_OUTPUTAD_FAN_EN,
         .enable_cs = DRV_OUTPUTAD_HP_SNS_EN,
+        .current_limit_amp = 15.0f,
+        .oc_timeout_ms = 250,
     },
 };


### PR DESCRIPTION
add fault detection for HSD vn9008, for overcurrent and overtemperature.
also added fault handling for both, similar to the existing tps2hb16ab implementation.

1. Describe changes...
- Added current_limit_amp and oc_timeout_ms to drv_vn9008_channelConfig_S
- Added oc_timer to drv_vn9008_data for debouncing
- Implemented overcurrent detection with timer-based confirmation
- Added state machine logic to distinguish overcurrent from overtemperature (in the switch case)
- Driver now reports faults via DRV_HSD_STATE_OVERCURRENT and DRV_HSD_STATE_OVERTEMP

2. Describe impact...
- In theory, this would automatically detect and respond to overcurrent/temperature.
- (the response in question is turning off the affected channel)

3.Test Plan
- [x] Flash the vn9008 board
- [x] Stress test it and see if it'll shut off on its own
- [x] Short circuit HSD, see if it shuts off after current surpasses 15A for pump and 10A for the fan
