### PR TITLE
Shock Linear Potentiometer Migration + Improvements

### DIFF
--- a/components/vc/front/src/shockpot.c
+++ b/components/vc/front/src/shockpot.c
@@ -1,6 +1,6 @@
 /**
  * @file shockpot.c
- * @brief Module source for steering angle sensor
+ * @brief Module source for Linear Potentiometer
  */
 
 /******************************************************************************
@@ -91,7 +91,7 @@ static void shockpot_init(void)
     lib_interpolation_init(&shockpot_map2, 0.0f);
 }
 
-static void shockpot_periodic_10Hz(void)
+static void shockpot_periodic_100Hz(void)
 {
     shockpot_FL.voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_L_SHK_DISP);
     shockpot_FR.voltage = drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_R_SHK_DISP);
@@ -102,5 +102,5 @@ static void shockpot_periodic_10Hz(void)
 
 const ModuleDesc_S shockpot_desc = {
     .moduleInit = &shockpot_init,
-    .periodic10Hz_CLK = &shockpot_periodic_10Hz,
+    .periodic100Hz_CLK = &shockpot_periodic_100Hz,
 };


### PR DESCRIPTION
### Describe changes

1. Changes separate source files for shockpot in front and rear into common code under 'vc/shared'
2. Recalibrate Shockpot transfer function to reflect pull up (previously power was given, which gives a non-linear transfer function)
3. Changes function periodic frequency from 10Hz to 100Hz
4. Reflect the same changes in network (10ms)

### Impact
Resolves #410
1. Remove redundant code, which can have diverging code for same sensors
2. Increase polling rate, as needed by aero and primarily VD subsystem
3. Improve accuracy of shock potentiometer
4. Previous 5Hz logging bottlenecked by ECUMaster (reason for 10Hz logging previously), resolved by can logging through carputer. 

### Test Plan

- [ ] Flash VCFront and VCRear (OTA)
- [ ] Move around all 4 shock potentiometers across full range
- [ ] Measure linear potentiometer steady state at quarter distance of each (using caliper) to verify correct transfer function to suspension travel
- [ ] Pull Influx log to verify polling rate
