### PR TITLE
NVM: Static assertions on struct sizes

### DIFF
--- a/components/bms_boss/include/BMS.h
+++ b/components/bms_boss/include/BMS.h
@@ -104,6 +104,9 @@ extern nvm_bmsbContactorData_S contactor_data;
 
 extern BMSB_S BMS;
 
+NVM_SIZE_ASSERT(nvm_bmsData_S, (4U + (4U * BMS_CONFIGURED_SERIES_SEGMENTS * BMS_CONFIGURED_SERIES_CELLS) + 16U));
+NVM_SIZE_ASSERT(nvm_bmsbContactorData_S, 28U);
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/bms_boss/include/BMS.h
+++ b/components/bms_boss/include/BMS.h
@@ -104,6 +104,8 @@ extern nvm_bmsbContactorData_S contactor_data;
 
 extern BMSB_S BMS;
 
+NVM_SIZE_ASSERT(nvm_bmsbContactorData_S, 28U);
+
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
  ******************************************************************************/

--- a/components/shared/code/DRV/drv_imu.h
+++ b/components/shared/code/DRV/drv_imu.h
@@ -57,6 +57,8 @@ typedef struct
 extern nvm_imuCalibration_S imuCalibration_data;
 extern const nvm_imuCalibration_S imuCalibration_default;
 
+NVM_SIZE_ASSERT(nvm_imuCalibration_S, 60U);
+
 /******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/

--- a/components/shared/code/app/app_vehicleSpeed.h
+++ b/components/shared/code/app/app_vehicleSpeed.h
@@ -60,6 +60,10 @@ typedef struct
 extern nvm_odometer_S odometer_data;
 #endif
 
+#if FEATURE_IS_ENABLED(FEATURE_VEHICLESPEED_LEADER)
+NVM_SIZE_ASSERT(nvm_odometer_S, 24U);
+#endif
+
 /******************************************************************************
  *                              E X T E R N S
  ******************************************************************************/

--- a/components/shared/code/libs/lib_nvm.c
+++ b/components/shared/code/libs/lib_nvm.c
@@ -132,6 +132,13 @@ typedef struct
     storage_t discarded;
 } LIB_NVM_STORAGE(lib_nvm_blockHeader_S);
 
+#if FEATURE_IS_ENABLED(NVM_FLASH_BACKED)
+NVM_SIZE_ASSERT(lib_nvm_recordHeader_S, 12U);
+#else
+NVM_SIZE_ASSERT(lib_nvm_recordHeader_S, 10U);
+#endif
+NVM_SIZE_ASSERT(lib_nvm_blockHeader_S, 6U);
+
 /******************************************************************************
  *                         P R I V A T E  V A R S
  ******************************************************************************/

--- a/components/shared/code/libs/lib_nvm.h
+++ b/components/shared/code/libs/lib_nvm.h
@@ -30,6 +30,7 @@
                                  x
 #define LIB_NVM_MEMORY_REGION_ARRAY(x, size) __attribute__((section(".nvm"))) x##_nvm[size] = { 0U }; \
                                              x[size]
+#define NVM_SIZE_ASSERT(entry, size) _Static_assert(sizeof(entry) == (size), "NVM deterministic size")
 
 /******************************************************************************
  *                              E X T E R N S
@@ -89,6 +90,9 @@ typedef struct
 {
     uint32_t totalCycles;
 } LIB_NVM_STORAGE(lib_nvm_nvmCycleLog_S);
+
+NVM_SIZE_ASSERT(lib_nvm_nvmRecordLog_S, 28U);
+NVM_SIZE_ASSERT(lib_nvm_nvmCycleLog_S, 4U);
 
 /******************************************************************************
  *                           P U B L I C  V A R S

--- a/components/vc/front/include/steeringAngle.h
+++ b/components/vc/front/include/steeringAngle.h
@@ -20,6 +20,8 @@ typedef struct
 } LIB_NVM_STORAGE(nvm_steeringCalibration_S);
 extern nvm_steeringCalibration_S steeringCalibration_data;
 
+NVM_SIZE_ASSERT(nvm_steeringCalibration_S, 24U);
+
 /******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/

--- a/components/vc/pdu/include/crashSensor.h
+++ b/components/vc/pdu/include/crashSensor.h
@@ -35,7 +35,8 @@ typedef struct
 } LIB_NVM_STORAGE(nvm_crashState_S);
 extern nvm_crashState_S crashState_data;
 
-_Static_assert(sizeof(nvm_crashState_S) == 18U, "NVM deterministic size");
+NVM_SIZE_ASSERT(nvm_crashState_S, 18U);
+
 /******************************************************************************
  *            P U B L I C  F U N C T I O N  P R O T O T Y P E S
  ******************************************************************************/


### PR DESCRIPTION
### Reason for Change

NVM structs lacked static size assertions, meaning a developer could modify a struct's layout without a compilation failure. Static assertions have been added to all NVM structs to enforce deterministic sizes at compile time.

### Changes

1. Added `_Static_assert(sizeof(...))` for all NVM structs across the repo to enforce deterministic sizes at compile time

### Test Plan

- [ ]  Build passes for all targets (`cfr25-embedded`, `cfr26-embedded`) with no static assertion failures
