### PR TITLE
buck2: add better compdb support

### DIFF
--- a/buck2/tools/comp_db.bxl
+++ b/buck2/tools/comp_db.bxl
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+
+# I copy-pasted this from prelude//cxx/tools/compilation_database.bxl:generate for ease of use
+# Use it like this:
+# `buck2 bxl buck2/tools/comp_db.bxl:gen -- --targets //components/steering_wheel:elf`
+
+load("@prelude//cxx:comp_db.bzl", "CxxCompilationDbInfo")
+load("@prelude//cxx:compile_types.bzl", "CxxSrcCompileCommand")
+load("@prelude//utils:utils.bzl", "flatten")
+
+def _make_entry(ctx: bxl.Context, target: Label, compile_command: CxxSrcCompileCommand, add_target_name: bool) -> dict:
+    args = compile_command.cxx_compile_cmd.base_compile_cmd.copy()
+
+    # This prevents clangd from jumping into `buck-out` when using Go To
+    # Definition, which significantly improves user experience.
+    args.add(["-I", "."])
+    args.add(compile_command.cxx_compile_cmd.argsfile.cmd_form)
+    args.add(compile_command.args)
+    ctx.output.ensure_multiple(args)
+
+    result = {
+        "arguments": args,
+        "directory": ctx.fs.abs_path_unsafe(ctx.root()),
+        "file": compile_command.src,
+    }
+
+    if add_target_name:
+        result["target"] = target.configured_target().raw_target()
+
+    return result
+
+def _impl(ctx: bxl.Context):
+    targets = ctx.configured_targets(flatten(ctx.cli_args.targets), modifiers = ctx.modifiers)
+    if ctx.cli_args.recursive:
+        targets = ctx.cquery().deps(targets)
+
+    actions = ctx.bxl_actions().actions
+
+    db = []
+    for name, target in ctx.analysis(targets).items():
+        comp_db_info = target.providers().get(CxxCompilationDbInfo)
+        if comp_db_info:
+            for cc in comp_db_info.info.values():
+                if ctx.cli_args.include_headers or (not cc.is_header):
+                    db.append(_make_entry(ctx, name, cc, ctx.cli_args.add_target_name))
+
+    db_file = actions.declare_output("compile_commands.json")
+    actions.write_json(db_file.as_output(), db, with_inputs = True, pretty = True)
+    ctx.output.print(ctx.output.ensure(db_file))
+
+gen = bxl_main(
+    doc = "Generate a compilation database for a set of targets and print its path to stdout",
+    impl = _impl,
+    cli_args = {
+        "add-target-name": cli_args.bool(
+            default = False,
+            doc = "Include the name of the target in the compilation database entries (non-standard)",
+        ),
+        "include-headers": cli_args.bool(
+            default = True,
+            doc = "Include header file compilation db actions",
+        ),
+        "recursive": cli_args.bool(
+            default = False,
+            doc = "Automatically include all dependent targets in the generated compilation db",
+        ),
+        "targets": cli_args.list(
+            cli_args.target_expr(),
+            doc = "Targets to generate the database for",
+        ),
+    },
+)

--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -427,11 +427,6 @@ inject_crc(
 ]
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = APP_NAME,
     actual = ":bin",
 )

--- a/components/bms_worker/BUCK
+++ b/components/bms_worker/BUCK
@@ -489,11 +489,6 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
-alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
 [
     conUDS_download(
         name = "download-node-{}".format(node),

--- a/components/bootloaders/STM/stm32f1/defs.bzl
+++ b/components/bootloaders/STM/stm32f1/defs.bzl
@@ -184,11 +184,6 @@ def _bootloader_impl(
         visibility = ["PUBLIC"],
     )
 
-    __rules__["alias"](
-        name = name_prefix.format("compdb"),
-        actual = ":" + name_prefix.format("elf") + "[full-compilation-database]",
-    )
-
     openocd_run(
         name = "gdb-{}-{}".format(config_id, "blu" if is_updater else "bl"),
         toolchain = toolchain,

--- a/components/steering_wheel/BUCK
+++ b/components/steering_wheel/BUCK
@@ -248,11 +248,6 @@ inject_crc(
 )
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = "stw",
     actual = ":bin",
 )

--- a/components/sws/BUCK
+++ b/components/sws/BUCK
@@ -393,11 +393,6 @@ inject_crc(
 ]
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = APP_NAME,
     actual = ":bin",
 )

--- a/components/vc/front/BUCK
+++ b/components/vc/front/BUCK
@@ -402,11 +402,6 @@ inject_crc(
 ]
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = APP_NAME,
     actual = ":bin",
 )

--- a/components/vc/pdu/BUCK
+++ b/components/vc/pdu/BUCK
@@ -396,11 +396,6 @@ inject_crc(
 ]
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = APP_NAME,
     actual = ":bin",
 )

--- a/components/vc/rear/BUCK
+++ b/components/vc/rear/BUCK
@@ -401,11 +401,6 @@ inject_crc(
 ]
 
 alias(
-    name = "compdb",
-    actual = ":elf[full-compilation-database]",
-)
-
-alias(
     name = APP_NAME,
     actual = ":bin",
 )


### PR DESCRIPTION
### Describe changes

The compilation database that was generated by the code I removed was not very good. There were a bunch of random issues I don't feel like enumerating, but the real issue is that the `directory` field was repo-relative, which means clangd actually just couldn't use it, which entirely defeats the purpose.

What I'm adding here is just a copy-paste of the BXL that is in the prelude. I copy-pasted it so that the path is shorter, rather than having to path all the way into where it's at in the prelude.

### Impact

1. For anyone using compile_commands.json, this makes it actually work lol

### Test Plan

- [ ] no
