### PR TITLE
cfr26: Update bmsw and bmsb battery config

### DIFF
--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -128,7 +128,7 @@ generate_feature_trees_by_platform(
         },
         PLATFORMS.CFR26: {
             "variants.yaml": "variants.yaml",
-            "BMS_FeatureSels.yaml": "//components/shared:FeatureSels/BMS_CFR25_FeatureSels.yaml",
+            "BMS_FeatureSels.yaml": "//components/shared:FeatureSels/BMS_CFR26_FeatureSels.yaml",
             "BMS_FeatureDefs.yaml": "//components/shared:FeatureDefs/BMS_FeatureDefs.yaml",
             "STM32F105_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F105_FeatureSels.yaml",
             "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",

--- a/components/bms_worker/BUCK
+++ b/components/bms_worker/BUCK
@@ -164,7 +164,7 @@ cxx_library(
     for bms_sels in [
         "//components/shared:FeatureSels/BMS_CFR25_FeatureSels.yaml"
         if vehicle_platform == PLATFORMS.CFR25
-        else "//components/shared:FeatureSels/BMS_CFR25_FeatureSels.yaml"
+        else "//components/shared:FeatureSels/BMS_CFR26_FeatureSels.yaml"
     ]
 ]
 


### PR DESCRIPTION
### Describe changes

Change CFR26 bmsb and bmsw variants to sue the cfr26 battery configuration

### Impact

1. Changes software expectations and limits of cfr26 bms

### Test Plan

- No functional changes, only configuration changes as per the cell manufacturer
- Ensure hex change in expected applications ✅ 
