### PR TITLE
vehicleState: Fix sleep transition bug

### DIFF
--- a/components/shared/code/app/app_vehicleState.c
+++ b/components/shared/code/app/app_vehicleState.c
@@ -244,10 +244,10 @@ void app_vehicleState_run100Hz(void)
         {
             vehicleState_data.state = VEHICLESTATE_SLEEP;
         }
-        else
-        {
-            app_vehicleState_init();
-        }
+    }
+    else if (app_vehicleState_sleeping())
+    {
+        app_vehicleState_init();
     }
 #endif // FDEFS_MODE_LEADER
 }


### PR DESCRIPTION
Fixes: 9ce3b0220dd8d9e96e1b9a9259edc5e84547e783 "vehicleState: Add sleep support"

### Describe changes

1. Prevents dropping out when racing against being ready to sleep
2. Supports future usecases where other applications on the leader will want to exit sleep from the PDU
