### PR TITLE
bmsb: Bringup fault manager and add open contactor faults

### DIFF
--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -356,6 +356,7 @@ cxx_binary(
             "//components/shared/code:libs/lib_nvm.c",
             "//components/shared/code:libs/lib_swFuse.c",
             "//components/shared/code:libs/lib_thermistors.c",
+            "//components/shared/code:app/app_faultManager.c",
             "//components/shared/code:libs/Utility.c",
             "//embedded/libs:libcrc.c",
             ("RTOS/FreeRTOSResources.c", ["-Wno-missing-prototypes"]),

--- a/components/bms_boss/include/CANIO_componentSpecific.h
+++ b/components/bms_boss/include/CANIO_componentSpecific.h
@@ -27,6 +27,7 @@
 #include "lib_nvm.h"
 #include "Module.h"
 #include "Sys.h"
+#include "app_faultManager.h"
 
 /******************************************************************************
  *          P R I V A T E  F U N C T I O N  P R O T O T Y P E S
@@ -42,6 +43,8 @@ CAN_prechargeContactorState_E CANIO_tx_getContactorState(void);
 
 #define CANIO_UDS_BUFFER_LENGTH                     8U
 #define CANIO_getTimeMs()                           (HW_TIM_getTimeMS())
+
+#define set_fault_message (*(CAN_data_T*)app_faultManager_transmit())
 
 #define set_packChargeLimit(m, b, n, s)             set(m, b, n, s, BMS.pack_charge_limit)
 #define set_packDischargeLimit(m, b, n, s)          set(m, b, n, s, BMS.pack_discharge_limit)

--- a/network/definition/data/components/bmsb/bmsb-message.yaml
+++ b/network/definition/data/components/bmsb/bmsb-message.yaml
@@ -1,4 +1,17 @@
 messages:
+  faults:
+    description: BMSB Faults
+    cycleTimeMs: 1000
+    id: 0x3a3
+    sourceBuses: veh
+    messageType: faults
+    signals:
+      contactorsOpenedUnderLoad:
+      bmsFaultOpenedContactors:
+      tsmsOpenedContactors:
+      imdOpenedContactors:
+      timeoutOpenedContactors:
+
   criticalData:
     description: BMS Boss Critical Data
     cycleTimeMs: 10

--- a/network/definition/data/components/bmsb/bmsb-signals.yaml
+++ b/network/definition/data/components/bmsb/bmsb-signals.yaml
@@ -1,4 +1,20 @@
 signals:
+  contactorsOpenedUnderLoad:
+    description: Contactors opened while current was not 0
+    discreteValues: faultStatus
+  bmsFaultOpenedContactors:
+    description: BMS Fault caused contactors to open
+    discreteValues: faultStatus
+  tsmsOpenedContactors:
+    description: TSMS caused contactors to open
+    discreteValues: faultStatus
+  imdOpenedContactors:
+    description: IMD OK caused contactors to open
+    discreteValues: faultStatus
+  timeoutOpenedContactors:
+    description: Timed out TS nodes caused contactors to open
+    discreteValues: faultStatus
+
   nlg513ControlByte:
     description: Brusa NLG513 Control Byte
     nativeRepresentation:


### PR DESCRIPTION
### Describe changes

1. Add BMSB fault manager and bringup open contactor faults

### Test Plan

- [x] Close TS
- [x] Open TS
- [x] Ensure to see a single TSMS opened contactor fault
