### PR TITLE
Bringup log processor

### DIFF
--- a/drive-stack/BUCK
+++ b/drive-stack/BUCK
@@ -5,5 +5,7 @@ filegroup(
         "//drive-stack/conUDS:bin-arm64",
         "//drive-stack/net-detec:bin-arm64",
         "//drive-stack/ota-agent:bin-arm64",
+        "//drive-stack/can-bridge:bin-arm64",
+        "//tools/log-processor:bin-arm64",
     ],
 )

--- a/third_party/BUCK
+++ b/third_party/BUCK
@@ -392,6 +392,27 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "base64-0.13.1.crate",
+    sha256 = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+    strip_prefix = "base64-0.13.1",
+    urls = ["https://static.crates.io/crates/base64/0.13.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "base64-0.13.1",
+    srcs = [":base64-0.13.1.crate"],
+    crate = "base64",
+    crate_root = "base64-0.13.1.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
     name = "base64-0.21.7.crate",
     sha256 = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
     strip_prefix = "base64-0.21.7",
@@ -614,6 +635,27 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "cc-1.2.35.crate",
+    sha256 = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3",
+    strip_prefix = "cc-1.2.35",
+    urls = ["https://static.crates.io/crates/cc/1.2.35/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "cc-1.2.35",
+    srcs = [":cc-1.2.35.crate"],
+    crate = "cc",
+    crate_root = "cc-1.2.35.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":find-msvc-tools-0.1.0",
+        ":shlex-1.3.0",
+    ],
+)
+
+http_archive(
     name = "cfg-if-1.0.3.crate",
     sha256 = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9",
     strip_prefix = "cfg-if-1.0.3",
@@ -670,9 +712,15 @@ cargo.rust_library(
     features = [
         "alloc",
         "clock",
+        "default",
         "iana-time-zone",
+        "js-sys",
         "now",
+        "oldtime",
+        "serde",
         "std",
+        "wasm-bindgen",
+        "wasmbind",
         "winapi",
         "windows-link",
     ],
@@ -697,7 +745,10 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":num-traits-0.2.19"],
+    deps = [
+        ":num-traits-0.2.19",
+        ":serde-1.0.219",
+    ],
 )
 
 alias(
@@ -893,6 +944,31 @@ cargo.rust_library(
         ":libc-0.2.175",
         ":once_cell-1.21.3",
         ":unicode-width-0.2.0",
+    ],
+)
+
+http_archive(
+    name = "core-foundation-0.9.4.crate",
+    sha256 = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
+    strip_prefix = "core-foundation-0.9.4",
+    urls = ["https://static.crates.io/crates/core-foundation/0.9.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "core-foundation-0.9.4",
+    srcs = [":core-foundation-0.9.4.crate"],
+    crate = "core_foundation",
+    crate_root = "core-foundation-0.9.4.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "link",
+    ],
+    visibility = [],
+    deps = [
+        ":core-foundation-sys-0.8.7",
+        ":libc-0.2.175",
     ],
 )
 
@@ -1116,6 +1192,48 @@ cargo.rust_library(
         ":generic-array-0.14.9",
         ":typenum-1.19.0",
     ],
+)
+
+http_archive(
+    name = "csv-1.3.1.crate",
+    sha256 = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf",
+    strip_prefix = "csv-1.3.1",
+    urls = ["https://static.crates.io/crates/csv/1.3.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "csv-1.3.1",
+    srcs = [":csv-1.3.1.crate"],
+    crate = "csv",
+    crate_root = "csv-1.3.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":csv-core-0.1.13",
+        ":itoa-1.0.15",
+        ":ryu-1.0.20",
+        ":serde-1.0.219",
+    ],
+)
+
+http_archive(
+    name = "csv-core-0.1.13.crate",
+    sha256 = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782",
+    strip_prefix = "csv-core-0.1.13",
+    urls = ["https://static.crates.io/crates/csv-core/0.1.13/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "csv-core-0.1.13",
+    srcs = [":csv-core-0.1.13.crate"],
+    crate = "csv_core",
+    crate_root = "csv-core-0.1.13.crate/src/lib.rs",
+    edition = "2018",
+    features = ["default"],
+    visibility = [],
+    deps = [":memchr-2.7.5"],
 )
 
 http_archive(
@@ -1354,6 +1472,23 @@ cargo.rust_library(
         ":quote-1.0.40",
         ":syn-2.0.106",
     ],
+)
+
+http_archive(
+    name = "doc-comment-0.3.4.crate",
+    sha256 = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9",
+    strip_prefix = "doc-comment-0.3.4",
+    urls = ["https://static.crates.io/crates/doc-comment/0.3.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "doc-comment-0.3.4",
+    srcs = [":doc-comment-0.3.4.crate"],
+    crate = "doc_comment",
+    crate_root = "doc-comment-0.3.4.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
 )
 
 alias(
@@ -1618,6 +1753,27 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "fallible-iterator-0.2.0.crate",
+    sha256 = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
+    strip_prefix = "fallible-iterator-0.2.0",
+    urls = ["https://static.crates.io/crates/fallible-iterator/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "fallible-iterator-0.2.0",
+    srcs = [":fallible-iterator-0.2.0.crate"],
+    crate = "fallible_iterator",
+    crate_root = "fallible-iterator-0.2.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
     name = "fastrand-2.3.0.crate",
     sha256 = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be",
     strip_prefix = "fastrand-2.3.0",
@@ -1675,6 +1831,23 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [":cfg-if-1.0.3"],
+)
+
+http_archive(
+    name = "find-msvc-tools-0.1.0.crate",
+    sha256 = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650",
+    strip_prefix = "find-msvc-tools-0.1.0",
+    urls = ["https://static.crates.io/crates/find-msvc-tools/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "find-msvc-tools-0.1.0",
+    srcs = [":find-msvc-tools-0.1.0.crate"],
+    crate = "find_msvc_tools",
+    crate_root = "find-msvc-tools-0.1.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 alias(
@@ -2118,6 +2291,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "go-parse-duration-0.1.1.crate",
+    sha256 = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd",
+    strip_prefix = "go-parse-duration-0.1.1",
+    urls = ["https://static.crates.io/crates/go-parse-duration/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "go-parse-duration-0.1.1",
+    srcs = [":go-parse-duration-0.1.1.crate"],
+    crate = "go_parse_duration",
+    crate_root = "go-parse-duration-0.1.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "h2-0.3.27.crate",
     sha256 = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d",
     strip_prefix = "h2-0.3.27",
@@ -2485,6 +2675,7 @@ cargo.rust_library(
         "h2",
         "http1",
         "http2",
+        "runtime",
         "server",
         "socket2",
         "stream",
@@ -2545,6 +2736,31 @@ cargo.rust_library(
         ":smallvec-1.15.1",
         ":tokio-1.47.1",
         ":want-0.3.1",
+    ],
+)
+
+http_archive(
+    name = "hyper-rustls-0.24.2.crate",
+    sha256 = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590",
+    strip_prefix = "hyper-rustls-0.24.2",
+    urls = ["https://static.crates.io/crates/hyper-rustls/0.24.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-rustls-0.24.2",
+    srcs = [":hyper-rustls-0.24.2.crate"],
+    crate = "hyper_rustls",
+    crate_root = "hyper-rustls-0.24.2.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":futures-util-0.3.31",
+        ":http-0.2.12",
+        ":hyper-0.14.32",
+        ":rustls-0.21.12",
+        ":tokio-1.47.1",
+        ":tokio-rustls-0.24.1",
     ],
 )
 
@@ -2972,6 +3188,96 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "influxdb2",
+    actual = ":influxdb2-0.5.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "influxdb2-0.5.2.crate",
+    sha256 = "24cc9f9d9fee9ebda1a77b61769cde513e03ad09607b347602f4ea887657689e",
+    strip_prefix = "influxdb2-0.5.2",
+    urls = ["https://static.crates.io/crates/influxdb2/0.5.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "influxdb2-0.5.2",
+    srcs = [":influxdb2-0.5.2.crate"],
+    crate = "influxdb2",
+    crate_root = "influxdb2-0.5.2.crate/src/lib.rs",
+    edition = "2018",
+    features = ["rustls"],
+    visibility = [],
+    deps = [
+        ":base64-0.13.1",
+        ":bytes-1.10.1",
+        ":chrono-0.4.42",
+        ":csv-1.3.1",
+        ":fallible-iterator-0.2.0",
+        ":futures-0.3.31",
+        ":go-parse-duration-0.1.1",
+        ":influxdb2-derive-0.1.1",
+        ":influxdb2-structmap-0.2.0",
+        ":ordered-float-3.9.2",
+        ":parking_lot-0.11.2",
+        ":reqwest-0.11.27",
+        ":secrecy-0.8.0",
+        ":serde-1.0.219",
+        ":serde_json-1.0.143",
+        ":snafu-0.6.10",
+        ":url-2.5.7",
+    ],
+)
+
+http_archive(
+    name = "influxdb2-derive-0.1.1.crate",
+    sha256 = "990f899841aa30130fc06f7938e3cc2cbc3d5b92c03fd4b5d79a965045abcf16",
+    strip_prefix = "influxdb2-derive-0.1.1",
+    urls = ["https://static.crates.io/crates/influxdb2-derive/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "influxdb2-derive-0.1.1",
+    srcs = [":influxdb2-derive-0.1.1.crate"],
+    crate = "influxdb2_derive",
+    crate_root = "influxdb2-derive-0.1.1.crate/src/lib.rs",
+    edition = "2018",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":itertools-0.10.5",
+        ":proc-macro2-1.0.101",
+        ":quote-1.0.40",
+        ":regex-1.11.2",
+        ":syn-1.0.109",
+    ],
+)
+
+http_archive(
+    name = "influxdb2-structmap-0.2.0.crate",
+    sha256 = "1408e712051787357e99ff732e44e8833e79cea0fabc9361018abfbff72b6265",
+    strip_prefix = "influxdb2-structmap-0.2.0",
+    urls = ["https://static.crates.io/crates/influxdb2-structmap/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "influxdb2-structmap-0.2.0",
+    srcs = [":influxdb2-structmap-0.2.0.crate"],
+    crate = "influxdb2_structmap",
+    crate_root = "influxdb2-structmap-0.2.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":chrono-0.4.42",
+        ":num-traits-0.2.19",
+        ":ordered-float-3.9.2",
+    ],
+)
+
 http_archive(
     name = "instability-0.3.9.crate",
     sha256 = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a",
@@ -2995,6 +3301,24 @@ cargo.rust_library(
         ":quote-1.0.40",
         ":syn-2.0.106",
     ],
+)
+
+http_archive(
+    name = "instant-0.1.13.crate",
+    sha256 = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222",
+    strip_prefix = "instant-0.1.13",
+    urls = ["https://static.crates.io/crates/instant/0.1.13/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "instant-0.1.13",
+    srcs = [":instant-0.1.13.crate"],
+    crate = "instant",
+    crate_root = "instant-0.1.13.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":cfg-if-1.0.3"],
 )
 
 http_archive(
@@ -3056,6 +3380,29 @@ cargo.rust_library(
     edition = "2021",
     features = ["default"],
     visibility = [],
+)
+
+http_archive(
+    name = "itertools-0.10.5.crate",
+    sha256 = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+    strip_prefix = "itertools-0.10.5",
+    urls = ["https://static.crates.io/crates/itertools/0.10.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "itertools-0.10.5",
+    srcs = [":itertools-0.10.5.crate"],
+    crate = "itertools",
+    crate_root = "itertools-0.10.5.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "use_alloc",
+        "use_std",
+    ],
+    visibility = [],
+    deps = [":either-1.15.0"],
 )
 
 http_archive(
@@ -4103,6 +4450,10 @@ cargo.rust_library(
     crate = "num_traits",
     crate_root = "num-traits-0.2.19.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
 )
 
@@ -4211,6 +4562,51 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "ordered-float-3.9.2.crate",
+    sha256 = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc",
+    strip_prefix = "ordered-float-3.9.2",
+    urls = ["https://static.crates.io/crates/ordered-float/3.9.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ordered-float-3.9.2",
+    srcs = [":ordered-float-3.9.2.crate"],
+    crate = "ordered_float",
+    crate_root = "ordered-float-3.9.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":num-traits-0.2.19"],
+)
+
+http_archive(
+    name = "parking_lot-0.11.2.crate",
+    sha256 = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99",
+    strip_prefix = "parking_lot-0.11.2",
+    urls = ["https://static.crates.io/crates/parking_lot/0.11.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "parking_lot-0.11.2",
+    srcs = [":parking_lot-0.11.2.crate"],
+    crate = "parking_lot",
+    crate_root = "parking_lot-0.11.2.crate/src/lib.rs",
+    edition = "2018",
+    features = ["default"],
+    visibility = [],
+    deps = [
+        ":instant-0.1.13",
+        ":lock_api-0.4.13",
+        ":parking_lot_core-0.8.6",
+    ],
+)
+
+http_archive(
     name = "parking_lot-0.12.4.crate",
     sha256 = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13",
     strip_prefix = "parking_lot-0.12.4",
@@ -4229,6 +4625,48 @@ cargo.rust_library(
     deps = [
         ":lock_api-0.4.13",
         ":parking_lot_core-0.9.11",
+    ],
+)
+
+http_archive(
+    name = "parking_lot_core-0.8.6.crate",
+    sha256 = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc",
+    strip_prefix = "parking_lot_core-0.8.6",
+    urls = ["https://static.crates.io/crates/parking_lot_core/0.8.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "parking_lot_core-0.8.6",
+    srcs = [":parking_lot_core-0.8.6.crate"],
+    crate = "parking_lot_core",
+    crate_root = "parking_lot_core-0.8.6.crate/src/lib.rs",
+    edition = "2018",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+        "windows-gnu": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+        "windows-msvc": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":cfg-if-1.0.3",
+        ":instant-0.1.13",
+        ":smallvec-1.15.1",
     ],
 )
 
@@ -4790,6 +5228,82 @@ cargo.rust_library(
     visibility = [],
 )
 
+http_archive(
+    name = "reqwest-0.11.27.crate",
+    sha256 = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62",
+    strip_prefix = "reqwest-0.11.27",
+    urls = ["https://static.crates.io/crates/reqwest/0.11.27/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "reqwest-0.11.27",
+    srcs = [":reqwest-0.11.27.crate"],
+    crate = "reqwest",
+    crate_root = "reqwest-0.11.27.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "__rustls",
+        "__tls",
+        "hyper-rustls",
+        "json",
+        "rustls",
+        "rustls-tls",
+        "rustls-tls-webpki-roots",
+        "serde_json",
+        "stream",
+        "tokio-rustls",
+        "tokio-util",
+        "wasm-streams",
+        "webpki-roots",
+    ],
+    platform = {
+        "macos-arm64": dict(
+            deps = [":system-configuration-0.5.1"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":system-configuration-0.5.1"],
+        ),
+        "windows-gnu": dict(
+            deps = [":winreg-0.50.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":winreg-0.50.0"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":base64-0.21.7",
+        ":bytes-1.10.1",
+        ":encoding_rs-0.8.35",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
+        ":h2-0.3.27",
+        ":http-0.2.12",
+        ":http-body-0.4.6",
+        ":hyper-0.14.32",
+        ":hyper-rustls-0.24.2",
+        ":ipnet-2.11.0",
+        ":log-0.4.28",
+        ":mime-0.3.17",
+        ":once_cell-1.21.3",
+        ":percent-encoding-2.3.2",
+        ":pin-project-lite-0.2.16",
+        ":rustls-0.21.12",
+        ":rustls-pemfile-1.0.4",
+        ":serde-1.0.219",
+        ":serde_json-1.0.143",
+        ":serde_urlencoded-0.7.1",
+        ":sync_wrapper-0.1.2",
+        ":tokio-1.47.1",
+        ":tokio-rustls-0.24.1",
+        ":tokio-util-0.7.16",
+        ":tower-service-0.3.3",
+        ":url-2.5.7",
+        ":webpki-roots-0.25.4",
+    ],
+)
+
 alias(
     name = "reqwest",
     actual = ":reqwest-0.12.24",
@@ -4835,6 +5349,87 @@ cargo.rust_library(
         ":tower-service-0.3.3",
         ":url-2.5.7",
     ],
+)
+
+http_archive(
+    name = "ring-0.17.14.crate",
+    sha256 = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
+    strip_prefix = "ring-0.17.14",
+    urls = ["https://static.crates.io/crates/ring/0.17.14/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ring-0.17.14",
+    srcs = [":ring-0.17.14.crate"],
+    crate = "ring",
+    crate_root = "ring-0.17.14.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "OUT_DIR": "$(location :ring-0.17.14-build-script-run[out_dir])",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "17",
+        "CARGO_PKG_VERSION_PATCH": "14",
+        "CARGO_PKG_VERSION_PRE": "0",
+        "CARGO_MANIFEST_LINKS": "ring_core_0_17_14_0",
+        "OPT_LEVEL": "2",
+        "CARGO_PKG_NAME": "ring",
+    },
+    features = [
+        "alloc",
+        "default",
+        "dev_urandom_fallback",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.175"],
+        ),
+    },
+    rustc_flags = ["@$(location :ring-0.17.14-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [
+        ":cfg-if-1.0.3",
+        ":getrandom-0.2.16",
+        ":untrusted-0.9.0",
+    ],
+)
+
+cargo.rust_binary(
+    name = "ring-0.17.14-build-script-build",
+    srcs = [":ring-0.17.14.crate"],
+    crate = "build_script_build",
+    crate_root = "ring-0.17.14.crate/build.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "dev_urandom_fallback",
+    ],
+    visibility = [],
+    deps = [":cc-1.2.35"],
+)
+
+buildscript_run(
+    name = "ring-0.17.14-build-script-run",
+    package_name = "ring",
+    buildscript_rule = ":ring-0.17.14-build-script-build",
+    features = [
+        "alloc",
+        "default",
+        "dev_urandom_fallback",
+    ],
+    env = {
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "17",
+        "CARGO_PKG_VERSION_PATCH": "14",
+        "CARGO_PKG_VERSION_PRE": "0",
+        "CARGO_MANIFEST_LINKS": "ring_core_0_17_14_0",
+        "OPT_LEVEL": "2",
+    },
+    version = "0.17.14",
 )
 
 http_archive(
@@ -5007,6 +5602,80 @@ buildscript_run(
 )
 
 http_archive(
+    name = "rustls-0.21.12.crate",
+    sha256 = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e",
+    strip_prefix = "rustls-0.21.12",
+    urls = ["https://static.crates.io/crates/rustls/0.21.12/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustls-0.21.12",
+    srcs = [":rustls-0.21.12.crate"],
+    crate = "rustls",
+    crate_root = "rustls-0.21.12.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "dangerous_configuration",
+        "default",
+        "log",
+        "logging",
+        "tls12",
+    ],
+    visibility = [],
+    deps = [
+        ":log-0.4.28",
+        ":ring-0.17.14",
+        ":rustls-webpki-0.101.7",
+        ":sct-0.7.1",
+    ],
+)
+
+http_archive(
+    name = "rustls-pemfile-1.0.4.crate",
+    sha256 = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c",
+    strip_prefix = "rustls-pemfile-1.0.4",
+    urls = ["https://static.crates.io/crates/rustls-pemfile/1.0.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustls-pemfile-1.0.4",
+    srcs = [":rustls-pemfile-1.0.4.crate"],
+    crate = "rustls_pemfile",
+    crate_root = "rustls-pemfile-1.0.4.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":base64-0.21.7"],
+)
+
+http_archive(
+    name = "rustls-webpki-0.101.7.crate",
+    sha256 = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
+    strip_prefix = "rustls-webpki-0.101.7",
+    urls = ["https://static.crates.io/crates/rustls-webpki/0.101.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustls-webpki-0.101.7",
+    srcs = [":rustls-webpki-0.101.7.crate"],
+    crate = "webpki",
+    crate_root = "rustls-webpki-0.101.7.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":ring-0.17.14",
+        ":untrusted-0.9.0",
+    ],
+)
+
+http_archive(
     name = "rustversion-1.0.22.crate",
     sha256 = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d",
     strip_prefix = "rustversion-1.0.22",
@@ -5093,6 +5762,49 @@ cargo.rust_library(
     crate_root = "scopeguard-1.2.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+http_archive(
+    name = "sct-0.7.1.crate",
+    sha256 = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
+    strip_prefix = "sct-0.7.1",
+    urls = ["https://static.crates.io/crates/sct/0.7.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sct-0.7.1",
+    srcs = [":sct-0.7.1.crate"],
+    crate = "sct",
+    crate_root = "sct-0.7.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":ring-0.17.14",
+        ":untrusted-0.9.0",
+    ],
+)
+
+http_archive(
+    name = "secrecy-0.8.0.crate",
+    sha256 = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e",
+    strip_prefix = "secrecy-0.8.0",
+    urls = ["https://static.crates.io/crates/secrecy/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "secrecy-0.8.0",
+    srcs = [":secrecy-0.8.0.crate"],
+    crate = "secrecy",
+    crate_root = "secrecy-0.8.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "alloc",
+        "default",
+    ],
+    visibility = [],
+    deps = [":zeroize-1.8.2"],
 )
 
 alias(
@@ -5447,6 +6159,27 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "shlex-1.3.0.crate",
+    sha256 = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+    strip_prefix = "shlex-1.3.0",
+    urls = ["https://static.crates.io/crates/shlex/1.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "shlex-1.3.0",
+    srcs = [":shlex-1.3.0.crate"],
+    crate = "shlex",
+    crate_root = "shlex-1.3.0.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
     name = "signal-hook-0.3.18.crate",
     sha256 = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2",
     strip_prefix = "signal-hook-0.3.18",
@@ -5608,6 +6341,55 @@ cargo.rust_library(
         "const_new",
     ],
     visibility = [],
+)
+
+http_archive(
+    name = "snafu-0.6.10.crate",
+    sha256 = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7",
+    strip_prefix = "snafu-0.6.10",
+    urls = ["https://static.crates.io/crates/snafu/0.6.10/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "snafu-0.6.10",
+    srcs = [":snafu-0.6.10.crate"],
+    crate = "snafu",
+    crate_root = "snafu-0.6.10.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "guide",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":doc-comment-0.3.4",
+        ":snafu-derive-0.6.10",
+    ],
+)
+
+http_archive(
+    name = "snafu-derive-0.6.10.crate",
+    sha256 = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b",
+    strip_prefix = "snafu-derive-0.6.10",
+    urls = ["https://static.crates.io/crates/snafu-derive/0.6.10/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "snafu-derive-0.6.10",
+    srcs = [":snafu-derive-0.6.10.crate"],
+    crate = "snafu_derive",
+    crate_root = "snafu-derive-0.6.10.crate/src/lib.rs",
+    edition = "2018",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.101",
+        ":quote-1.0.40",
+        ":syn-1.0.109",
+    ],
 )
 
 http_archive(
@@ -6031,19 +6813,12 @@ cargo.rust_library(
         "default",
         "derive",
         "extra-traits",
+        "full",
         "parsing",
         "printing",
         "proc-macro",
         "quote",
     ],
-    platform = {
-        "linux-arm64": dict(
-            features = ["full"],
-        ),
-        "linux-x86_64": dict(
-            features = ["full"],
-        ),
-    },
     rustc_flags = ["@$(location :syn-1.0.109-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
@@ -6064,19 +6839,12 @@ cargo.rust_binary(
         "default",
         "derive",
         "extra-traits",
+        "full",
         "parsing",
         "printing",
         "proc-macro",
         "quote",
     ],
-    platform = {
-        "linux-arm64": dict(
-            features = ["full"],
-        ),
-        "linux-x86_64": dict(
-            features = ["full"],
-        ),
-    },
     visibility = [],
 )
 
@@ -6089,19 +6857,12 @@ buildscript_run(
         "default",
         "derive",
         "extra-traits",
+        "full",
         "parsing",
         "printing",
         "proc-macro",
         "quote",
     ],
-    platform = {
-        "linux-arm64": dict(
-            features = ["full"],
-        ),
-        "linux-x86_64": dict(
-            features = ["full"],
-        ),
-    },
     version = "1.0.109",
 )
 
@@ -6138,6 +6899,23 @@ cargo.rust_library(
         ":quote-1.0.40",
         ":unicode-ident-1.0.18",
     ],
+)
+
+http_archive(
+    name = "sync_wrapper-0.1.2.crate",
+    sha256 = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
+    strip_prefix = "sync_wrapper-0.1.2",
+    urls = ["https://static.crates.io/crates/sync_wrapper/0.1.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sync_wrapper-0.1.2",
+    srcs = [":sync_wrapper-0.1.2.crate"],
+    crate = "sync_wrapper",
+    crate_root = "sync_wrapper-0.1.2.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 http_archive(
@@ -6185,6 +6963,49 @@ cargo.rust_library(
         ":proc-macro2-1.0.101",
         ":quote-1.0.40",
         ":syn-2.0.106",
+    ],
+)
+
+http_archive(
+    name = "system-configuration-0.5.1.crate",
+    sha256 = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7",
+    strip_prefix = "system-configuration-0.5.1",
+    urls = ["https://static.crates.io/crates/system-configuration/0.5.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "system-configuration-0.5.1",
+    srcs = [":system-configuration-0.5.1.crate"],
+    crate = "system_configuration",
+    crate_root = "system-configuration-0.5.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":bitflags-1.3.2",
+        ":core-foundation-0.9.4",
+        ":system-configuration-sys-0.5.0",
+    ],
+)
+
+http_archive(
+    name = "system-configuration-sys-0.5.0.crate",
+    sha256 = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9",
+    strip_prefix = "system-configuration-sys-0.5.0",
+    urls = ["https://static.crates.io/crates/system-configuration-sys/0.5.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "system-configuration-sys-0.5.0",
+    srcs = [":system-configuration-sys-0.5.0.crate"],
+    crate = "system_configuration_sys",
+    crate_root = "system-configuration-sys-0.5.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":core-foundation-sys-0.8.7",
+        ":libc-0.2.175",
     ],
 )
 
@@ -6655,6 +7476,32 @@ cargo.rust_library(
         ":proc-macro2-1.0.101",
         ":quote-1.0.40",
         ":syn-2.0.106",
+    ],
+)
+
+http_archive(
+    name = "tokio-rustls-0.24.1.crate",
+    sha256 = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081",
+    strip_prefix = "tokio-rustls-0.24.1",
+    urls = ["https://static.crates.io/crates/tokio-rustls/0.24.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tokio-rustls-0.24.1",
+    srcs = [":tokio-rustls-0.24.1.crate"],
+    crate = "tokio_rustls",
+    crate_root = "tokio-rustls-0.24.1.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "logging",
+        "tls12",
+    ],
+    visibility = [],
+    deps = [
+        ":rustls-0.21.12",
+        ":tokio-1.47.1",
     ],
 )
 
@@ -7191,6 +8038,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "untrusted-0.9.0.crate",
+    sha256 = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+    strip_prefix = "untrusted-0.9.0",
+    urls = ["https://static.crates.io/crates/untrusted/0.9.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "untrusted-0.9.0",
+    srcs = [":untrusted-0.9.0.crate"],
+    crate = "untrusted",
+    crate_root = "untrusted-0.9.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "url-2.5.7.crate",
     sha256 = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b",
     strip_prefix = "url-2.5.7",
@@ -7342,6 +8206,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "webpki-roots-0.25.4.crate",
+    sha256 = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1",
+    strip_prefix = "webpki-roots-0.25.4",
+    urls = ["https://static.crates.io/crates/webpki-roots/0.25.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "webpki-roots-0.25.4",
+    srcs = [":webpki-roots-0.25.4.crate"],
+    crate = "webpki_roots",
+    crate_root = "webpki-roots-0.25.4.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "winapi-0.3.9.crate",
     sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
     strip_prefix = "winapi-0.3.9",
@@ -7369,6 +8250,7 @@ cargo.rust_library(
         "minwinbase",
         "minwindef",
         "ntdef",
+        "ntstatus",
         "processenv",
         "setupapi",
         "synchapi",
@@ -7438,6 +8320,37 @@ cargo.rust_library(
     crate_root = "windows-link-0.2.1.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
+)
+
+http_archive(
+    name = "windows-sys-0.48.0.crate",
+    sha256 = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+    strip_prefix = "windows-sys-0.48.0",
+    urls = ["https://static.crates.io/crates/windows-sys/0.48.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-sys-0.48.0",
+    srcs = [":windows-sys-0.48.0.crate"],
+    crate = "windows_sys",
+    crate_root = "windows-sys-0.48.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "Win32",
+        "Win32_Foundation",
+        "Win32_Security",
+        "Win32_Storage",
+        "Win32_Storage_FileSystem",
+        "Win32_System",
+        "Win32_System_Diagnostics",
+        "Win32_System_Diagnostics_Debug",
+        "Win32_System_Registry",
+        "Win32_System_Time",
+        "default",
+    ],
+    visibility = [],
+    deps = [":windows-targets-0.48.5"],
 )
 
 http_archive(
@@ -7550,6 +8463,31 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows-targets-0.48.5.crate",
+    sha256 = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c",
+    strip_prefix = "windows-targets-0.48.5",
+    urls = ["https://static.crates.io/crates/windows-targets/0.48.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-targets-0.48.5",
+    srcs = [":windows-targets-0.48.5.crate"],
+    crate = "windows_targets",
+    crate_root = "windows-targets-0.48.5.crate/src/lib.rs",
+    edition = "2018",
+    platform = {
+        "windows-gnu": dict(
+            deps = [":windows_x86_64_gnu-0.48.5"],
+        ),
+        "windows-msvc": dict(
+            deps = [":windows_x86_64_msvc-0.48.5"],
+        ),
+    },
+    visibility = [],
+)
+
+http_archive(
     name = "windows-targets-0.52.6.crate",
     sha256 = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
     strip_prefix = "windows-targets-0.52.6",
@@ -7600,6 +8538,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows_x86_64_gnu-0.48.5.crate",
+    sha256 = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
+    strip_prefix = "windows_x86_64_gnu-0.48.5",
+    urls = ["https://static.crates.io/crates/windows_x86_64_gnu/0.48.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows_x86_64_gnu-0.48.5",
+    srcs = [":windows_x86_64_gnu-0.48.5.crate"],
+    crate = "windows_x86_64_gnu",
+    crate_root = "windows_x86_64_gnu-0.48.5.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "windows_x86_64_gnu-0.52.6.crate",
     sha256 = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
     strip_prefix = "windows_x86_64_gnu-0.52.6",
@@ -7630,6 +8585,23 @@ cargo.rust_library(
     crate = "windows_x86_64_gnu",
     crate_root = "windows_x86_64_gnu-0.53.0.crate/src/lib.rs",
     edition = "2021",
+    visibility = [],
+)
+
+http_archive(
+    name = "windows_x86_64_msvc-0.48.5.crate",
+    sha256 = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
+    strip_prefix = "windows_x86_64_msvc-0.48.5",
+    urls = ["https://static.crates.io/crates/windows_x86_64_msvc/0.48.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows_x86_64_msvc-0.48.5",
+    srcs = [":windows_x86_64_msvc-0.48.5.crate"],
+    crate = "windows_x86_64_msvc",
+    crate_root = "windows_x86_64_msvc-0.48.5.crate/src/lib.rs",
+    edition = "2018",
     visibility = [],
 )
 
@@ -7683,6 +8655,27 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [":winapi-0.3.9"],
+)
+
+http_archive(
+    name = "winreg-0.50.0.crate",
+    sha256 = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1",
+    strip_prefix = "winreg-0.50.0",
+    urls = ["https://static.crates.io/crates/winreg/0.50.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "winreg-0.50.0",
+    srcs = [":winreg-0.50.0.crate"],
+    crate = "winreg",
+    crate_root = "winreg-0.50.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":cfg-if-1.0.3",
+        ":windows-sys-0.48.0",
+    ],
 )
 
 http_archive(
@@ -7840,6 +8833,24 @@ cargo.rust_library(
         ":syn-2.0.106",
         ":synstructure-0.13.2",
     ],
+)
+
+http_archive(
+    name = "zeroize-1.8.2.crate",
+    sha256 = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0",
+    strip_prefix = "zeroize-1.8.2",
+    urls = ["https://static.crates.io/crates/zeroize/1.8.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "zeroize-1.8.2",
+    srcs = [":zeroize-1.8.2.crate"],
+    crate = "zeroize",
+    crate_root = "zeroize-1.8.2.crate/src/lib.rs",
+    edition = "2021",
+    features = ["alloc"],
+    visibility = [],
 )
 
 http_archive(

--- a/third_party/Cargo.lock
+++ b/third_party/Cargo.lock
@@ -169,6 +169,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -272,7 +278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -350,6 +359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +416,7 @@ dependencies = [
  "bitflags 2.9.4",
  "crossterm_winapi",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.4",
  "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
@@ -421,6 +440,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -527,6 +567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
 name = "ecu_diagnostics"
 version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +591,7 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "thiserror 2.0.16",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -616,6 +662,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -806,6 +858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "go-parse-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1051,20 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1196,6 +1268,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "influxdb2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc9f9d9fee9ebda1a77b61769cde513e03ad09607b347602f4ea887657689e"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "chrono",
+ "csv",
+ "fallible-iterator",
+ "futures",
+ "go-parse-duration",
+ "influxdb2-derive",
+ "influxdb2-structmap",
+ "ordered-float",
+ "parking_lot 0.11.2",
+ "reqwest 0.11.27",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "snafu",
+ "url",
+]
+
+[[package]]
+name = "influxdb2-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990f899841aa30130fc06f7938e3cc2cbc3d5b92c03fd4b5d79a965045abcf16"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "influxdb2-structmap"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1408e712051787357e99ff732e44e8833e79cea0fabc9361018abfbff72b6265"
+dependencies = [
+ "chrono",
+ "num-traits",
+ "ordered-float",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1327,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1240,6 +1370,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1329,7 +1468,7 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
@@ -1647,13 +1786,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1664,7 +1837,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1812,13 +1985,22 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1872,6 +2054,49 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
@@ -1893,7 +2118,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-http",
@@ -1902,6 +2127,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1931,11 +2170,12 @@ dependencies = [
  "hostname",
  "if-addrs",
  "indicatif",
+ "influxdb2",
  "libc",
  "log",
  "mdns-sd",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1984,6 +2224,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2277,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -2183,6 +2473,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "socket-pktinfo"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,7 +2533,7 @@ dependencies = [
  "bitflags 2.9.4",
  "embedded-can",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "log",
  "nb",
@@ -2339,6 +2650,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2355,6 +2672,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2479,7 +2817,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -2497,6 +2835,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2533,7 +2881,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2686,7 +3034,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -2708,6 +3056,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2867,6 +3221,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +3252,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -2984,6 +3357,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3007,6 +3389,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3044,6 +3441,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3056,6 +3459,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3065,6 +3474,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3092,6 +3507,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3101,6 +3522,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3116,6 +3543,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3125,6 +3558,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3145,6 +3584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3227,6 +3676,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/third_party/Cargo.toml
+++ b/third_party/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 hostname = "0.3"
 if-addrs = "0.14"
 indicatif = "0.17.8"
+influxdb2 = { version = "0.5.2", default-features = false, features = ["rustls"] }
 log = { version = "0.4.21", features = ["std"] }
 libc = "0.2.175"
 mdns-sd = "0.15.1"

--- a/third_party/fixups/openssl-sys/fixups.toml
+++ b/third_party/fixups/openssl-sys/fixups.toml
@@ -1,0 +1,1 @@
+buildscript.run = true

--- a/third_party/fixups/ring/fixups.toml
+++ b/third_party/fixups/ring/fixups.toml
@@ -1,0 +1,1 @@
+buildscript.run = true

--- a/tools/log-processor/BUCK
+++ b/tools/log-processor/BUCK
@@ -1,0 +1,50 @@
+rust_library(
+    name = "lib",
+    crate = "log_processor",
+    srcs = glob(["src/**/*.rs"], exclude=["main.rs"]),
+    edition = "2024",
+    deps = [
+        "//third_party:anyhow",
+        "//third_party:clap",
+        "//third_party:flate2",
+        "//third_party:futures",
+        "//third_party:indicatif",
+        "//third_party:serde",
+        "//third_party:serde_json",
+        "//third_party:reqwest",
+        "//third_party:tar",
+        "//third_party:tokio",
+    ],
+    target_compatible_with = [
+        "prelude//os/constraints:linux",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rust_binary(
+    name = "log-processor",
+    srcs = ["src/main.rs"],
+    edition = "2024",
+    deps = [
+        ":lib",
+        "//drive-stack/net-detec:lib",
+        "//third_party:anyhow",
+        "//third_party:clap",
+        "//third_party:indicatif",
+        "//third_party:flate2",
+        "//third_party:futures",
+        "//third_party:reqwest",
+        "//third_party:serde",
+        "//third_party:serde_json",
+        "//third_party:tar",
+        "//third_party:tokio",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+configured_alias(
+    name = "bin-arm64",
+    actual = ":log-processor",
+    platform = "//buck2/platforms:arm64-linux",
+    visibility = ["PUBLIC"],
+)

--- a/tools/log-processor/Cargo.toml
+++ b/tools/log-processor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "log-processor"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+indicatif = "0.17"
+flate2 = "1"
+futures = "0.3"
+reqwest = { version = "0.11", default-features = false, features = ["json", "http1", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tar = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/tools/log-processor/log-processor.service
+++ b/tools/log-processor/log-processor.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Log processor
+After=network.target
+
+[Service]
+ExecStart=/bin/cfr/log_processor /application/logs/* --url http://baseputer:8086 --token I6-01gwJym0GAAKd2A2ZJzCHuV_8swths_kksr4ocCyfAGsy99qGfBkDCJNyuXBLGQln7gnhNh3mcWZUr0gcNw== --org FormulaTeam --bucket CarTelemetry --delete
+Restart=always
+RestartSec=600s
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/log-processor/src/lib.rs
+++ b/tools/log-processor/src/lib.rs
@@ -1,0 +1,437 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::fs::remove_file;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{anyhow, Context, Result};
+use flate2::read::GzDecoder;
+use reqwest;
+use reqwest::Url;
+use serde::Deserialize;
+use serde_json;
+use serde_json::Value;
+use tar::Archive;
+use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
+
+/// Ingest one `.tar.gz` (JSON-lines files inside), writing to InfluxDB via HTTP
+const INFLIGHT_HTTP: usize = 6;
+const PARSE_WORKERS: usize = 2;
+
+#[derive(Debug, Deserialize)]
+pub struct Bus {
+    pub iface: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Id {
+    pub err: Option<bool>,
+    pub ext: Option<bool>,
+    pub rtr: Option<bool>,
+    pub val: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Record {
+    pub bus: Option<Bus>,
+    pub data: Option<Vec<String>>,
+    pub dlc: Option<u8>,
+    pub id: Option<Id>,
+    pub meas: Option<BTreeMap<String, Value>>,
+    pub msg: Option<String>,
+    /// epoch seconds (float)
+    pub time: Option<f64>,
+}
+
+fn parse_line(line: &[u8]) -> Result<Option<Record>> {
+    // skip blank/whitespace-only lines without allocating
+    if line.iter().all(|b| b.is_ascii_whitespace()) {
+        return Ok(None);
+    }
+    let rec: Record = serde_json::from_slice(line)
+        .with_context(|| format!("invalid JSON: {}", String::from_utf8_lossy(line)))?;
+    Ok(Some(rec))
+}
+
+fn as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        Value::Object(m) => m.get("value").and_then(|x| x.as_f64()),
+        Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+// ----- Influx Line Protocol helpers -----
+
+fn escape_measurement(s: &str) -> String {
+    s.replace(',', r"\,").replace(' ', r"\ ")
+}
+
+fn escape_tag_key_val(s: &str) -> String {
+    s.replace(',', r"\,").replace(' ', r"\ ").replace('=', r"\=")
+}
+
+fn escape_field_key(s: &str) -> String {
+    s.replace(',', r"\,").replace(' ', r"\ ")
+}
+
+fn escape_field_string(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', r#"\""#)
+}
+
+fn to_line_protocol(
+    measurement: &str,
+    tags: &BTreeMap<String, String>,
+    fields: &BTreeMap<String, Value>,
+    ts_ns: Option<i64>,
+) -> Option<String> {
+    if fields.is_empty() {
+        return None;
+    }
+
+    // measurement and tags
+    let mut line = escape_measurement(measurement);
+    for (k, v) in tags {
+        let k = escape_tag_key_val(k);
+        let v = escape_tag_key_val(v);
+        line.push(',');
+        line.push_str(&k);
+        line.push('=');
+        line.push_str(&v);
+    }
+
+    // fields
+    line.push(' ');
+    let mut first = true;
+    for (k, v) in fields {
+        if !first { line.push(','); }
+        first = false;
+
+        let key = escape_field_key(k);
+        // numeric/bool -> numeric/bool; strings quoted
+        match v {
+            Value::Number(n) => {
+                // Prefer integer if possible, else float
+                if let Some(i) = n.as_i64() {
+                    line.push_str(&format!("{key}={}", i));
+                } else if let Some(f) = n.as_f64() {
+                    // Influx float requires decimal + trailing '0' is fine; appending 'i' is ONLY for integers
+                    line.push_str(&format!("{key}={}", f));
+                } else {
+                    // fallback as string
+                    line.push_str(&format!("{key}=\"{}\"", escape_field_string(&n.to_string())));
+                }
+            }
+            Value::Bool(b) => {
+                line.push_str(&format!("{key}={}", if *b { "true" } else { "false" }));
+            }
+            Value::String(s) => {
+                line.push_str(&format!("{key}=\"{}\"", escape_field_string(s)));
+            }
+            Value::Object(obj) => {
+                if let Some(v) = obj.get("value").and_then(|x| x.as_f64()) {
+                    line.push_str(&format!("{key}={}", v));
+                } else {
+                    let s = serde_json::to_string(obj).unwrap_or_else(|_| "{}".to_string());
+                    line.push_str(&format!("{key}=\"{}\"", escape_field_string(&s)));
+                }
+            }
+            other => {
+                line.push_str(&format!("{key}=\"{}\"", escape_field_string(&other.to_string())));
+            }
+        }
+    }
+
+    // timestamp
+    if let Some(ns) = ts_ns {
+        line.push(' ');
+        line.push_str(&ns.to_string());
+    }
+
+    Some(line)
+}
+
+// Build tags/fields from a Record
+fn record_to_line(rec: &Record) -> Option<String> {
+    let measurement = rec.msg.as_deref().unwrap_or("veh_msg");
+
+    let mut tags = BTreeMap::<String, String>::new();
+    if let Some(bus) = &rec.bus {
+        if let Some(iface) = &bus.iface { tags.insert("iface".into(), iface.clone()); }
+        if let Some(name)  = &bus.name  { tags.insert("bus_name".into(), name.clone()); }
+    }
+    if let Some(id) = &rec.id {
+        if let Some(v) = id.val { tags.insert("can_id".into(), v.to_string()); }
+        if let Some(b) = id.err { tags.insert("id_err".into(), if b { "1" } else { "0" }.into()); }
+        if let Some(b) = id.ext { tags.insert("id_ext".into(), if b { "1" } else { "0" }.into()); }
+        if let Some(b) = id.rtr { tags.insert("id_rtr".into(), if b { "1" } else { "0" }.into()); }
+    }
+
+    let mut fields = BTreeMap::<String, Value>::new();
+    if let Some(dlc) = rec.dlc {
+        fields.insert("dlc".into(), Value::Number((dlc as i64).into()));
+    }
+    if let Some(meas) = &rec.meas {
+        for (k, v) in meas {
+            if let Some(f) = as_f64(v) {
+                fields.insert(k.clone(), Value::Number(serde_json::Number::from_f64(f).unwrap()));
+            } else if let Some(s) = v.as_str() {
+                fields.insert(k.clone(), Value::String(s.to_string()));
+            } else {
+                // keep as-is (object/bool/etc.) and let to_line_protocol handle
+                fields.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    let ts_ns = rec.time.map(|ts| (ts * 1_000_000_000.0).round() as i64);
+    to_line_protocol(measurement, &tags, &fields, ts_ns)
+}
+
+// ----- HTTP write -----
+async fn write_batch_http(
+    client: &reqwest::Client,
+    base_url: &str,
+    org: &str,
+    bucket: &str,
+    token: &str,
+    lines: &[String],
+) -> Result<()> {
+    if lines.is_empty() {
+        return Ok(());
+    }
+
+    // Ensure using http:// (no TLS)
+    if base_url.starts_with("https://") {
+        return Err(anyhow!(
+            "This build is HTTP-only; use an http:// URL or add a TLS backend."
+        ));
+    }
+
+    // Build the /api/v2/write URL safely with reqwest::Url
+    let mut url = Url::parse(base_url.trim_end_matches('/'))
+        .with_context(|| format!("invalid base URL: {base_url}"))?;
+    url.set_path("api/v2/write");
+
+    url.query_pairs_mut()
+        .append_pair("org", org)
+        .append_pair("bucket", bucket)
+        .append_pair("precision", "ns");
+
+    let body = lines.join("\n");
+    let resp = client
+        .post(url.clone())
+        .header("Authorization", format!("Token {}", token))
+        .header("Content-Type", "text/plain; charset=utf-8")
+        .body(body)
+        .send()
+        .await
+        .with_context(|| format!("POST {}", url))?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(anyhow!("influx write failed: {} | {}", status, text));
+    }
+
+    Ok(())
+}
+
+pub async fn ingest_tar_gz(
+    client: &reqwest::Client,
+    base_url: &str,
+    org: &str,
+    bucket: &str,
+    token: &str,
+    path: &Path,
+    batch_size: usize,
+) -> Result<(usize, usize)> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let gz   = GzDecoder::new(file);
+    let stream = BufReader::new(gz);
+    let mut archive = Archive::new(stream);
+
+    // Raw line channel from IO → parsers
+    let (tx_lines, mut rx_lines) = mpsc::channel::<Vec<u8>>(16_384);
+
+    // Parsed LP channel from parsers → HTTP
+    let (tx_lp, mut rx_lp) = mpsc::channel::<String>(16_384);
+
+    // Spawn parser worker
+    tokio::spawn(async move {
+        while let Some(line) = rx_lines.recv().await {
+            if let Ok(Some(rec)) = parse_line(&line) {
+                if let Some(lp) = record_to_line(&rec) {
+                    // ignore send error if receiver closed
+                    let _ = tx_lp.send(lp).await;
+                }
+            }
+        }
+    });
+
+    // HTTP writer with limited concurrency
+    let sem = Arc::new(Semaphore::new(INFLIGHT_HTTP));
+    let mut ok = 0usize;
+    let mut bad = 0usize;
+
+    let http = client.clone();
+    let base_url = base_url.to_string();
+    let org = org.to_string();
+    let bucket = bucket.to_string();
+    let token = token.to_string();
+
+    // Batch aggregator task
+    let writer = tokio::spawn({
+        let sem = sem.clone();
+        async move {
+            let mut batch = Vec::with_capacity(batch_size);
+            let mut tasks = vec![];
+
+            while let Some(lp) = rx_lp.recv().await {
+                batch.push(lp);
+                if batch.len() >= batch_size {
+                    let permit = sem.clone().acquire_owned().await.unwrap();
+                    let body = std::mem::take(&mut batch);
+
+                    // fire off write concurrently
+                    let http = http.clone();
+                    let base_url = base_url.clone();
+                    let org = org.clone();
+                    let bucket = bucket.clone();
+                    let token = token.clone();
+                    tasks.push(tokio::spawn(async move {
+                        let res = write_batch_http(&http, &base_url, &org, &bucket, &token, &body).await;
+                        drop(permit);
+                        (res, body.len())
+                    }));
+                }
+            }
+
+            // flush final
+            if !batch.is_empty() {
+                let permit = sem.acquire_owned().await.unwrap();
+                let body = std::mem::take(&mut batch);
+                let http2 = http.clone();
+                let base_url2 = base_url.clone();
+                let org2 = org.clone();
+                let bucket2 = bucket.clone();
+                let token2 = token.clone();
+                tasks.push(tokio::spawn(async move {
+                    let res = write_batch_http(&http2, &base_url2, &org2, &bucket2, &token2, &body).await;
+                    drop(permit);
+                    (res, body.len())
+                }));
+            }
+
+            // collect results
+            let mut ok = 0usize;
+            let mut bad = 0usize;
+            for t in tasks {
+                match t.await {
+                    Ok((res, n)) => {
+                        if res.is_ok() {
+                            ok += n;
+                        } else {
+                            eprintln!("Result error: {:?} {n}", res);
+                            bad += n;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Task error: {e}");
+                        bad += 1;
+                    }
+                }
+            }
+            (ok, bad)
+        }
+    });
+
+    // IO stage: read entries and push lines quickly
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if !entry.header().entry_type().is_file() { continue; }
+
+        let mut buf = Vec::with_capacity(256 * 1024);
+        entry.read_to_end(&mut buf)?;
+        for slice in buf.split(|&b| b == b'\n') {
+            if slice.is_empty() { continue; }
+            if tx_lines.send(slice.to_vec()).await.is_err() { break; }
+        }
+    }
+    drop(tx_lines); // close, signal parsers to finish
+
+    let (o, b) = writer.await.expect("writer task").clone();
+    Ok((o, b))
+}
+
+/// Ingest multiple files — only `.tar.gz`; others/missing are skipped with a message.
+pub async fn ingest_files(
+    url: &str,
+    token: &str,
+    org: &str,
+    bucket: &str,
+    files: &[PathBuf],
+    batch_size: usize,
+    delete: bool,
+) -> Result<(usize, usize, usize, usize)> {
+    let http = reqwest::Client::builder()
+        .pool_max_idle_per_host(8)
+        .pool_idle_timeout(std::time::Duration::from_secs(30))
+        .tcp_nodelay(true)
+        .build()?;
+
+    let mut ok = 0usize;
+    let mut bad = 0usize;
+    let mut skipped = 0usize;
+    let mut missing = 0usize;
+
+    for p in files {
+        if !p.exists() {
+            missing += 1;
+            eprintln!("Skipping missing file: {}", p.display());
+            continue;
+        }
+        let fname = p.file_name().and_then(|f| f.to_str()).unwrap_or_default();
+        if !fname.ends_with(".tar.gz") {
+            skipped += 1;
+            eprintln!("Skipping non-tar.gz file: {}", p.display());
+            continue;
+        }
+
+        println!("Start ingesting '{}'", p.display());
+        let start_time = Instant::now();
+        let (o, b) = match ingest_tar_gz(&http, url, org, bucket, token, p, batch_size)
+                .await
+                .with_context(|| format!("ingesting {}", p.display())) {
+            Ok((o, b)) => (o, b),
+            Err(e) => {
+                eprintln!("Error ingesting tar file {}: {:?}", p.display(), e); 
+                continue;
+            }
+        };
+        println!("Finished ingesting '{}', duration: {:?}", p.display(), start_time.elapsed());
+        ok += o;
+        bad += b;
+
+        println!("Complete. wrote_points={ok} bad_records={bad}");
+
+        if delete && bad <= 1 {
+            match remove_file(&p) {
+                Ok(_) => {
+                    println!("log: deleted log '{}'", p.display());
+                }
+                Err(e) => {
+                    eprintln!("log: failed to delete '{}': {}", p.display(), e);
+                    // keep trying next files
+                }
+            }
+        }
+    }
+
+    Ok((ok, bad, skipped, missing))
+}

--- a/tools/log-processor/src/main.rs
+++ b/tools/log-processor/src/main.rs
@@ -1,0 +1,210 @@
+use std::path::PathBuf;
+use std::path::Path;
+use std::fs;
+use std::fs::remove_file;
+use std::time::Duration;
+use std::thread;
+
+use anyhow::{Context, Result};
+use clap::{ArgAction, Parser};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use log_processor::ingest_files;
+
+/// Ingest `.tar.gz` CAN/telemetry log archives into InfluxDB 2.x
+#[derive(Debug, Parser)]
+struct Opts {
+    /// .tar.gz files or glob patterns (e.g. logs/*.tar.gz)
+    #[arg(required = true)]
+    inputs: Vec<String>,
+
+    /// InfluxDB URL (e.g. http://localhost:8086)
+    #[arg(long)]
+    url: String,
+
+    /// InfluxDB API Token
+    #[arg(long)]
+    token: String,
+
+    /// InfluxDB org
+    #[arg(long)]
+    org: String,
+
+    /// InfluxDB bucket
+    #[arg(long)]
+    bucket: String,
+
+    /// Batch size for Influx writes
+    #[arg(long, default_value_t = 5_000)]
+    batch_size: usize,
+
+    /// Print matched files and exit
+    #[arg(long, action = ArgAction::SetTrue)]
+    dry_run: bool,
+
+    /// Delete files once extracted
+    #[arg(long, action = ArgAction::SetTrue)]
+    delete: bool,
+}
+
+/// Expand patterns like "dir/*.ext" without using the `glob` crate.
+/// - Supports `*` in the file name portion only (no recursion / no `**`).
+/// - If a pattern has no `*`, it's treated as a literal path (included if it exists).
+pub fn expand_inputs(patterns: &[String]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+
+    for pat in patterns {
+        if !pat.contains('*') {
+            let p = Path::new(pat);
+            if p.exists() {
+                files.push(p.to_path_buf());
+            }
+            continue;
+        }
+
+        let (dir, file_pat) = split_dir_and_basename_pattern(pat)?;
+        let entries = fs::read_dir(&dir)
+            .with_context(|| format!("reading directory {}", dir.display()))?;
+
+        for ent in entries {
+            let ent = ent?;
+            let name = match ent.file_name().into_string() {
+                Ok(s) => s,
+                Err(_) => continue, // skip invalid UTF-8 names
+            };
+            if matches_star_only(&file_pat, &name) {
+                files.push(ent.path());
+            }
+        }
+    }
+
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+/// Split "some/dir/*.ext" into ("some/dir", "*.ext").
+/// If there's no parent, uses "." as the directory.
+fn split_dir_and_basename_pattern(pat: &str) -> Result<(PathBuf, String)> {
+    let path = Path::new(pat);
+    let dir = path.parent().map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from("."));
+    let basename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("invalid pattern (missing basename): {}", pat))?
+        .to_string();
+    Ok((dir, basename))
+}
+
+/// Simple wildcard matcher supporting only `*` (matches any sequence, including empty).
+/// No character escaping; path separators are not special here since we only match basenames.
+fn matches_star_only(pattern: &str, text: &str) -> bool {
+    // Fast path: no `*` means exact match.
+    if !pattern.contains('*') {
+        return pattern == text;
+    }
+
+    // Two-pointer greedy matcher for `*` only.
+    let (p_bytes, t_bytes) = (pattern.as_bytes(), text.as_bytes());
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star_idx, mut match_after_star) = (None, 0usize);
+
+    while ti < t_bytes.len() {
+        if pi < p_bytes.len() && (p_bytes[pi] == t_bytes[ti]) {
+            // literal char match
+            pi += 1;
+            ti += 1;
+        } else if pi < p_bytes.len() && p_bytes[pi] == b'*' {
+            // record star, advance pattern, try to match zero chars first
+            star_idx = Some(pi);
+            pi += 1;
+            match_after_star = ti;
+        } else if let Some(si) = star_idx {
+            // backtrack: let star consume one more char
+            pi = si + 1;
+            match_after_star += 1;
+            ti = match_after_star;
+        } else {
+            return false;
+        }
+    }
+
+    // Consume trailing stars
+    while pi < p_bytes.len() && p_bytes[pi] == b'*' {
+        pi += 1;
+    }
+
+    pi == p_bytes.len()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opts = Opts::parse();
+
+    loop {
+        let files = expand_inputs(&opts.inputs)?;
+        if files.is_empty() {
+            thread::sleep(Duration::from_secs(60));
+        }
+
+        if opts.dry_run {
+            for f in &files {
+                println!("{}", f.display());
+            }
+            return Ok(());
+        }
+
+        let pb = ProgressBar::new(files.len() as u64);
+        pb.set_style(
+            ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] [{wide_bar}] {pos}/{len} {msg}",
+            )
+            .unwrap(),
+        );
+
+        let (ok, bad, skipped, missing) = ingest_files(
+            &opts.url,
+            &opts.token,
+            &opts.org,
+            &opts.bucket,
+            &files,
+            opts.batch_size,
+            opts.delete,
+        )
+        .await?;
+
+        pb.finish_and_clear();
+        println!(
+            "Done. wrote_points={ok} bad_records={bad} files_matched={} files_skipped={} files_missing={}",
+            files.len(),
+            skipped,
+            missing
+        );
+        if ok == 0 && skipped > 0 {
+            thread::sleep(Duration::from_secs(60));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_star_only;
+
+    #[test]
+    fn test_matches_star_only() {
+        assert!(matches_star_only("*.rs", "main.rs"));
+        assert!(matches_star_only("file.*", "file.txt"));
+        assert!(matches_star_only("*", "anything"));
+        assert!(matches_star_only("a*b*c", "axxxbxxc"));
+        assert!(matches_star_only("no_star", "no_star"));
+        assert!(!matches_star_only("no_star", "nope"));
+        assert!(!matches_star_only("*.rs", "main.r"));
+        assert!(matches_star_only("foo*bar", "foobar"));
+        assert!(matches_star_only("foo*bar", "foo___bar"));
+        assert!(matches_star_only("foo*bar*", "foo_bar_baz"));
+        assert!(matches_star_only("*end", "the_end"));
+        assert!(!matches_star_only("*end", "the_end_"));
+        assert!(matches_star_only("prefix*", "prefix"));
+    }
+}


### PR DESCRIPTION
### Describe changes

Adds ability to process can logs and ingest into influx db

### Impact

High CPU load on carputer until ingestion is done in the server

### Test Plan

- [x] With can bridge continuously logging, ensure the log processor is continuously ingesting logs faster than are being generated
