### PR TITLE
bmsb: Correct pack current can output

### DIFF
--- a/network/definition/data/components/bmsb/bmsb-signals.yaml
+++ b/network/definition/data/components/bmsb/bmsb-signals.yaml
@@ -118,8 +118,8 @@ signals:
       bitWidth: 15
       resolution: 0.1
       range:
-        min: -100
-        max: 400
+        min: -400
+        max: 100
     continuous: true
 
   packContactorState:


### PR DESCRIPTION
### Describe changes

1. Current is higher in the discharge path which is negative current
