### PR TITLE
sws: Disable race request when requesting reverse

### DIFF
--- a/components/sws/include/Module_componentSpecific.h
+++ b/components/sws/include/Module_componentSpecific.h
@@ -19,6 +19,7 @@
 /**< Modules */
 extern const ModuleDesc_S CANIO_rx;
 extern const ModuleDesc_S UDS_desc;
+extern const ModuleDesc_S driverInput_desc;
 extern const ModuleDesc_S light_desc;
 extern const ModuleDesc_S CANIO_tx;
 
@@ -30,6 +31,7 @@ typedef enum
 {
     MODULE_CANIO_rx = 0x00U,
     MODULE_UDS,
+    MODULE_DRIVERINPUT,
     MODULE_LIGHT,
     MODULE_CANIO_tx,
     MODULE_CNT

--- a/components/sws/src/Module_componentSpecific.c
+++ b/components/sws/src/Module_componentSpecific.c
@@ -22,6 +22,7 @@
 const ModuleDesc_S* modules[MODULE_CNT] = {
     &CANIO_rx,
     &UDS_desc,
+    &driverInput_desc,
     &light_desc,
     &CANIO_tx,
 };

--- a/components/sws/src/driverInput.c
+++ b/components/sws/src/driverInput.c
@@ -231,12 +231,12 @@ static void update_combos(const bool pg_next, const bool pg_prev,
 
     // require stability for the involved buttons to progress debounce timers
     const bool run_stable  = run_combo  && !(db_pg_next || db_pg_prev);
-    const bool race_stable = race_combo && !(db_sl_inc || db_sl_dec || db_tq_inc || db_tq_dec);
     const bool rev_stable  = rev_combo  && !(db_sl_inc || db_sl_dec || db_tq_inc || db_tq_dec);
+    const bool race_stable = race_combo && !rev_stable && !(db_sl_inc || db_sl_dec || db_tq_inc || db_tq_dec);
 
     data.run_active = run_stable;
-    data.race_active = race_stable;
     data.reverse_active = rev_stable;
+    data.race_active = race_stable;
 }
 
 static void update_page_nav(const bool pg_next, const bool pg_prev,


### PR DESCRIPTION
### Describe changes

Disables race request when also requesting reverse

### Impact

Prevents entering race mode unwantingly when requesting revers

### Test Plan

- Press all 4 reverse mode buttons - ensure it requests reverse :white_check_mark: 
- Ensure race mode is not requested :white_check_mark: 
