### PR TITLE
ota-agent: Keep critical logging when flashing

### DIFF
--- a/drive-stack/ota-agent/src/main.rs
+++ b/drive-stack/ota-agent/src/main.rs
@@ -748,7 +748,7 @@ async fn flash_handler(
         &state.can_device, &p.node, &staged.filename
     );
 
-    let bridge_unit = "can-bridge.service";
+    let bridge_unit = "log-processor.service";
     if let Err(e) = systemd_service("stop", bridge_unit).await {
         error!("Failed to stop {}: {}", bridge_unit, e);
     }


### PR DESCRIPTION
### Describe changes

1. Keep logging, but turn off the log-processor

### Test Plan

- [x] Force OTA car, ensure no flash fails
