### PR TITLE
Add vehicle state NVM tracking and crash implausibility fault on boot

### DIFF
--- a/components/vc/pdu/include/crashSensor.h
+++ b/components/vc/pdu/include/crashSensor.h
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "lib_nvm.h"
+#include "app_vehicleState.h"
 #include "LIB_Types.h"
 #include "CANTypes_generated.h"
 
@@ -23,15 +24,18 @@ typedef enum
     CRASHSENSOR_OK,
     CRASHSENSOR_CRASHED,
     CRASHSENSOR_ERROR,
+    CRASHSENSOR_IMPLAUSIBILITY,
 } crashSensor_state_E;
 
 typedef struct
 {
     bool crashLatched;
-    uint8_t reserved[16U];
+    app_vehicleState_state_E vehicleState;
+    uint8_t reserved[15U];
 } LIB_NVM_STORAGE(nvm_crashState_S);
 extern nvm_crashState_S crashState_data;
 
+_Static_assert(sizeof(nvm_crashState_S) == 18U, "NVM deterministic size");
 /******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/

--- a/components/vc/pdu/src/crashSensor.c
+++ b/components/vc/pdu/src/crashSensor.c
@@ -127,15 +127,26 @@ void crashSensor_task(void)
 
     if (cs.sensorState == CRASHSENSOR_INIT)
     {
-        const float32_t vehicleAccel = imu_getAccelNormPeak();
-        if (vehicleStateOk(vehicleAccel) && !imu_isFaulted())
+        const app_vehicleState_state_E nvmVehiclestate = crashState_data.vehicleState;
+        if (nvmVehiclestate == VEHICLESTATE_TS_RUN)
         {
-            cs.sensorState = CRASHSENSOR_OK;
-            drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_VCU_SFTY_EN, DRV_IO_ACTIVE);
+            cs.sensorState = CRASHSENSOR_IMPLAUSIBILITY;
+            app_faultManager_setFaultState(FM_FAULT_VCPDU_CRASHIMPLAUSIBILITY, true);
+            crashState_data.crashLatched = true;
+            lib_nvm_requestWrite(NVM_ENTRYID_CRASH_STATE);
         }
         else
         {
-            cs.sensorState = CRASHSENSOR_ERROR;
+            const float32_t vehicleAccel = imu_getAccelNormPeak();
+            if (vehicleStateOk(vehicleAccel) && !imu_isFaulted())
+            {
+                cs.sensorState = CRASHSENSOR_OK;
+                drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_VCU_SFTY_EN, DRV_IO_ACTIVE);
+            }
+            else
+            {
+                cs.sensorState = CRASHSENSOR_ERROR;
+            }
         }
     }
 
@@ -174,6 +185,7 @@ void crashSensor_task(void)
                 {
                     cs.sensorState = CRASHSENSOR_OK;
                     crashState_data.crashLatched = false;
+                    app_faultManager_setFaultState(FM_FAULT_VCPDU_CRASHIMPLAUSIBILITY, false);
                     lib_nvm_requestWrite(NVM_ENTRYID_CRASH_STATE);
                     cs.accelTripped = 0.0f;
                     cs.accelMax = 0.0f;
@@ -196,6 +208,12 @@ void crashSensor_task(void)
         const drv_io_activeState_E safetyState = cs.sensorState == CRASHSENSOR_OK ? DRV_IO_ACTIVE : DRV_IO_INACTIVE;
         drv_outputAD_setDigitalActiveState(DRV_OUTPUTAD_VCU_SFTY_EN, safetyState);
 #endif
+        const app_vehicleState_state_E currentVehicleState = app_vehicleState_getState();
+        if (currentVehicleState != crashState_data.vehicleState)
+        {
+            crashState_data.vehicleState = currentVehicleState;
+            lib_nvm_requestWrite(NVM_ENTRYID_CRASH_STATE);
+        }
     }
 }
 

--- a/components/vc/pdu/src/lib_nvm_componentSpecific.c
+++ b/components/vc/pdu/src/lib_nvm_componentSpecific.c
@@ -42,6 +42,7 @@ const nvm_imuCalibration_S imuCalibration_default = {
 LIB_NVM_MEMORY_REGION(nvm_imuCalibration_S imuCalibration_data) = { 0U };
 static const nvm_crashState_S crashState_default = {
     .crashLatched = true,
+    .vehicleState = VEHICLESTATE_TS_RUN,
     .reserved = { 0U },
 };
 LIB_NVM_MEMORY_REGION(nvm_crashState_S crashState_data) = { 0U };

--- a/network/definition/data/components/vcpdu/vcpdu-message.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-message.yaml
@@ -18,6 +18,7 @@ messages:
       imuFsmInitFailure:
       imuUncalibrated:
       imuInvalid:
+      crashImplausibility:
 
   udsResponse:
     description: UDS response message from the VCPDU

--- a/network/definition/data/components/vcpdu/vcpdu-signals.yaml
+++ b/network/definition/data/components/vcpdu/vcpdu-signals.yaml
@@ -51,6 +51,10 @@ signals:
     description: Crash sensor state
     discreteValues: crashSensorState
 
+  crashImplausibility:
+    description: NVM vehicle state is in TS_RUN on boot
+    discreteValues: faultStatus
+
   vehicleState:
     description: "Current state of the vehicle"
     discreteValues: vehicleState


### PR DESCRIPTION
### Reason for Change
With the addition of the crash sensor in software, there exists a failure mode where we can experience a crash and immediate loss of power before; therefore, the crash state would not have the chance to be registered in NVM. On the next boot, the system would have no record of this crash and would initialize as normal. To protect against this edge case, vehicle state is now tracked in NVM on every cycle through the crashSensor. If the last known vehicle state was `TS_RUN` in NVM, then we cannot confirm that a crash did not occur. We treat this scenario as a crash implausibility state and force a driver crash reset action before the system can return to normal operations. 

### Changes

1. Added `vehicleState` field to `nvm_crashState_S` to persist vehicle state across power cycles. 
2. Added a static assert to assert that even with added `vehicleState` the struct size is deterministic.
3. In `crashSensor_task`, each loop cycle compares the current vehicle state to the NVM stored state, if the vehicle state has changed, then the change is registered in NVM.
4. On boot, if the vehicle state registered in NVM is `VEHICLESTATE_TS_RUN`, the crash sensor is set to `CRASHSENSOR_IMPLAUSIBILITY`, and a `FM_FAULT_VCPDU_CRASHIMPLAUSIBILITY` is raised
5. On implausibility, `crashLatched` is set to `true` and updated in NVM so that a power cycle _without_ driver reset boots into `CRASHSENSOR_CRASHED` rather than having to reevaluate implausibility. 
6. Driver crash reset clears both `crashLatched` and the implausibility fault and write to NVM

### Test Plan

- [ ] Boot with default NVM (defaults to `VEHICLESTATE_TS_RUN`) and verify `CRASHSENSOR_IMPLAUSIBILITY` state and `crashImplausibility` fault are set.
- [ ] Verify `crashLatched` is written to NVM on implausibility detection.
- [ ] Power cycle _without_ performing a driver reset to verify that the system boots into `CRASHSENSOR_CRASHED`.
- [ ] Perform driver crash reset from implausibility state and verify that the system transitions to `CRASHSENSOR_OK` and that the fault clears.
- [ ] Boot with NVM vehicle state set to a state that is not `VEHICLESTATE_TS_RUN` and verify normal init occurs without implausibility error. 
- [ ] Transition through vehicle states during normal operation and verify that NVM `vehicleState` is being properly registered on each change. 
- [ ] Verify that a clean shutdown from a state that is not `VEHICLESTATE_TS_RUN` followed by a reboot does not trigger implausibility. 
