### PR TITLE
conUDS: Error when a download fails

### DIFF
--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -647,6 +647,10 @@ impl UdsClient {
         // early
         self.transfer_stop().await?;
 
+        if error {
+            return Err(anyhow!("Download failed!"));
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Describe changes

1. conUDS now will properly error if a download fails and not silently fail
