### PR TITLE
nvm: Dont evaluate record header if its not in current page

### DIFF
--- a/components/shared/code/libs/lib_nvm.c
+++ b/components/shared/code/libs/lib_nvm.c
@@ -212,8 +212,8 @@ void lib_nvm_init(void)
     {
         // While the current record in NVM is initialized and we remain in the same block
         // bounds, continue iterating and updating the current record of each entry
-        while ((hdr->initialized == SET_STATE) &&
-            (getBlockBaseAddress((uint32_t)block_hdr) == getBlockBaseAddress((uint32_t)(hdr))))
+        while ((getBlockBaseAddress((uint32_t)block_hdr) == getBlockBaseAddress((uint32_t)(hdr) + sizeof(*hdr))) &&
+               (hdr->initialized == SET_STATE))
         {
             storage_t* record = (storage_t*)(hdr + 1);
 


### PR DESCRIPTION
### Describe changes

1. NVM init can lockup in a hard fault when the last record header extends from the current page into the following page. An edge case of this is when the next page is outside of the flash memory region, triggering a HardFault and subsequent lockup

### Impact

1. Correct nvm initialization

### Test Plan

- [x] With the edge case nvm state, ensure the app no longer gets stuck in init
