### PR TITLE
OTA staging, flashing, and promotion

### DIFF
--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -522,6 +522,7 @@ impl UdsClient {
 
     /// Negotiate the start of a download with the ECU
     async fn download_start(&mut self, data: UdsDownloadStart) -> Result<DownloadParams> {
+        info!("Starting UDS download...");
         let mut buf = vec![UdsCommand::RequestDownload.into()];
 
         buf.extend_from_slice(&data.to_bytes());


### PR DESCRIPTION
### Describe changes

1. Improve the ota-agent API to support individually staging binaries, flash staged and production binaries, and promote binaries from staged to production
2. Support force flashing over the agent

### Test Plan

- [x] Successfully stage binary
- [x] Successfully flash binary - ensure it is the latest binary sha
- [x] Successfully OTA binary - ensure the correct sha is staged and flashed
- [x] Ensure application is successfully ran on boot when installed onto the carcomputer
