### PR TITLE
added NVM tracking for BMSB contactor cycles for HV+, HV-, precharge electromagnetic contactors

### DIFF
--- a/components/bms_boss/include/BMS.h
+++ b/components/bms_boss/include/BMS.h
@@ -17,6 +17,14 @@ _Static_assert(BMS_MAX_SEGMENTS >= BMS_CONFIGURED_SERIES_SEGMENTS);
 
 #define BMS_VPACK_SOURCE BMS.pack_voltage_calculated
 
+// TDK HVC43 series, worst case 200A load at break
+// https://www.tdk-electronics.tdk.com/inf/100/ds/HVC43MC_B88269X.pdf
+# define BMSB_CONTACTOR_LIFETIME_HVC43            1000U
+
+// Comus 3350 series reed relay, no cycle count published in datasheet
+// https://www.comus-intl.com/wp-content/uploads/2017/01/High-Voltage-Reed-Relays.pdf
+#define BMSB_CONTACTOR_LIFETIME_3350_PRECHARGE   2000U
+
 typedef enum {
     BMS_INIT = 0x00,
     BMS_RUNNING,
@@ -71,7 +79,25 @@ typedef struct
     float32_t pack_amp_hours;
     float32_t cell_amp_hours[BMS_CONFIGURED_SERIES_SEGMENTS * BMS_CONFIGURED_SERIES_CELLS];
     uint8_t spare[16U];
-} LIB_NVM_STORAGE(nvm_bms_data_S);
-extern nvm_bms_data_S current_data;
+} LIB_NVM_STORAGE(nvm_bmsData_S);
+
+typedef struct {
+    struct{
+        uint32_t contactorHvp;
+        uint32_t contactorHvn;
+        uint32_t precharge;
+    } contactorLifetime;
+    uint8_t reserved[16U];
+} LIB_NVM_STORAGE(nvm_bmsbContactorData_S);
+
+extern nvm_bmsData_S current_data;
+extern nvm_bmsbContactorData_S contactor_data;
 
 extern BMSB_S BMS;
+
+float32_t BMSB_getContactorSohHvp(void);
+float32_t BMSB_getContactorSohHvn(void);
+float32_t BMSB_getContactorSohPrecharge(void);
+uint32_t BMSB_getContactorLifetimeHvp(void);
+uint32_t BMSB_getContactorLifetimeHvn(void);
+uint32_t BMSB_getContactorLifetimePrecharge(void);

--- a/components/bms_boss/include/CANIO_componentSpecific.h
+++ b/components/bms_boss/include/CANIO_componentSpecific.h
@@ -41,82 +41,88 @@ CAN_prechargeContactorState_E CANIO_tx_getContactorState(void);
  *                              D E F I N E S
  ******************************************************************************/
 
-#define CANIO_UDS_BUFFER_LENGTH                     8U
-#define CANIO_getTimeMs()                           (HW_TIM_getTimeMS())
+#define CANIO_UDS_BUFFER_LENGTH                        8U
+#define CANIO_getTimeMs()                              (HW_TIM_getTimeMS())
 
 #define set_fault_message (*(CAN_data_T*)app_faultManager_transmit())
 
-#define set_packChargeLimit(m, b, n, s)             set(m, b, n, s, BMS.pack_charge_limit)
-#define set_packDischargeLimit(m, b, n, s)          set(m, b, n, s, BMS.pack_discharge_limit)
-#define set_packVoltage(m, b, n, s)                 set(m, b, n, s, BMS_VPACK_SOURCE)
-#define set_packVoltageCalculated(m, b, n, s)       set(m, b, n, s, BMS.pack_voltage_calculated)
-#define set_packVoltageMeasured(m, b, n, s)         set(m, b, n, s, BMS.pack_voltage_measured)
-#define set_packVoltageMeasurementFault(m, b, n, s) set(m, b, n, s, BMS.pack_voltage_sense_fault ? CAN_FLAG_SET : CAN_FLAG_CLEARED)
-#define set_packCycleCountedCoulombs(m, b, n, s)    set(m, b, n, s, BMS.counted_coulombs.amp_hr)
-#define set_packAmpHours(m, b, n, s)                set(m, b, n, s, current_data.pack_amp_hours)
-#define set_packCurrent(m, b, n, s)                 set(m, b, n, s, BMS.pack_current)
-#define set_packPower(m, b, n, s)                   set(m, b, n, s, BMS.packPowerKW)
-#define set_packContactorState(m, b, n, s)          set(m, b, n, s, CANIO_tx_getContactorState())
-#define set_nlg513ControlByte(m, b, n, s)           set(m, b, n, s, CANIO_tx_getNLG513ControlByte())
-#define set_nlg513MaxMainsCurrent(m, b, n, s)       set(m, b, n, s, 16.0f)
-#define set_nlg513MaxChargeVoltage(m, b, n, s)      set(m, b, n, s, BMS_CONFIGURED_PACK_MAX_VOLTAGE)
-#define set_nlg513MaxChargeCurrent(m, b, n, s)      set(m, b, n, s, (CANIO_tx_getNLG513ControlByte() == 0x40) ? 0.0f : BMS.pack_charge_limit)
-#define transmit_BMSB_brusaChargeCommand            (SYS_SFT_checkBrusaChargerTimeout() == false)
-#define set_taskUsage1kHz(m, b, n, s)               set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_1kHz_TASK));
-#define set_taskUsage100Hz(m, b, n, s)              set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_100Hz_TASK));
-#define set_taskUsage10Hz(m, b, n, s)               set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_10Hz_TASK));
-#define set_taskUsage1Hz(m, b, n, s)                set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_1Hz_TASK));
-#define set_taskUsageIdle(m, b, n, s)               set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
-#define set_elconMaxChargeVoltage(m, b, n, s)       set(m, b, n, s, BMS_CONFIGURED_PACK_MAX_VOLTAGE)
-#define set_elconMaxChargeCurrent(m, b, n, s)       set(m, b, n, s, BMS.pack_charge_limit)
-#define set_elconControlByte(m, b, n, s)            set(m, b, n, s, CANIO_tx_getElconControlByte())
-#define transmit_BMSB_elconChargeCommand            (SYS_SFT_checkElconChargerTimeout() == false)
-#define transmit_BMSB_currentLimit                  (SYS_SFT_checkMCTimeout() == false)
-#define set_maxCharge(m, b, n, s)                   set(m, b, n, s, BMS.pack_charge_limit);
-#define set_maxDischarge(m, b, n, s)                set(m, b, n, s, BMS.pack_discharge_limit);
-#define set_packRH(m, b, n, s)                      set(m, b, n, s, ENV.board.rh)
-#define set_packTemperature(m, b, n, s)             set(m, b, n, s, ENV.board.ambient_temp)
-#define set_taskIterations1kHz(m, b, n, s)          set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_1kHz_TASK))
-#define set_taskIterations100Hz(m, b, n, s)         set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_100Hz_TASK))
-#define set_taskIterations10Hz(m, b, n, s)          set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_10Hz_TASK))
-#define set_taskIterations1Hz(m, b, n, s)           set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_1Hz_TASK))
-#define set_taskStack1kHz(m, b, n, s)               set(m, b, n, s, Module_getMinStackLeft(MODULE_1kHz_TASK))
-#define set_taskStack100Hz(m, b, n, s)              set(m, b, n, s, Module_getMinStackLeft(MODULE_100Hz_TASK))
-#define set_taskStack10Hz(m, b, n, s)               set(m, b, n, s, Module_getMinStackLeft(MODULE_10Hz_TASK))
-#define set_taskStack1Hz(m, b, n, s)                set(m, b, n, s, Module_getMinStackLeft(MODULE_1Hz_TASK))
-#define set_tsmsChg(m, b, n, s)                     set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_TSMS_CHG) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_okHS(m, b, n, s)                        set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_OK_HS) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_bmsIMDReset(m, b, n, s)                 set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_BMS_IMD_RESET) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_imdStatusMem(m, b, n, s)                set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_IMD_STATUS_MEM) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_bmsStatusMem(m, b, n, s)                set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_BMS_STATUS_MEM) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_bmsStatus(m, b, n, s)                   set(m, b, n, s, (drv_outputAD_getDigitalActiveState(DRV_OUTPUTAD_DIGITAL_STATUS_BMS) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_imdStatus(m, b, n, s)                   set(m, b, n, s, (drv_outputAD_getDigitalActiveState(DRV_OUTPUTAD_DIGITAL_STATUS_IMD) == DRV_IO_ACTIVE) ? \
-                                                        CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-#define set_imdState(m, b, n, s)                    set(m, b, n, s, (uint8_t)IMD_getState())
-#define set_imdIsolationResistance(m, b, n, s)      set(m, b, n, s, IMD_getIsolation())
-#define set_packCSVoltage(m, b, n, s)               set(m, b, n, s, drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_CS))
-#define set_packCSPVoltage(m, b, n, s)              set(m, b, n, s, HW_ADC_getVFromBank1Channel(ADC_BANK_CHANNEL_CS))
-#define set_packCSNVoltage(m, b, n, s)              set(m, b, n, s, HW_ADC_getVFromBank2Channel(ADC_BANK_CHANNEL_CS))
-#define set_packVPackPVoltage(m, b, n, s)           set(m, b, n, s, HW_ADC_getVFromBank1Channel(ADC_BANK_CHANNEL_VPACK))
-#define set_packVPackNVoltage(m, b, n, s)           set(m, b, n, s, HW_ADC_getVFromBank2Channel(ADC_BANK_CHANNEL_VPACK))
-#define set_mcuTemperature(m, b, n, s)              set(m, b, n, s, ENV.board.mcu_temp)
+#define set_packChargeLimit(m, b, n, s)                set(m, b, n, s, BMS.pack_charge_limit)
+#define set_packDischargeLimit(m, b, n, s)             set(m, b, n, s, BMS.pack_discharge_limit)
+#define set_packVoltage(m, b, n, s)                    set(m, b, n, s, BMS_VPACK_SOURCE)
+#define set_packVoltageCalculated(m, b, n, s)          set(m, b, n, s, BMS.pack_voltage_calculated)
+#define set_packVoltageMeasured(m, b, n, s)            set(m, b, n, s, BMS.pack_voltage_measured)
+#define set_packVoltageMeasurementFault(m, b, n, s)    set(m, b, n, s, BMS.pack_voltage_sense_fault ? CAN_FLAG_SET : CAN_FLAG_CLEARED)
+#define set_packCycleCountedCoulombs(m, b, n, s)       set(m, b, n, s, BMS.counted_coulombs.amp_hr)
+#define set_packAmpHours(m, b, n, s)                   set(m, b, n, s, current_data.pack_amp_hours)
+#define set_packCurrent(m, b, n, s)                    set(m, b, n, s, BMS.pack_current)
+#define set_packPower(m, b, n, s)                      set(m, b, n, s, BMS.packPowerKW)
+#define set_packContactorState(m, b, n, s)             set(m, b, n, s, CANIO_tx_getContactorState())
+#define set_nlg513ControlByte(m, b, n, s)              set(m, b, n, s, CANIO_tx_getNLG513ControlByte())
+#define set_nlg513MaxMainsCurrent(m, b, n, s)          set(m, b, n, s, 16.0f)
+#define set_nlg513MaxChargeVoltage(m, b, n, s)         set(m, b, n, s, BMS_CONFIGURED_PACK_MAX_VOLTAGE)
+#define set_nlg513MaxChargeCurrent(m, b, n, s)         set(m, b, n, s, (CANIO_tx_getNLG513ControlByte() == 0x40) ? 0.0f : BMS.pack_charge_limit)
+#define transmit_BMSB_brusaChargeCommand               (SYS_SFT_checkBrusaChargerTimeout() == false)
+#define set_taskUsage1kHz(m, b, n, s)                  set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_1kHz_TASK));
+#define set_taskUsage100Hz(m, b, n, s)                 set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_100Hz_TASK));
+#define set_taskUsage10Hz(m, b, n, s)                  set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_10Hz_TASK));
+#define set_taskUsage1Hz(m, b, n, s)                   set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_1Hz_TASK));
+#define set_taskUsageIdle(m, b, n, s)                  set(m, b, n, s, Module_getTotalRuntimePercentage(MODULE_IDLE_TASK));
+#define set_elconMaxChargeVoltage(m, b, n, s)          set(m, b, n, s, BMS_CONFIGURED_PACK_MAX_VOLTAGE)
+#define set_elconMaxChargeCurrent(m, b, n, s)          set(m, b, n, s, BMS.pack_charge_limit)
+#define set_elconControlByte(m, b, n, s)               set(m, b, n, s, CANIO_tx_getElconControlByte())
+#define transmit_BMSB_elconChargeCommand               (SYS_SFT_checkElconChargerTimeout() == false)
+#define transmit_BMSB_currentLimit                     (SYS_SFT_checkMCTimeout() == false)
+#define set_maxCharge(m, b, n, s)                      set(m, b, n, s, BMS.pack_charge_limit);
+#define set_maxDischarge(m, b, n, s)                   set(m, b, n, s, BMS.pack_discharge_limit);
+#define set_packRH(m, b, n, s)                         set(m, b, n, s, ENV.board.rh)
+#define set_packTemperature(m, b, n, s)                set(m, b, n, s, ENV.board.ambient_temp)
+#define set_taskIterations1kHz(m, b, n, s)             set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_1kHz_TASK))
+#define set_taskIterations100Hz(m, b, n, s)            set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_100Hz_TASK))
+#define set_taskIterations10Hz(m, b, n, s)             set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_10Hz_TASK))
+#define set_taskIterations1Hz(m, b, n, s)              set(m, b, n, s, (uint16_t)Module_getTotalRuntimeIterations(MODULE_1Hz_TASK))
+#define set_taskStack1kHz(m, b, n, s)                  set(m, b, n, s, Module_getMinStackLeft(MODULE_1kHz_TASK))
+#define set_taskStack100Hz(m, b, n, s)                 set(m, b, n, s, Module_getMinStackLeft(MODULE_100Hz_TASK))
+#define set_taskStack10Hz(m, b, n, s)                  set(m, b, n, s, Module_getMinStackLeft(MODULE_10Hz_TASK))
+#define set_taskStack1Hz(m, b, n, s)                   set(m, b, n, s, Module_getMinStackLeft(MODULE_1Hz_TASK))
+#define set_tsmsChg(m, b, n, s)                        set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_TSMS_CHG) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_okHS(m, b, n, s)                           set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_OK_HS) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_bmsIMDReset(m, b, n, s)                    set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_BMS_IMD_RESET) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_imdStatusMem(m, b, n, s)                   set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_IMD_STATUS_MEM) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_bmsStatusMem(m, b, n, s)                   set(m, b, n, s, (drv_inputAD_getDigitalActiveState(DRV_INPUTAD_DIGITAL_BMS_STATUS_MEM) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_bmsStatus(m, b, n, s)                      set(m, b, n, s, (drv_outputAD_getDigitalActiveState(DRV_OUTPUTAD_DIGITAL_STATUS_BMS) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_imdStatus(m, b, n, s)                      set(m, b, n, s, (drv_outputAD_getDigitalActiveState(DRV_OUTPUTAD_DIGITAL_STATUS_IMD) == DRV_IO_ACTIVE) ? \
+                                                           CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_imdState(m, b, n, s)                       set(m, b, n, s, (uint8_t)IMD_getState())
+#define set_imdIsolationResistance(m, b, n, s)         set(m, b, n, s, IMD_getIsolation())
+#define set_packCSVoltage(m, b, n, s)                  set(m, b, n, s, drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_CS))
+#define set_packCSPVoltage(m, b, n, s)                 set(m, b, n, s, HW_ADC_getVFromBank1Channel(ADC_BANK_CHANNEL_CS))
+#define set_packCSNVoltage(m, b, n, s)                 set(m, b, n, s, HW_ADC_getVFromBank2Channel(ADC_BANK_CHANNEL_CS))
+#define set_packVPackPVoltage(m, b, n, s)              set(m, b, n, s, HW_ADC_getVFromBank1Channel(ADC_BANK_CHANNEL_VPACK))
+#define set_packVPackNVoltage(m, b, n, s)              set(m, b, n, s, HW_ADC_getVFromBank2Channel(ADC_BANK_CHANNEL_VPACK))
+#define set_mcuTemperature(m, b, n, s)                 set(m, b, n, s, ENV.board.mcu_temp)
 
 #if FEATURE_IS_ENABLED(NVM_LIB_ENABLED)
-# define set_nvmBootCycles(m, b, n, s)              set(m, b, n, s, (uint16_t)lib_nvm_getTotalCycles())
-# define set_nvmRecordWrites(m, b, n, s)            set(m, b, n, s, (uint16_t)lib_nvm_getTotalRecordWrites())
-# define set_nvmBlockErases(m, b, n, s)             set(m, b, n, s, (uint8_t)lib_nvm_getTotalBlockErases())
-# define set_nvmFailedCrc(m, b, n, s)               set(m, b, n, s, (uint8_t)lib_nvm_getTotalFailedCrc())
-# define set_nvmRecordFailedInit(m, b, n, s)        set(m, b, n, s, (uint8_t)lib_nvm_getTotalFailedRecordInit())
-# define set_nvmRecordEmptyInit(m, b, n, s)         set(m, b, n, s, (uint8_t)lib_nvm_getTotalEmptyRecordInit())
-# define set_nvmRecordsVersionFailed(m, b, n, s)    set(m, b, n, s, (uint8_t)lib_nvm_getTotalRecordsVersionFailed())
+# define set_nvmBootCycles(m, b, n, s)                 set(m, b, n, s, (uint16_t)lib_nvm_getTotalCycles())
+# define set_nvmRecordWrites(m, b, n, s)               set(m, b, n, s, (uint16_t)lib_nvm_getTotalRecordWrites())
+# define set_nvmBlockErases(m, b, n, s)                set(m, b, n, s, (uint8_t)lib_nvm_getTotalBlockErases())
+# define set_nvmFailedCrc(m, b, n, s)                  set(m, b, n, s, (uint8_t)lib_nvm_getTotalFailedCrc())
+# define set_nvmRecordFailedInit(m, b, n, s)           set(m, b, n, s, (uint8_t)lib_nvm_getTotalFailedRecordInit())
+# define set_nvmRecordEmptyInit(m, b, n, s)            set(m, b, n, s, (uint8_t)lib_nvm_getTotalEmptyRecordInit())
+# define set_nvmRecordsVersionFailed(m, b, n, s)       set(m, b, n, s, (uint8_t)lib_nvm_getTotalRecordsVersionFailed())
+# define set_contactorLifetimeHvp(m, b, n, s)          set(m, b, n, s, (uint16_t)(BMSB_getContactorLifetimeHvp()))
+# define set_contactorLifetimeHvn(m, b, n, s)          set(m, b, n, s, (uint16_t)(BMSB_getContactorLifetimeHvn()))
+# define set_contactorLifetimePrecharge(m, b, n, s)    set(m, b, n, s, (uint16_t)(BMSB_getContactorLifetimePrecharge()))
+# define set_contactorSohHvp(m, b, n, s)               set(m, b, n, s, BMSB_getContactorSohHvp() * 100.0f)
+# define set_contactorSohHvn(m, b, n, s)               set(m, b, n, s, BMSB_getContactorSohHvn() * 100.0f)
+# define set_contactorSohPrecharge(m, b, n, s)         set(m, b, n, s, BMSB_getContactorSohPrecharge() * 100.0f)
 #else
-# define transmit_BMSB_nvmInformation               false
+# define transmit_BMSB_nvmInformation                  false
 #endif
 
 #include "TemporaryStubbing.h"

--- a/components/bms_boss/include/lib_nvm_componentSpecific.h
+++ b/components/bms_boss/include/lib_nvm_componentSpecific.h
@@ -27,5 +27,6 @@ typedef enum
     NVM_ENTRYID_LOG = 0U,
     NVM_ENTRYID_CYCLE,
     NVM_ENTRYID_COULOMB_COUNT,
+    NVM_ENTRYID_CONTACTOR_LIFETIME,
     NVM_ENTRYID_COUNT, // All entries must be added to the end!
 } lib_nvm_entryId_E;

--- a/components/bms_boss/src/BMS.c
+++ b/components/bms_boss/src/BMS.c
@@ -28,11 +28,52 @@
 
 #define LOAD_CURRENT_THRESHOLD 5
 
+#define CONTACTOR_SOH_LOW_WARN_THRESHOLD_PERCENTAGE 0.1f
+
 BMSB_S BMS;
 
 static drv_timer_S precharge_timer;
 
 void BMS_workerWatchdog(void);
+
+float32_t BMSB_getContactorSohHvp(void)
+{
+    return SATURATE(
+        0.0f,
+        1.0f - ((float32_t)contactor_data.contactorLifetime.contactorHvp / BMSB_CONTACTOR_LIFETIME_HVC43),
+        1.0f);
+}
+
+float32_t BMSB_getContactorSohHvn(void)
+{
+    return SATURATE(
+        0.0f,
+        1.0f - ((float32_t)contactor_data.contactorLifetime.contactorHvn / BMSB_CONTACTOR_LIFETIME_HVC43),
+        1.0f);
+}
+
+float32_t BMSB_getContactorSohPrecharge(void)
+{
+    return SATURATE(
+        0.0f,
+        1.0f - ((float32_t)contactor_data.contactorLifetime.precharge / BMSB_CONTACTOR_LIFETIME_3350_PRECHARGE),
+        1.0f);
+}
+
+uint32_t BMSB_getContactorLifetimeHvp(void)
+{
+    return contactor_data.contactorLifetime.contactorHvp;
+}
+
+uint32_t BMSB_getContactorLifetimeHvn(void)
+{
+    return contactor_data.contactorLifetime.contactorHvn;
+}
+
+uint32_t BMSB_getContactorLifetimePrecharge(void)
+{
+    return contactor_data.contactorLifetime.precharge;
+}
 
 static void BMS_init(void)
 {
@@ -131,6 +172,9 @@ static void BMS100Hz_PRD(void)
     app_faultManager_setFaultState(FM_FAULT_BMSB_BMSFAULT, bmsFault);
     app_faultManager_setFaultState(FM_FAULT_BMSB_IMDNOK, imdOpen);
     app_faultManager_setFaultState(FM_FAULT_BMSB_TIMEOUT, timeout);
+    app_faultManager_setFaultState(FM_FAULT_BMSB_CONTACTORLOWSOHHVP, BMSB_getContactorSohHvp() <  CONTACTOR_SOH_LOW_WARN_THRESHOLD_PERCENTAGE);
+    app_faultManager_setFaultState(FM_FAULT_BMSB_CONTACTORLOWSOHHVN, BMSB_getContactorSohHvn() <  CONTACTOR_SOH_LOW_WARN_THRESHOLD_PERCENTAGE);
+    app_faultManager_setFaultState(FM_FAULT_BMSB_CONTACTORLOWSOHPRECHARGE, BMSB_getContactorSohPrecharge() < CONTACTOR_SOH_LOW_WARN_THRESHOLD_PERCENTAGE);
 
     if (bmsFault)
     {
@@ -164,6 +208,8 @@ static void BMS100Hz_PRD(void)
             {
                 SYS_SFT_cycleContacts();
                 drv_timer_start(&precharge_timer, PRECHARGE_MIN_TIME_MS);
+                contactor_data.contactorLifetime.contactorHvn++;
+                contactor_data.contactorLifetime.precharge++;
             }
             else if ((SYS.contacts == SYS_CONTACTORS_PRECHARGE) || (SYS.contacts == SYS_CONTACTORS_CLOSED))
             {
@@ -177,6 +223,8 @@ static void BMS100Hz_PRD(void)
                     (drv_timer_getState(&precharge_timer) == DRV_TIMER_EXPIRED))
                 {
                     SYS_SFT_cycleContacts();
+                    contactor_data.contactorLifetime.contactorHvp++;
+                    lib_nvm_requestWrite(NVM_ENTRYID_CONTACTOR_LIFETIME);
                 }
             }
         }

--- a/components/bms_boss/src/lib_nvm_componentSpecific.c
+++ b/components/bms_boss/src/lib_nvm_componentSpecific.c
@@ -17,6 +17,7 @@
 
 extern lib_nvm_nvmRecordLog_S recordLog;
 extern lib_nvm_nvmCycleLog_S cycleLog;
+extern nvm_bmsbContactorData_S contactor_data;
 
 /******************************************************************************
  *                     P R I V A T E  F U N C T I O N S
@@ -31,7 +32,7 @@ static uint16_t version_handler_current(const uint16_t version, const storage_t*
     if (new_version == 0U)
     {
         // Example: NVM uprec
-        nvm_bms_data_S flash;
+        nvm_bmsData_S flash;
         memcpy(&flash, entry_Ptr, sizeof(flash.pack_amp_hours));
         current_data.pack_amp_hours = flash.pack_amp_hours;
         new_version = 1;
@@ -46,12 +47,19 @@ static uint16_t version_handler_current(const uint16_t version, const storage_t*
  ******************************************************************************/
 
 #if FEATURE_IS_ENABLED(NVM_LIB_ENABLED)
-static const nvm_bms_data_S current_data_default = {
+static const nvm_bmsData_S current_data_default = {
     .pack_amp_hours = 0U,
     .cell_amp_hours = { 0 },
     .spare = { 0U },
 };
-LIB_NVM_MEMORY_REGION(nvm_bms_data_S current_data) = { 0U };
+LIB_NVM_MEMORY_REGION(nvm_bmsData_S current_data) = { 0U };
+
+static const nvm_bmsbContactorData_S contactor_data_default = {
+    .contactorLifetime.contactorHvp = 0U,
+    .contactorLifetime.contactorHvn = 0U,
+    .contactorLifetime.precharge = 0U,
+};
+LIB_NVM_MEMORY_REGION(nvm_bmsbContactorData_S contactor_data) = {0U};
 
 const lib_nvm_entry_S lib_nvm_entries[NVM_ENTRYID_COUNT] = {
     [NVM_ENTRYID_LOG] = {
@@ -68,8 +76,15 @@ const lib_nvm_entry_S lib_nvm_entries[NVM_ENTRYID_COUNT] = {
         .minTimeBetweenWritesMs = 60000U, // Should only change once per boot cycle
         .version = 0U,
     },
+    [NVM_ENTRYID_CONTACTOR_LIFETIME] = {
+        .entrySize = sizeof(nvm_bmsbContactorData_S),
+        .entryDefault_Ptr = &contactor_data_default,
+        .entryRam_Ptr = &contactor_data,
+        .minTimeBetweenWritesMs = 60000U,
+        .version = 0U,
+    },
     [NVM_ENTRYID_COULOMB_COUNT] = {
-        .entrySize = sizeof(nvm_bms_data_S),
+        .entrySize = sizeof(nvm_bmsData_S),
         .entryDefault_Ptr = &current_data_default,
         .entryRam_Ptr = &current_data,
         .minTimeBetweenWritesMs = 10000U,

--- a/components/sws/src/screenManager.c
+++ b/components/sws/src/screenManager.c
@@ -56,6 +56,7 @@ typedef enum
     WARN_CONTACTS_OPEN_IN_RUN,
     WARN_IMU_UNCALIBRATED,
     WARN_APPS_DISABLED,
+    WARN_CONTACTOR_SOH_LOW,
     WARN_COUNT,
 } warnings_E;
 
@@ -147,6 +148,9 @@ static CAN_screenWarnings_E translateWarningToCAN(warnings_E warning)
         case WARN_APPS_DISABLED:
             ret = CAN_SCREENWARNINGS_APPS_DISABLED;
             break;
+        case WARN_CONTACTOR_SOH_LOW:
+            ret = CAN_SCREENWARNINGS_CONTACTOR_SOH_LOW;
+            break;
         case WARN_NONE:
         case WARN_COUNT:
             break;
@@ -188,11 +192,15 @@ static void getWarnings(void)
     const bool contactsOpeninRun = app_faultManager_getNetworkedFault_state(VEH, VCPDU_faults, FM_FAULT_VCPDU_CONTACTSOPENINRUN);
     const bool imuUncalibrated = app_faultManager_getNetworkedFault_state(VEH, VCPDU_faults, FM_FAULT_VCPDU_IMUUNCALIBRATED);
     const bool appsBypassed = app_faultManager_getNetworkedFault_state(VEH, VCFRONT_faults, FM_FAULT_VCFRONT_APPSDISABLED);
+    const bool contactorSohLow = app_faultManager_getNetworkedFault_state(VEH, BMSB_faults, FM_FAULT_BMSB_CONTACTORLOWSOHHVP) ||
+                              app_faultManager_getNetworkedFault_state(VEH, BMSB_faults, FM_FAULT_BMSB_CONTACTORLOWSOHHVN) ||
+                              app_faultManager_getNetworkedFault_state(VEH, BMSB_faults, FM_FAULT_BMSB_CONTACTORLOWSOHPRECHARGE);
 
     WARNING_INGRESS(WARN_LOW_GLV, lowGLV);
     WARNING_INGRESS(WARN_CONTACTS_OPEN_IN_RUN, contactsOpeninRun);
     WARNING_INGRESS(WARN_IMU_UNCALIBRATED, imuUncalibrated);
     WARNING_INGRESS(WARN_APPS_DISABLED, appsBypassed);
+    WARNING_INGRESS(WARN_CONTACTOR_SOH_LOW, contactorSohLow);
 }
 
 static void determineActiveWarning(void)

--- a/network/definition/data/components/bmsb/bmsb-message.yaml
+++ b/network/definition/data/components/bmsb/bmsb-message.yaml
@@ -13,6 +13,9 @@ messages:
       bmsFault:
       imdNOK:
       timeout:
+      contactorLowSohHvp:
+      contactorLowSohHvn:
+      contactorLowSohPrecharge:
 
   criticalData:
     description: BMS Boss Critical Data

--- a/network/definition/data/components/bmsb/bmsb-signals.yaml
+++ b/network/definition/data/components/bmsb/bmsb-signals.yaml
@@ -14,6 +14,15 @@ signals:
   bmsFault:
     description: BMS Fault
     discreteValues: faultStatus
+  contactorLowSohHvp:
+    description: HVP contactor state of health below threshold
+    discreteValues: faultStatus
+  contactorLowSohHvn:
+    description: HVN contactor state of health below threshold
+    discreteValues: faultStatus
+  contactorLowSohPrecharge:
+    description: Precharge contactor state of health below threshold
+    discreteValues: faultStatus
   imdNOK:
     description: IMD NOK
     discreteValues: faultStatus

--- a/network/definition/data/components/sws/sws-rx.yaml
+++ b/network/definition/data/components/sws/sws-rx.yaml
@@ -4,6 +4,7 @@ messages:
     unrecorded: true
   VCPDU_faults:
   VCFRONT_faults:
+  BMSB_faults:
 signals:
   VCFRONT_launchControlState:
   VCPDU_vehicleState:

--- a/network/definition/data/templates/messages.yaml
+++ b/network/definition/data/templates/messages.yaml
@@ -61,6 +61,21 @@ messages:
         template: nvmRecordFailedInit
       nvmRecordsVersionFailed:
         template: nvmRecordsVersionFailed
+  contactorInfo:
+    cycleTimeMs: 1000
+    signals:
+      contactorLifetimeHvp:
+        template: contactorLifetimeHvp
+      contactorLifetimeHvn:
+        template: contactorLifetimeHvn
+      contactorLifetimePrecharge:
+        template: contactorLifetimePrecharge
+      contactorSohHvp:
+        template: contactorSohHvp
+      contactorSohHvn:
+        template: contactorSohHvn
+      contactorSohPrecharge:
+        template: contactorSohPrecharge
   sleepableNode:
     cycleTimeMs: 1000
     signals:

--- a/network/definition/data/templates/signals.yaml
+++ b/network/definition/data/templates/signals.yaml
@@ -230,6 +230,51 @@ signals:
     nativeRepresentation:
       bitWidth: 7
       resolution: 1
+  contactorLifetimeHvp:
+    unit: ''
+    description: Count of BMSB contactor cycles for HV+ for product lifetime
+    nativeRepresentation:
+      bitWidth: 14
+      resolution: 1
+  contactorLifetimeHvn:
+    unit: ''
+    description: Count of BMSB contactor cycles for HV- for product lifetime
+    nativeRepresentation:
+      bitWidth: 14
+      resolution: 1
+  contactorLifetimePrecharge:
+    unit: ''
+    description: Count of BMSB contactor cycles for precharge for product lifetime
+    nativeRepresentation:
+      bitWidth: 14
+      resolution: 1
+  contactorSohHvp:
+    unit: '%'
+    description: State of health for HV+ contactor
+    nativeRepresentation:
+      bitWidth: 7
+      resolution: 1
+      range:
+        min: 0
+        max: 100
+  contactorSohHvn:
+    unit: '%'
+    description: State of health for HV- contactor
+    nativeRepresentation:
+      bitWidth: 7
+      resolution: 1
+      range:
+        min: 0
+        max: 100
+  contactorSohPrecharge:
+    unit: '%'
+    description: State of health for precharge contactor
+    nativeRepresentation:
+      bitWidth: 7
+      resolution: 1
+      range:
+        min: 0
+        max: 100
   bytes:
     unit: "B"
     nativeRepresentation:

--- a/network/definition/discrete_values.yaml
+++ b/network/definition/discrete_values.yaml
@@ -255,6 +255,7 @@ screenWarnings:
   CONTACTS_OPEN_IN_RUN: 5
   IMU_UNCALIBRATED: 6
   APPS_DISABLED: 7
+  CONTACTOR_SOH_LOW: 8
 
 configSelection:
   NONE: 0


### PR DESCRIPTION
### Describe changes
1. Added NVM entry `NVM_ENTRYID_CONTACTOR_LIFETIME` tracking HVP, HVN, and precharge contactor cycle counts in `nvm_bmsbContactorData_S`
2. Increments lifecycle counters on contactor state transitions in `BMS100Hz_PRD` — HVN and precharge on `OPEN → PRECHARGE`, HVP on `PRECHARGE → CLOSED`
3. Added SOH functions for each contactor computed against rated cycle counts
    - HVP and HVN: TDK HVC43, worst case 450VDC 200A break, 1,000 cycles [[datasheet](https://www.tdk-electronics.tdk.com/inf/100/ds/HVC43MC_B88269X.pdf)]
    - Precharge: Comus 3350 series reed relay, no cycle count published in [[datasheet](https://www.comus-intl.com/wp-content/uploads/2017/01/High-Voltage-Reed-Relays.pdf)], assumed 2,000 cycles
4. Exposes lifetime counts and SOH on CAN via new `contactorInfo` message
5. Added contactor SOH low faults to BMSB fault manager and driver screen warning

### Impact
1. Contactor lifecycle counts persist across power cycles via NVM
2. New `contactorInfo` CAN message transmitted at 1Hz
3. Driver screen warning triggered when any contactor SOH falls below 10%
4. Minor increase in NVM flash usage (28 bytes per entry, 12 bytes of contactor data, and 16 bytes reserved)

### Test Plan
- [ ] Cycle contactors and confirm lifetime counters increment correctly on CAN telemetry
- [ ] Power cycle board and confirm counts are retained in NVM
- [ ] Verify SOH reads 100% on fresh contactor and decreases proportionally with cycle count
- [ ] Verify driver screen warning appears when contactor SOH falls below 10%
- [ ] Confirm build passes with no warnings on all targets