### PR TITLE
Adding support for 103JT Thermistors

### DIFF
--- a/components/shared/code/libs/lib_thermistors.h
+++ b/components/shared/code/libs/lib_thermistors.h
@@ -45,6 +45,12 @@ static const lib_thermistors_BParameter_S NCP21_bParam = { // For the NCP21XV103
     .R0 = 10000U,
 };
 
+static const lib_thermistors_BParameter_S NTC103JT_bParam = { // For the 103JT-100 and 103JT-050
+    .B = 3435U,
+    .T0 = 25U + KELVIN_OFFSET,
+    .R0 = 10000U,
+};
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/


### PR DESCRIPTION
### Describe changes

1. Added instance of `lib_thermistors_BParameter_S` in shared thermistor library to be used in new worker.

### Impact

1. Allows proper voltage to temperature conversion with 103JT thermistor's b parameter.

Resolves #408 
### Test Plan

- [ ] Once BMS Worker is assembled and validated, thermistors will be tested against ambient temperature of cells.
- [ ] Tested for all 6 workers (should be identical)
- [ ] Add config for worker to use `NTC103JT_bParam`