### PR TITLE
Safety session crash reset UDS routine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,12 +465,12 @@ dependencies = [
  "conUDS",
  "env_logger",
  "futures",
+ "libc",
  "log",
  "minijinja",
  "serde",
  "serde_json",
  "serde_yaml",
- "socketcan",
  "tokio",
  "warp",
 ]
@@ -821,6 +821,30 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
 
 [[package]]
 name = "heck"
@@ -1423,6 +1447,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1659,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1751,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1840,6 +1941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +2030,17 @@ dependencies = [
  "nix 0.23.2",
  "regex",
  "winapi",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2453,6 +2571,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,6 +2668,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2998,6 +3170,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/components/vc/pdu/include/crashSensor.h
+++ b/components/vc/pdu/include/crashSensor.h
@@ -47,3 +47,4 @@ float32_t crashSensor_getTrippedAcceleration(void);
 float32_t crashSensor_getMaxAcceleration(void);
 
 void crashSensor_notifyFromImu(void);
+void crashSensor_requestCrashReset(void);

--- a/components/vc/pdu/src/crashSensor.c
+++ b/components/vc/pdu/src/crashSensor.c
@@ -51,6 +51,7 @@ static struct
     float32_t accelTripped;
     uint8_t   missedCycles;
     drv_timer_S calibrationTimer;
+    bool requestCrashReset;
 } cs;
 
 static TaskHandle_t crashSensorTaskHandle = NULL;
@@ -183,7 +184,7 @@ void crashSensor_task(void)
 
                 cs.accelMax = vehicleAccel > cs.accelMax ? vehicleAccel : cs.accelMax;
 
-                if (driverResetting && vehicleOk && !imu_isFaulted())
+                if ((driverResetting || cs.requestCrashReset) && vehicleOk && !imu_isFaulted())
                 {
                     cs.sensorState = CRASHSENSOR_OK;
                     crashState_data.crashLatched = false;
@@ -191,6 +192,7 @@ void crashSensor_task(void)
                     lib_nvm_requestWrite(NVM_ENTRYID_CRASH_STATE);
                     cs.accelTripped = 0.0f;
                     cs.accelMax = 0.0f;
+                    cs.requestCrashReset = false;
                 }
             }
         }
@@ -225,4 +227,9 @@ void crashSensor_notifyFromImu(void)
     {
         (void)xTaskNotifyGive(crashSensorTaskHandle);
     }
+}
+
+void crashSensor_requestCrashReset(void)
+{
+    cs.requestCrashReset = true;
 }

--- a/components/vc/pdu/src/uds_componentSpecific.c
+++ b/components/vc/pdu/src/uds_componentSpecific.c
@@ -28,6 +28,7 @@
 #include "lib_uds.h"
 #include "LIB_app.h"
 #include "Utility.h"
+#include "crashSensor.h"
 
 // system includes
 #include <string.h>
@@ -66,6 +67,35 @@ extern void     isotp_user_debug(const char* message, ...);
  *                     P R I V A T E  F U N C T I O N S
  ******************************************************************************/
 
+static void routine_resetCrash(udsRoutineControlType_E routineControlType, uint8_t *payload, uint8_t payloadLengthBytes)
+{
+    UNUSED(payloadLengthBytes);
+    UNUSED(payload);
+
+    if (udsSrv_getCurrentSession() != UDS_SESSION_TYPE_SAFETY_DIAG)
+    {
+        uds_sendNegativeResponse(
+            UDS_SID_ROUTINE_CONTROL,
+            UDS_NRC_SUB_FUNCTION_NOT_SUPPORTED_SESSION
+        );
+        return;
+    }
+
+    switch (routineControlType)
+    {
+        case UDS_ROUTINE_CONTROL_START:
+            crashSensor_requestCrashReset();
+            uds_sendPositiveResponse(UDS_SID_ROUTINE_CONTROL, UDS_ROUTINE_CONTROL_START, payload, 0x02);
+            break;
+
+        case UDS_ROUTINE_CONTROL_GET_RESULT:
+        case UDS_ROUTINE_CONTROL_STOP:
+        case UDS_ROUTINE_CONTROL_NONE:
+        default:
+            uds_sendNegativeResponse(UDS_SID_ROUTINE_CONTROL, UDS_NRC_SUB_FUNCTION_NOT_SUPPORTED);
+            break;
+    }
+}
 
 /******************************************************************************
  *                       P U B L I C  F U N C T I O N S
@@ -175,6 +205,9 @@ void uds_cb_routineControl(udsRoutineControlType_E routineControlType, uint8_t *
 
     switch (routineId.u16)
     {
+        case 0x1000:
+            routine_resetCrash(routineControlType, payload + 2U, payloadLengthBytes);
+            break;
         default:
             uds_sendNegativeResponse(UDS_SID_ROUTINE_CONTROL, UDS_NRC_SERVICE_NOT_SUPPORTED);
             break;

--- a/drive-stack/car-dashboard/src/lib.rs
+++ b/drive-stack/car-dashboard/src/lib.rs
@@ -1477,6 +1477,10 @@ fn default_session_options() -> Vec<DiagnosticSessionOption> {
             key: "programming".to_string(),
             label: "Programming".to_string(),
         },
+        DiagnosticSessionOption {
+            key: "safety-system".to_string(),
+            label: "Safety Diagnostic".to_string(),
+        },
     ]
 }
 
@@ -2898,5 +2902,13 @@ mod tests {
 
         let snapshot = store.snapshot(now + Duration::from_secs(1));
         assert!(snapshot.controllers[0].faults.is_empty());
+    }
+
+    #[test]
+    fn default_session_options_include_safety_diagnostic() {
+        let sessions = default_session_options();
+        assert!(sessions.iter().any(|session| {
+            session.key == "safety-system" && session.label == "Safety Diagnostic"
+        }));
     }
 }

--- a/drive-stack/conUDS/routines.yml
+++ b/drive-stack/conUDS/routines.yml
@@ -3,3 +3,7 @@ nodes:
     routines:
       resetOdometer:
         id: 0x1000
+  vcpdu:
+    routines:
+      resetCrash:
+        id: 0x1000

--- a/embedded/libs/uds/src/lib_udsServer.c
+++ b/embedded/libs/uds/src/lib_udsServer.c
@@ -246,6 +246,11 @@ static inline void handleDIDRead(udsRequestDesc_S *req)
  */
 static udsResult_E udsSrv_handleReceive(udsRequestDesc_S *req)
 {
+    // Any completed UDS request indicates an active tester connection.
+    // Keeping the session alive only on TesterPresent causes long-running
+    // requests to expire back to default mid-transaction.
+    udsSrv.testerPresentTimerMs = 0U;
+
     switch (req->id)
     {
         case UDS_SID_TESTER_PRESENT:


### PR DESCRIPTION
### Reason for Change

Crash' were only reset able through the driver interface. Ideally, crashes need a specific reset sequence in an elevated diagnostic functionality without driver intervention. Support a diagnostic session backed crash reset routine in UDS 

### Changes

1. Support reset crash UDS routine
2. Extend tester present timeouts to handle valid UDS transactions
3. Display safety diagnostic sessions in the UDS dashboard

### Test Plan

- Run crash reset in default session, ensure it does not succeed :heavy_check_mark: 
- Run safety diagnostic session request, ensure it is accepted and the session returns to default without tester present :heavy_check_mark: 
- Enable persistent tester present and enter a safety diagnostic session :heavy_check_mark: 
- Run the crash reset routine and ensure it succeeds :heavy_check_mark: 
- Ensure the active session stays in a safety session :heavy_check_mark: 
