### PR TITLE
added a motorcontroller check for timeout and used for validating data

### DIFF
--- a/components/vc/pdu/src/powerManager.c
+++ b/components/vc/pdu/src/powerManager.c
@@ -143,7 +143,8 @@ static void evalAbilities(void)
     pm_data.charged = charged;
     pm_data.okBattery = okBattery && !overvoltage;
     pm_data.okLoads = okLoads && !pm_data.sleeping && !overvoltage && charged;
-    pm_data.okSafety = okSafety && !pm_data.sleeping && !overvoltage && charged;
+    const bool motorControllerTimeout = SYS_SFT_checkMCTimeout();
+    pm_data.okSafety = okSafety && !pm_data.sleeping && !overvoltage && charged && !motorControllerTimeout;
 
     app_faultManager_setFaultState(FM_FAULT_VCPDU_LOWVOLTAGE, lowBattery);
     app_faultManager_setFaultState(FM_FAULT_VCPDU_OVERVOLTAGE, overvoltage);


### PR DESCRIPTION
### Describe changes

Used the CAN signal to check for timeout and set it to safety = false if timeout. 

### Impact

Blocks the VCPDU safety controller if it is not hearing from the motorcontroller

### Test Plan

- [ ] force motrocontroller timeout and see how VCPDU safety reacts.
