### PR TITLE
bms_worker: NX3_NEN low on init for variant 0

### DIFF
--- a/components/bms_worker/HW/HW_adc_componentSpecific.c
+++ b/components/bms_worker/HW/HW_adc_componentSpecific.c
@@ -133,6 +133,7 @@ HW_StatusTypeDef_E HW_ADC_init_componentSpecific(void)
     {
         Error_Handler();
     }
+    HW_GPIO_writePin(HW_GPIO_NX3_NEN, false);
 #elif APP_VARIANT_ID == 1U
     sConfig.Channel      = ADC_CHANNEL_TEMP_BOARD;
     sConfig.Rank         = ADC_REGULAR_RANK_5;

--- a/components/bms_worker/src/Environment.c
+++ b/components/bms_worker/src/Environment.c
@@ -135,7 +135,9 @@ static void Environment_Init()
     ENV.fault = false;
     drv_timer_initWithRuntime(&env.timerDisconnected, ENV_ERROR_TIMEOUT_MS);
     drv_timer_initWithRuntime(&env.timerInsufficient, ENV_ERROR_TIMEOUT_MS);
-
+#if APP_VARIANT_ID == 0U
+    HW_GPIO_writePin(HW_GPIO_NX3_NEN, false);
+#endif
     drv_sht40_init(&sht_chip);
 }
 


### PR DESCRIPTION
### Reason for Change

`HW_GPIO_NX3_NEN` is configured with `resetState = HW_GPIO_PINSET` in the GPIO pinmux, which drives the pin high on init via `HW_GPIO_init()`. Since the pin is active low, the NX3 was never being enabled on variant 0 hardware, and no driver was bringing it low after init. It needs to be explicitly driven low during ADC init.

### Changes

1. Assert `HW_GPIO_NX3_NEN` low in `HW_ADC_init_componentSpecific()` under the `APP_VARIANT_ID == 0U` block

### Test Plan

- [ ]  Flash variant 0 hardware and verify NX3 is enabled and functioning after init