### PR TITLE
Improve conUDS

### DIFF
--- a/drive-stack/car-dashboard/src/lib.rs
+++ b/drive-stack/car-dashboard/src/lib.rs
@@ -725,6 +725,11 @@ pub async fn run(opts: Opts) -> Result<()> {
         .and(state_filter.clone())
         .and_then(handle_start_tester_present);
 
+    let send_tester_present = warp::path!("api" / "controllers" / String / "tester-present" / "request")
+        .and(warp::post())
+        .and(state_filter.clone())
+        .and_then(handle_send_tester_present);
+
     let stop_tester_present = warp::path!("api" / "controllers" / String / "tester-present")
         .and(warp::delete())
         .and(state_filter.clone())
@@ -885,6 +890,7 @@ pub async fn run(opts: Opts) -> Result<()> {
         .or(run_routine)
         .or(reset_controller)
         .or(flash_controller)
+        .or(send_tester_present)
         .or(start_tester_present)
         .or(stop_tester_present)
         .or(tester_present_state)
@@ -894,7 +900,7 @@ pub async fn run(opts: Opts) -> Result<()> {
         .or(health);
     let addr = ([0, 0, 0, 0], opts.port);
     info!(
-        "starting HTTP server on http://0.0.0.0:{} with routes '/', '/signals', '/controllers/:name', '/api/signals/manifest', '/assets/uPlot.iife.min.js', '/assets/uPlot.min.css', '/assets/signal-cache-worker.js', '/api/controllers/:name/current-session', '/api/controllers/:name/session', '/api/controllers/:name/routines/:routine', '/api/controllers/:name/reset', '/api/controllers/:name/flash', '/api/controllers/:name/tester-present', '/api/controllers/:name/jobs', '/events', '/signal-events', '/healthz'",
+        "starting HTTP server on http://0.0.0.0:{} with routes '/', '/signals', '/controllers/:name', '/api/signals/manifest', '/assets/uPlot.iife.min.js', '/assets/uPlot.min.css', '/assets/signal-cache-worker.js', '/api/controllers/:name/current-session', '/api/controllers/:name/session', '/api/controllers/:name/routines/:routine', '/api/controllers/:name/reset', '/api/controllers/:name/flash', '/api/controllers/:name/tester-present', '/api/controllers/:name/tester-present/request', '/api/controllers/:name/jobs', '/events', '/signal-events', '/healthz'",
         opts.port
     );
     let (_, server) = warp::serve(routes)
@@ -1344,6 +1350,48 @@ async fn handle_start_tester_present(
     let job_id = job.id.clone();
     tokio::spawn(async move {
         run_tester_present_job(state_for_job, capability, job_id, stop_rx).await;
+    });
+
+    Ok(json_success_response(ActionAcceptedResponse {
+        ok: true,
+        job_id: job.id.clone(),
+        job,
+    }))
+}
+
+async fn handle_send_tester_present(
+    controller_name: String,
+    state: AppState,
+) -> Result<warp::reply::Response, Infallible> {
+    let controller_name = controller_name.to_ascii_lowercase();
+    let Some(capability) = state.capabilities.get(&controller_name).cloned() else {
+        return Ok(json_error_response(
+            warp::http::StatusCode::NOT_FOUND,
+            "unknown controller",
+        ));
+    };
+
+    let job = match create_job(
+        &state,
+        &controller_name,
+        "tester-present-request",
+        "Queued tester present with response".to_string(),
+    )
+    .await
+    {
+        Ok(job) => job,
+        Err(error) => {
+            return Ok(json_error_response(
+                warp::http::StatusCode::CONFLICT,
+                &error.to_string(),
+            ));
+        }
+    };
+
+    let state_for_job = state.clone();
+    let job_id = job.id.clone();
+    tokio::spawn(async move {
+        run_tester_present_request_job(state_for_job, capability, job_id).await;
     });
 
     Ok(json_success_response(ActionAcceptedResponse {
@@ -1998,6 +2046,42 @@ async fn run_tester_present_job(
     let _ = state.publish_jobs_if_changed().await;
 }
 
+async fn run_tester_present_request_job(
+    state: AppState,
+    capability: ControllerCapability,
+    job_id: String,
+) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        return;
+    };
+    info!(
+        "starting tester present request job '{}' for controller='{}' on iface='{}'",
+        job_id, capability.name, capability.uds_iface
+    );
+    {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_started(&job_id, "Sending tester present with response".to_string());
+    }
+    let _ = state.publish_jobs_if_changed().await;
+
+    match worker.tester_present(true).await {
+        Ok(response) => {
+            let (detail, payload_hex) = format_tester_present_response(&response);
+            let mut jobs = state.jobs.write().await;
+            jobs.mark_succeeded(&job_id, detail, None, payload_hex);
+        }
+        Err(error) => {
+            let mut jobs = state.jobs.write().await;
+            jobs.mark_failed(&job_id, error.to_string(), None, None);
+        }
+    }
+
+    let _ = state.publish_jobs_if_changed().await;
+}
+
 fn session_key_label(session: DiagnosticSessionKind) -> &'static str {
     match session {
         DiagnosticSessionKind::Default => "Default",
@@ -2038,6 +2122,40 @@ fn format_session_response(response: DiagnosticSessionResponse) -> (String, Opti
             (!payload.is_empty()).then(|| hex_string(&payload)),
         ),
     }
+}
+
+fn format_tester_present_response(response: &[u8]) -> (String, Option<String>) {
+    if response.is_empty() {
+        return ("Tester present sent".to_string(), None);
+    }
+
+    if response[0] == 0x7F {
+        if response.len() >= 3 {
+            return (
+                format!(
+                    "Tester present rejected: NRC 0x{:02X}",
+                    response[2]
+                ),
+                Some(hex_string(response)),
+            );
+        }
+        return (
+            "Tester present rejected: malformed negative response".to_string(),
+            Some(hex_string(response)),
+        );
+    }
+
+    if response[0] == 0x7E {
+        return (
+            "Tester present acknowledged".to_string(),
+            Some(hex_string(response)),
+        );
+    }
+
+    (
+        format!("Unexpected tester present response SID 0x{:02X}", response[0]),
+        Some(hex_string(response)),
+    )
 }
 
 fn format_routine_response(

--- a/drive-stack/car-dashboard/src/lib.rs
+++ b/drive-stack/car-dashboard/src/lib.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use conUDS::config::Config as UdsConfig;
 use conUDS::modules::uds::{
     CurrentDiagnosticSession, DiagnosticSessionKind, DiagnosticSessionResponse,
-    RoutineStartResponse, UdsSession,
+    RoutineStartResponse, UdsWorkerHandle,
 };
 use conUDS::FlashStatus;
 use conUDS::SupportedResetTypes;
@@ -314,6 +314,7 @@ struct CurrentSessionResponse {
 struct AppState {
     store: Arc<RwLock<DashboardStore>>,
     capabilities: Arc<BTreeMap<String, ControllerCapability>>,
+    uds_workers: Arc<BTreeMap<String, UdsWorkerHandle>>,
     signal_manifest: Arc<SignalManifestResponse>,
     veh_iface: Arc<String>,
     body_iface: Arc<Option<String>>,
@@ -473,7 +474,9 @@ impl JobStore {
             job.payload_text = payload_text;
             job.payload_hex = payload_hex;
             job.finished_at_ms = Some(now_ms());
-            self.active_by_controller.remove(&job.controller);
+            if self.active_by_controller.get(&job.controller) == Some(&job.id) {
+                self.active_by_controller.remove(&job.controller);
+            }
         }
     }
 
@@ -490,7 +493,9 @@ impl JobStore {
             job.payload_text = payload_text;
             job.payload_hex = payload_hex;
             job.finished_at_ms = Some(now_ms());
-            self.active_by_controller.remove(&job.controller);
+            if self.active_by_controller.get(&job.controller) == Some(&job.id) {
+                self.active_by_controller.remove(&job.controller);
+            }
         }
     }
 
@@ -573,6 +578,22 @@ pub async fn run(opts: Opts) -> Result<()> {
     )?);
     let signal_manifest = Arc::new(build_signal_manifest());
     let controller_names = capabilities.keys().cloned().collect::<Vec<_>>();
+    let uds_workers = Arc::new(
+        capabilities
+            .iter()
+            .map(|(name, capability)| {
+                (
+                    name.clone(),
+                    UdsWorkerHandle::new(
+                        capability.uds_iface.clone(),
+                        capability.request_id,
+                        capability.response_id,
+                        false,
+                    ),
+                )
+            })
+            .collect::<BTreeMap<_, _>>(),
+    );
     info!(
         "loaded {} deployable controller(s) from UDS manifest: {}",
         controller_names.len(),
@@ -594,6 +615,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     let state = AppState {
         store,
         capabilities,
+        uds_workers,
         signal_manifest,
         veh_iface: Arc::new(opts.veh_iface.clone()),
         body_iface: Arc::new(opts.body_iface.clone()),
@@ -1003,22 +1025,20 @@ async fn handle_current_session(
     state: AppState,
 ) -> Result<warp::reply::Response, Infallible> {
     let controller_name = controller_name.to_ascii_lowercase();
-    let Some(capability) = state.capabilities.get(&controller_name).cloned() else {
+    if !state.capabilities.contains_key(&controller_name) {
         return Ok(json_error_response(
             warp::http::StatusCode::NOT_FOUND,
             "unknown controller",
         ));
+    }
+    let Some(worker) = state.uds_workers.get(&controller_name).cloned() else {
+        return Ok(json_error_response(
+            warp::http::StatusCode::BAD_GATEWAY,
+            "UDS worker unavailable for controller",
+        ));
     };
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-    let result = uds.read_current_session().await;
-    uds.teardown().await;
+    let result = worker.read_current_session().await;
 
     let session = match result {
         Ok(session) => session,
@@ -1643,6 +1663,12 @@ async fn run_session_job(
     job_id: String,
     session: DiagnosticSessionKind,
 ) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        return;
+    };
     info!(
         "starting session job '{}' for controller='{}' session='{:?}' on iface='{}'",
         job_id, capability.name, session, capability.uds_iface
@@ -1656,15 +1682,7 @@ async fn run_session_job(
     }
     let _ = state.publish_jobs_if_changed().await;
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-    let result = uds.client.enter_diagnostic_session(session).await;
-    uds.teardown().await;
+    let result = worker.enter_diagnostic_session(session).await;
 
     match result {
         Ok(response) => {
@@ -1690,6 +1708,12 @@ async fn run_routine_job(
     routine: RoutineCapability,
     payload: Option<Vec<u8>>,
 ) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        return;
+    };
     info!(
         "starting routine job '{}' for controller='{}' routine='{}' on iface='{}'",
         job_id, capability.name, routine.name, capability.uds_iface
@@ -1717,15 +1741,7 @@ async fn run_routine_job(
         }
     };
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-    let result = uds.client.routine_start(routine_id, payload).await;
-    uds.teardown().await;
+    let result = worker.routine_start(routine_id, payload).await;
 
     match result {
         Ok(response) => {
@@ -1751,6 +1767,12 @@ async fn run_reset_job(
     job_id: String,
     reset_type: SupportedResetTypes,
 ) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        return;
+    };
     let reset_label = reset_key_label(&reset_type).to_string();
     info!(
         "starting reset job '{}' for controller='{}' reset='{}' on iface='{}'",
@@ -1765,15 +1787,7 @@ async fn run_reset_job(
     }
     let _ = state.publish_jobs_if_changed().await;
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-    let result = uds.reset_node(reset_type).await;
-    uds.teardown().await;
+    let result = worker.reset_node(reset_type).await;
 
     match result {
         Ok(()) => {
@@ -1801,6 +1815,13 @@ async fn run_flash_job(
     firmware_path: PathBuf,
     firmware_name: String,
 ) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        let _ = fs::remove_file(&firmware_path);
+        return;
+    };
     info!(
         "starting flash job '{}' for controller='{}' file='{}' on iface='{}'",
         job_id, capability.name, firmware_name, capability.uds_iface
@@ -1811,41 +1832,41 @@ async fn run_flash_job(
     }
     let _ = state.publish_jobs_if_changed().await;
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-    let result = uds.download_app_to_target(&firmware_path, false).await;
-    uds.teardown().await;
+    let result = worker.download_app_to_target(firmware_path.clone(), false).await;
 
     {
         let mut jobs = state.jobs.write().await;
-        match result.result {
-            FlashStatus::DownloadSuccess => jobs.mark_succeeded(
-                &job_id,
-                format!(
-                    "Flash completed from {firmware_name} in {:.2}s",
-                    result.duration.as_secs_f32()
+        match result {
+            Ok(result) => match result.result {
+                FlashStatus::DownloadSuccess => jobs.mark_succeeded(
+                    &job_id,
+                    format!(
+                        "Flash completed from {firmware_name} in {:.2}s",
+                        result.duration.as_secs_f32()
+                    ),
+                    None,
+                    None,
                 ),
-                None,
-                None,
-            ),
-            FlashStatus::CrcMatch => jobs.mark_succeeded(
-                &job_id,
-                format!("Flash skipped for {firmware_name}: CRC already matches"),
-                None,
-                None,
-            ),
-            FlashStatus::Skipped => jobs.mark_succeeded(
-                &job_id,
-                format!("Flash skipped for {firmware_name}"),
-                None,
-                None,
-            ),
-            FlashStatus::Failed(error) => jobs.mark_failed(
+                FlashStatus::CrcMatch => jobs.mark_succeeded(
+                    &job_id,
+                    format!("Flash skipped for {firmware_name}: CRC already matches"),
+                    None,
+                    None,
+                ),
+                FlashStatus::Skipped => jobs.mark_succeeded(
+                    &job_id,
+                    format!("Flash skipped for {firmware_name}"),
+                    None,
+                    None,
+                ),
+                FlashStatus::Failed(error) => jobs.mark_failed(
+                    &job_id,
+                    format!("Flash failed for {firmware_name}: {error}"),
+                    None,
+                    None,
+                ),
+            },
+            Err(error) => jobs.mark_failed(
                 &job_id,
                 format!("Flash failed for {firmware_name}: {error}"),
                 None,
@@ -1863,6 +1884,14 @@ async fn run_tester_present_job(
     job_id: String,
     stop_rx: oneshot::Receiver<String>,
 ) {
+    let Some(worker) = state.uds_workers.get(&capability.name).cloned() else {
+        let mut jobs = state.jobs.write().await;
+        jobs.mark_failed(&job_id, "UDS worker unavailable for controller".to_string(), None, None);
+        let _ = state.publish_jobs_if_changed().await;
+        let mut tester_present = state.tester_present.lock().await;
+        tester_present.remove(&capability.name);
+        return;
+    };
     info!(
         "starting persistent tester present job '{}' for controller='{}' on iface='{}'",
         job_id, capability.name, capability.uds_iface
@@ -1876,15 +1905,7 @@ async fn run_tester_present_job(
     }
     let _ = state.publish_jobs_if_changed().await;
 
-    let mut uds = UdsSession::new(
-        &capability.uds_iface,
-        capability.request_id,
-        capability.response_id,
-        false,
-    )
-    .await;
-
-    match uds.client.start_persistent_tp().await {
+    match worker.start_persistent_tp().await {
         Ok(()) => {
             {
                 let mut jobs = state.jobs.write().await;
@@ -1908,7 +1929,6 @@ async fn run_tester_present_job(
                         );
                     }
                     let _ = state.publish_jobs_if_changed().await;
-                    uds.teardown().await;
                     let mut tester_present = state.tester_present.lock().await;
                     tester_present.remove(&capability.name);
                     return;
@@ -1923,7 +1943,7 @@ async fn run_tester_present_job(
             }
             let _ = state.publish_jobs_if_changed().await;
 
-            if let Err(error) = uds.client.stop_persistent_tp().await {
+            if let Err(error) = worker.stop_persistent_tp().await {
                 {
                     let mut jobs = state.jobs.write().await;
                     jobs.mark_failed(
@@ -1973,9 +1993,9 @@ async fn run_tester_present_job(
         }
     }
 
-    uds.teardown().await;
     let mut tester_present = state.tester_present.lock().await;
     tester_present.remove(&capability.name);
+    let _ = state.publish_jobs_if_changed().await;
 }
 
 fn session_key_label(session: DiagnosticSessionKind) -> &'static str {

--- a/drive-stack/car-dashboard/templates/controller.html
+++ b/drive-stack/car-dashboard/templates/controller.html
@@ -27,12 +27,18 @@
       <div id="operation-feedback" class="feedback" hidden></div>
       <div class="ops-grid">
         <form id="tester-present-form" class="stack-form">
-          <label class="field-label" for="tester-present-enabled">Persistent tester present</label>
+          <label class="field-label" for="tester-present-enabled">Persistent Tester Present</label>
           <div class="inline-field">
             <label class="checkbox-field" for="tester-present-enabled">
               <input id="tester-present-enabled" type="checkbox">
-              <span>Tester Present Enabled</span>
+              <span>Persistent Tester Present Enabled</span>
             </label>
+          </div>
+        </form>
+        <form id="tester-present-request-form" class="stack-form">
+          <label class="field-label" for="tester-present-request-button">Tester Present With Response</label>
+          <div class="inline-field">
+            <button id="tester-present-request-button" type="submit">Send Tester Present</button>
           </div>
         </form>
         <form id="reset-form" class="stack-form">
@@ -178,6 +184,8 @@
     const sessionForm = document.getElementById("session-form");
     const resetForm = document.getElementById("reset-form");
     const testerPresentForm = document.getElementById("tester-present-form");
+    const testerPresentRequestForm = document.getElementById("tester-present-request-form");
+    const testerPresentRequestButton = document.getElementById("tester-present-request-button");
     const testerPresentEnabled = document.getElementById("tester-present-enabled");
     const flashForm = document.getElementById("flash-form");
     const routineForm = document.getElementById("routine-form");
@@ -483,6 +491,27 @@
         setFeedback(error.message, true);
       } finally {
         testerPresentEnabled.disabled = false;
+      }
+    });
+
+    testerPresentRequestForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      testerPresentRequestButton.disabled = true;
+      try {
+        const response = await fetch(
+          `/api/controllers/${encodeURIComponent(controllerName)}/tester-present/request`,
+          { method: "POST" },
+        );
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error || "Request failed");
+        }
+        mergeJob(payload.job);
+        setFeedback(`Tester present request queued: ${payload.job_id}`, false);
+      } catch (error) {
+        setFeedback(error.message, true);
+      } finally {
+        testerPresentRequestButton.disabled = false;
       }
     });
 

--- a/drive-stack/conUDS/src/lib.rs
+++ b/drive-stack/conUDS/src/lib.rs
@@ -71,10 +71,6 @@ pub enum FlashStatus {
     Skipped,
 }
 
-pub enum PrdCmd {
-    PersistentTesterPresent(bool),
-}
-
 pub struct UdsDownloadStart {
     pub compression: u8,
     pub encryption: u8,

--- a/drive-stack/conUDS/src/main.rs
+++ b/drive-stack/conUDS/src/main.rs
@@ -5,11 +5,10 @@ use std::time::{Duration, Instant};
 use log::{debug, error, info};
 use simplelog::{CombinedLogger, TermLogger, WriteLogger};
 
-use conUDS::SupportedResetTypes;
 use conUDS::arguments::{ArgSubCommands, Arguments};
 use conUDS::config::Config;
 use conUDS::modules::uds::{
-    CurrentDiagnosticSession, DiagnosticSessionResponse, RoutineStartResponse, UdsSession,
+    CurrentDiagnosticSession, DiagnosticSessionResponse, RoutineStartResponse, UdsWorkerHandle,
 };
 use conUDS::{FlashStatus, UpdateResult};
 
@@ -92,15 +91,20 @@ async fn main() {
 
                 info!("Downloading binary {:?} to node '{}'", bin, node);
 
-                let mut uds = UdsSession::new(
-                    &args.device,
+                let uds = UdsWorkerHandle::new(
+                    args.device.clone(),
                     uds_node.request_id,
                     uds_node.response_id,
                     false,
-                )
-                .await;
-                let result = uds.download_app_to_target(&bin, true).await;
-                uds.teardown().await;
+                );
+                let result = uds
+                    .download_app_to_target(bin.clone(), true)
+                    .await
+                    .unwrap_or_else(|e| UpdateResult {
+                        bin: bin.clone(),
+                        result: FlashStatus::Failed(e.to_string()),
+                        duration: Duration::from_secs(0),
+                    });
 
                 results.push((node.clone(), result));
             }
@@ -119,13 +123,12 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
             info!(
                 "Performing {:?} reset for node '{}'",
                 reset.reset_type, node
@@ -133,7 +136,6 @@ async fn main() {
             if let Err(e) = uds.reset_node(reset.reset_type).await {
                 error!("Error while resetting ecu: {}", e);
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::Download(dl) => {
@@ -146,31 +148,26 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
-                dl.no_skip,
-            )
-            .await;
+                false,
+            );
             info!("Downloading binary {:?} to node '{}'", dl.binary, node);
-
-            if let Err(e) = uds.reset_node(SupportedResetTypes::Hard).await {
-                error!("Error while resetting ecu: {}", e);
-                if !dl.no_skip {
-                    return;
-                }
-            }
-            if let FlashStatus::Failed(e) = uds
-                .download_app_to_target(&dl.binary, !dl.no_skip)
+            match uds
+                .download_app_to_target(dl.binary.clone(), !dl.no_skip)
                 .await
-                .result
             {
-                error!("Download failed for node '{}': {}", node, e);
-            } else {
-                info!("Download successful for node '{}'...", node);
+                Ok(result) => {
+                    if let FlashStatus::Failed(e) = result.result {
+                        error!("Download failed for node '{}': {}", node, e);
+                    } else {
+                        info!("Download successful for node '{}'...", node);
+                    }
+                }
+                Err(e) => error!("Download failed for node '{}': {}", node, e),
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::BootloaderDownload(dl) => {
@@ -183,18 +180,16 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
             info!("Downloading bootloader {:?} to node '{}'", dl.binary, node);
-            if let Err(e) = uds.file_download(&dl.binary, 0x08000000).await {
+            if let Err(e) = uds.file_download(dl.binary.clone(), 0x08000000).await {
                 error!("While downloading bootloader: {}", e);
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::ReadDID(did) => {
@@ -207,20 +202,18 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
             info!(
                 "Performing DID read on id {:#?} for node '{}'",
                 did.id, node
             );
             let id = u16::from_str_radix(&did.id, 16).unwrap();
-            let resp = uds.client.did_read(id).await;
-            uds.teardown().await;
+            let resp = uds.did_read(id).await;
             println!("{:?}", resp);
         }
 
@@ -234,13 +227,12 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
             match uds.read_current_session().await {
                 Ok(session) => println!("{}", fmt_current_session(session)),
                 Err(e) => error!(
@@ -248,7 +240,6 @@ async fn main() {
                     node, e
                 ),
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::SetSession(session) => {
@@ -262,14 +253,13 @@ async fn main() {
             });
 
             let target_session = session.session.into();
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
-            match uds.client.enter_diagnostic_session(target_session).await {
+            );
+            match uds.enter_diagnostic_session(target_session).await {
                 Ok(resp) => println!("{}", fmt_diagnostic_session_response(&resp)),
                 Err(e) => error!(
                     "Failed to change diagnostic session for node '{}' to '{}': {}",
@@ -278,7 +268,6 @@ async fn main() {
                     e
                 ),
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::PersistentTesterPresent(_) => {
@@ -291,20 +280,18 @@ async fn main() {
                 std::process::exit(1)
             });
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
 
             if let Err(e) = uds.start_persistent_tp().await {
                 error!(
                     "Failed to start persistent tester present for node '{}': {}",
                     node, e
                 );
-                uds.teardown().await;
                 std::process::exit(1);
             }
 
@@ -323,7 +310,6 @@ async fn main() {
                     node, e
                 );
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::RoutineStart(routine) => {
@@ -345,22 +331,20 @@ async fn main() {
                 std::process::exit(1)
             };
 
-            let mut uds = UdsSession::new(
-                &args.device,
+            let uds = UdsWorkerHandle::new(
+                args.device.clone(),
                 uds_node.request_id,
                 uds_node.response_id,
                 true,
-            )
-            .await;
+            );
             info!(
                 "Starting routine '{}' (0x{:04X}) for node '{}'",
                 routine.routine, routine_id, node
             );
-            match uds.client.routine_start(routine_id, None).await {
+            match uds.routine_start(routine_id, None).await {
                 Ok(resp) => println!("{}", fmt_routine_start_response(&resp)),
                 Err(e) => error!("While starting routine '{}': {}", routine.routine, e),
             }
-            uds.teardown().await;
         }
 
         ArgSubCommands::RoutineList(_) => {

--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -772,6 +772,7 @@ async fn worker_download_app_to_target(
     persistent_tp: &mut Option<PersistentTpTask>,
 ) -> UpdateResult {
     let node_start = Instant::now();
+    let mut node_crc: Option<u32> = None;
 
     if skip {
         let mut file = File::open(binary_path).expect("Binary does not exist!");
@@ -783,14 +784,15 @@ async fn worker_download_app_to_target(
 
         let crc = match get_app_crc(uds).await {
             Err(e) => {
-                let node_dur = node_start.elapsed();
-                return UpdateResult {
-                    bin: binary_path.to_path_buf(),
-                    result: FlashStatus::Failed(format!("{:?}", e)),
-                    duration: node_dur,
-                };
+                info!(
+                    "CRC read failed before download ({e:?}); continuing with download path"
+                );
+                0
             }
-            Ok(crc) => crc,
+            Ok(crc) => {
+                node_crc = Some(crc);
+                crc
+            }
         };
 
         if crc == app_crc {
@@ -806,6 +808,31 @@ async fn worker_download_app_to_target(
                 crc, app_crc
             );
         }
+    } else if let Ok(crc) = get_app_crc(uds).await {
+        node_crc = Some(crc);
+    }
+
+    if node_crc == Some(0xffff_ffff) {
+        info!("ECU appears to already be in bootloader; starting download without reset");
+        let result = match uds.file_download(binary_path, 0x08002000).await {
+            Ok(()) => {
+                let node_dur = node_start.elapsed();
+                UpdateResult {
+                    bin: binary_path.to_path_buf(),
+                    result: FlashStatus::DownloadSuccess,
+                    duration: node_dur,
+                }
+            }
+            Err(e) => {
+                let node_dur = node_start.elapsed();
+                UpdateResult {
+                    bin: binary_path.to_path_buf(),
+                    result: FlashStatus::Failed(format!("Error downloading binary: '{}'", e)),
+                    duration: node_dur,
+                }
+            }
+        };
+        return result;
     }
 
     let restore_persistent_tp_after_download = persistent_tp.is_some();

--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -291,6 +291,10 @@ enum UdsWorkerCommand {
         did: u16,
         resp: oneshot::Sender<Result<Vec<u8>, String>>,
     },
+    TesterPresent {
+        response_required: bool,
+        resp: oneshot::Sender<Result<Vec<u8>, String>>,
+    },
     ReadCurrentSession {
         resp: oneshot::Sender<Result<CurrentDiagnosticSession, String>>,
     },
@@ -405,6 +409,10 @@ impl UdsSession {
             Some(error) => anyhow!("failed to read DID 0x{did:04X}: {error:?}"),
             None => anyhow!("failed to read DID 0x{did:04X}"),
         })
+    }
+
+    pub async fn tester_present(&mut self, response_required: bool) -> Result<Vec<u8>> {
+        self.client.tester_present(response_required).await
     }
 
     pub async fn enter_diagnostic_session(
@@ -539,6 +547,16 @@ impl UdsWorkerHandle {
                     UdsWorkerCommand::DidRead { did, resp } => {
                         let _ = resp.send(uds.did_read(did).await.map_err(|e| e.to_string()));
                     }
+                    UdsWorkerCommand::TesterPresent {
+                        response_required,
+                        resp,
+                    } => {
+                        let _ = resp.send(
+                            uds.tester_present(response_required)
+                                .await
+                                .map_err(|e| e.to_string()),
+                        );
+                    }
                     UdsWorkerCommand::ReadCurrentSession { resp } => {
                         let _ = resp.send(uds.read_current_session().await.map_err(|e| e.to_string()));
                     }
@@ -615,6 +633,20 @@ impl UdsWorkerHandle {
         let (tx, rx) = oneshot::channel();
         self.tx
             .send(UdsWorkerCommand::ReadCurrentSession { resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn tester_present(&self, response_required: bool) -> Result<Vec<u8>> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::TesterPresent {
+                response_required,
+                resp: tx,
+            })
             .await
             .map_err(|_| anyhow!("UDS worker is unavailable"))?;
         rx.await
@@ -908,6 +940,18 @@ impl UdsClient {
     /// Create a UDS client
     pub fn new(uds_queue_tx: mpsc::Sender<CanioCmd>) -> Self {
         Self { uds_queue_tx }
+    }
+
+    pub async fn tester_present(&mut self, response_required: bool) -> Result<Vec<u8>> {
+        let payload = UDSProtocol::create_tp_msg(response_required).to_bytes();
+        if response_required {
+            CanioCmd::send_recv(&payload, self.uds_queue_tx.clone(), 50).await
+        } else {
+            self.uds_queue_tx
+                .send(CanioCmd::UdsCmdNoResponse(payload))
+                .await?;
+            Ok(Vec::new())
+        }
     }
 
     pub async fn read_current_session(&mut self) -> Result<CurrentDiagnosticSession> {

--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -22,7 +22,7 @@ use ecu_diagnostics::dynamic_diag::EcuNRC;
 use ecu_diagnostics::uds::UDSProtocol;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, error, info};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::CRC8;
@@ -287,6 +287,50 @@ pub struct UdsSession {
     interactive_session: bool,
 }
 
+enum UdsWorkerCommand {
+    DidRead {
+        did: u16,
+        resp: oneshot::Sender<Result<Vec<u8>, String>>,
+    },
+    ReadCurrentSession {
+        resp: oneshot::Sender<Result<CurrentDiagnosticSession, String>>,
+    },
+    EnterDiagnosticSession {
+        session: DiagnosticSessionKind,
+        resp: oneshot::Sender<Result<DiagnosticSessionResponse, String>>,
+    },
+    RoutineStart {
+        routine_id: u16,
+        data: Option<Vec<u8>>,
+        resp: oneshot::Sender<Result<RoutineStartResponse, String>>,
+    },
+    ResetNode {
+        reset_type: SupportedResetTypes,
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+    StartPersistentTp {
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+    StopPersistentTp {
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+    DownloadApp {
+        binary_path: PathBuf,
+        skip: bool,
+        resp: oneshot::Sender<Result<UpdateResult, String>>,
+    },
+    FileDownload {
+        binary_path: PathBuf,
+        address: u32,
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+}
+
+#[derive(Clone)]
+pub struct UdsWorkerHandle {
+    tx: mpsc::Sender<UdsWorkerCommand>,
+}
+
 impl UdsSession {
     pub async fn new(
         device: &str,
@@ -354,6 +398,28 @@ impl UdsSession {
 
     pub async fn read_current_session(&mut self) -> Result<CurrentDiagnosticSession> {
         self.client.read_current_session().await
+    }
+
+    pub async fn did_read(&mut self, did: u16) -> Result<Vec<u8>> {
+        self.client.did_read(did).await.map_err(|error| match error {
+            Some(error) => anyhow!("failed to read DID 0x{did:04X}: {error:?}"),
+            None => anyhow!("failed to read DID 0x{did:04X}"),
+        })
+    }
+
+    pub async fn enter_diagnostic_session(
+        &mut self,
+        session: DiagnosticSessionKind,
+    ) -> Result<DiagnosticSessionResponse> {
+        self.client.enter_diagnostic_session(session).await
+    }
+
+    pub async fn routine_start(
+        &mut self,
+        routine_id: u16,
+        data: Option<Vec<u8>>,
+    ) -> Result<RoutineStartResponse> {
+        self.client.routine_start(routine_id, data).await
     }
 
     pub async fn start_persistent_tp(&mut self) -> Result<()> {
@@ -457,6 +523,216 @@ impl UdsSession {
     }
 }
 
+impl UdsWorkerHandle {
+    pub fn new(
+        device: String,
+        request_id: u32,
+        response_id: u32,
+        is_interactive: bool,
+    ) -> Self {
+        let (tx, mut rx) = mpsc::channel(32);
+        tokio::spawn(async move {
+            let mut session: Option<UdsSession> = None;
+
+            while let Some(cmd) = rx.recv().await {
+                if session.is_none() {
+                    session = Some(
+                        UdsSession::new(&device, request_id, response_id, is_interactive).await,
+                    );
+                }
+                let uds = session.as_mut().expect("session initialized");
+
+                match cmd {
+                    UdsWorkerCommand::DidRead { did, resp } => {
+                        let _ = resp.send(uds.did_read(did).await.map_err(|e| e.to_string()));
+                    }
+                    UdsWorkerCommand::ReadCurrentSession { resp } => {
+                        let _ = resp.send(uds.read_current_session().await.map_err(|e| e.to_string()));
+                    }
+                    UdsWorkerCommand::EnterDiagnosticSession { session, resp } => {
+                        let _ = resp.send(
+                            uds.enter_diagnostic_session(session)
+                                .await
+                                .map_err(|e| e.to_string()),
+                        );
+                    }
+                    UdsWorkerCommand::RoutineStart {
+                        routine_id,
+                        data,
+                        resp,
+                    } => {
+                        let _ = resp.send(
+                            uds.routine_start(routine_id, data)
+                                .await
+                                .map_err(|e| e.to_string()),
+                        );
+                    }
+                    UdsWorkerCommand::ResetNode { reset_type, resp } => {
+                        let _ = resp.send(uds.reset_node(reset_type).await.map_err(|e| e.to_string()));
+                    }
+                    UdsWorkerCommand::StartPersistentTp { resp } => {
+                        let _ =
+                            resp.send(uds.start_persistent_tp().await.map_err(|e| e.to_string()));
+                    }
+                    UdsWorkerCommand::StopPersistentTp { resp } => {
+                        let _ =
+                            resp.send(uds.stop_persistent_tp().await.map_err(|e| e.to_string()));
+                    }
+                    UdsWorkerCommand::DownloadApp {
+                        binary_path,
+                        skip,
+                        resp,
+                    } => {
+                        let _ = resp.send(Ok(uds.download_app_to_target(&binary_path, skip).await));
+                    }
+                    UdsWorkerCommand::FileDownload {
+                        binary_path,
+                        address,
+                        resp,
+                    } => {
+                        let _ = resp.send(
+                            uds.file_download(&binary_path, address)
+                                .await
+                                .map_err(|e| e.to_string()),
+                        );
+                    }
+                }
+            }
+
+            if let Some(session) = session {
+                session.teardown().await;
+            }
+        });
+
+        Self { tx }
+    }
+
+    pub async fn read_current_session(&self) -> Result<CurrentDiagnosticSession> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::ReadCurrentSession { resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn did_read(&self, did: u16) -> Result<Vec<u8>> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::DidRead { did, resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn enter_diagnostic_session(
+        &self,
+        session: DiagnosticSessionKind,
+    ) -> Result<DiagnosticSessionResponse> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::EnterDiagnosticSession { session, resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn routine_start(
+        &self,
+        routine_id: u16,
+        data: Option<Vec<u8>>,
+    ) -> Result<RoutineStartResponse> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::RoutineStart {
+                routine_id,
+                data,
+                resp: tx,
+            })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn reset_node(&self, reset_type: SupportedResetTypes) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::ResetNode {
+                reset_type,
+                resp: tx,
+            })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn start_persistent_tp(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::StartPersistentTp { resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn stop_persistent_tp(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::StopPersistentTp { resp: tx })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn download_app_to_target(
+        &self,
+        binary_path: PathBuf,
+        skip: bool,
+    ) -> Result<UpdateResult> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::DownloadApp {
+                binary_path,
+                skip,
+                resp: tx,
+            })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+
+    pub async fn file_download(&self, binary_path: PathBuf, address: u32) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(UdsWorkerCommand::FileDownload {
+                binary_path,
+                address,
+                resp: tx,
+            })
+            .await
+            .map_err(|_| anyhow!("UDS worker is unavailable"))?;
+        rx.await
+            .map_err(|_| anyhow!("UDS worker response channel closed"))?
+            .map_err(|e| anyhow!(e))
+    }
+}
+
 /// CANIO task
 ///
 /// Owns the CAN hardware and handles all transmitting and receiving functions
@@ -499,12 +775,11 @@ async fn tsk_10ms(
             }
         } else {
             if send_tp {
-                let _resp = CanioCmd::send_recv(
-                    &UDSProtocol::create_tp_msg(true).to_bytes(),
-                    uds_queue.clone(),
-                    10,
-                )
-                .await;
+                let _ = uds_queue
+                    .send(CanioCmd::UdsCmdNoResponse(
+                        UDSProtocol::create_tp_msg(false).to_bytes(),
+                    ))
+                    .await;
             }
         }
 

--- a/drive-stack/conUDS/src/modules/uds.rs
+++ b/drive-stack/conUDS/src/modules/uds.rs
@@ -31,7 +31,7 @@ use crate::SupportedDiagnosticSessions;
 use crate::SupportedResetTypes;
 use crate::UdsDownloadStart;
 use crate::modules::canio::CANIO;
-use crate::{CanioCmd, PrdCmd};
+use crate::CanioCmd;
 use crate::{FlashStatus, UpdateResult};
 
 const UDS_DID_CRC: u16 = 0x03;
@@ -276,14 +276,13 @@ fn decode_routine_payload_text(payload: &[u8]) -> Option<String> {
 
 #[derive(Debug)]
 pub struct UdsClient {
-    cmd_queue_tx: mpsc::Sender<PrdCmd>,
     uds_queue_tx: mpsc::Sender<CanioCmd>,
 }
 
 pub struct UdsSession {
     pub client: UdsClient,
     exit: Arc<Mutex<bool>>,
-    threads: [JoinHandle<Result<()>>; 2],
+    threads: [JoinHandle<Result<()>>; 1],
     interactive_session: bool,
 }
 
@@ -331,6 +330,11 @@ pub struct UdsWorkerHandle {
     tx: mpsc::Sender<UdsWorkerCommand>,
 }
 
+struct PersistentTpTask {
+    stop_tx: oneshot::Sender<()>,
+    handle: JoinHandle<()>,
+}
+
 impl UdsSession {
     pub async fn new(
         device: &str,
@@ -340,12 +344,10 @@ impl UdsSession {
     ) -> Self {
         let exit = Arc::new(Mutex::new(bool::default()));
         let app_canio = Arc::clone(&exit);
-        let app_10ms = Arc::clone(&exit);
 
         let (uds_queue_tx, uds_queue_rx) = mpsc::channel::<CanioCmd>(100);
-        let (cmd_queue_tx, mut cmd_queue_rx) = mpsc::channel::<PrdCmd>(10);
 
-        let uds_client = UdsClient::new(cmd_queue_tx.clone(), uds_queue_tx.clone());
+        let uds_client = UdsClient::new(uds_queue_tx.clone());
         debug!("UDS client initialized: {:#?}", uds_client);
 
         let canio = {
@@ -362,12 +364,10 @@ impl UdsSession {
 
         debug!("Spawning threads");
         let t1 = tokio::spawn(async move { tsk_canio(app_canio, canio).await });
-        let t2 =
-            tokio::spawn(async move { tsk_10ms(app_10ms, &mut cmd_queue_rx, uds_queue_tx).await });
         Self {
             exit: exit,
             client: uds_client,
-            threads: [t1, t2],
+            threads: [t1],
             interactive_session: is_interactive,
         }
     }
@@ -420,14 +420,6 @@ impl UdsSession {
         data: Option<Vec<u8>>,
     ) -> Result<RoutineStartResponse> {
         self.client.routine_start(routine_id, data).await
-    }
-
-    pub async fn start_persistent_tp(&mut self) -> Result<()> {
-        self.client.start_persistent_tp().await
-    }
-
-    pub async fn stop_persistent_tp(&mut self) -> Result<()> {
-        self.client.stop_persistent_tp().await
     }
 
     pub async fn file_download(&mut self, path: &PathBuf, address: u32) -> Result<()> {
@@ -487,8 +479,8 @@ impl UdsSession {
             }
         }
 
-        let _ = self.client.start_persistent_tp().await;
         if !self.interactive_session {
+            let _ = self.client.tester_present(false).await;
             if let Err(_) = self
                 .client
                 .ecu_reset(SupportedResetTypes::Hard, self.interactive_session)
@@ -533,6 +525,7 @@ impl UdsWorkerHandle {
         let (tx, mut rx) = mpsc::channel(32);
         tokio::spawn(async move {
             let mut session: Option<UdsSession> = None;
+            let mut persistent_tp: Option<PersistentTpTask> = None;
 
             while let Some(cmd) = rx.recv().await {
                 if session.is_none() {
@@ -571,19 +564,29 @@ impl UdsWorkerHandle {
                         let _ = resp.send(uds.reset_node(reset_type).await.map_err(|e| e.to_string()));
                     }
                     UdsWorkerCommand::StartPersistentTp { resp } => {
-                        let _ =
-                            resp.send(uds.start_persistent_tp().await.map_err(|e| e.to_string()));
+                        if persistent_tp.is_none() {
+                            persistent_tp = Some(spawn_persistent_tp_task(uds.client.uds_queue_tx.clone()));
+                        }
+                        let _ = resp.send(Ok(()));
                     }
                     UdsWorkerCommand::StopPersistentTp { resp } => {
-                        let _ =
-                            resp.send(uds.stop_persistent_tp().await.map_err(|e| e.to_string()));
+                        stop_persistent_tp_task(&mut persistent_tp).await;
+                        let _ = resp.send(Ok(()));
                     }
                     UdsWorkerCommand::DownloadApp {
                         binary_path,
                         skip,
                         resp,
                     } => {
-                        let _ = resp.send(Ok(uds.download_app_to_target(&binary_path, skip).await));
+                        let _ = resp.send(Ok(
+                            worker_download_app_to_target(
+                                uds,
+                                &binary_path,
+                                skip,
+                                &mut persistent_tp,
+                            )
+                            .await,
+                        ));
                     }
                     UdsWorkerCommand::FileDownload {
                         binary_path,
@@ -599,6 +602,7 @@ impl UdsWorkerHandle {
                 }
             }
 
+            stop_persistent_tp_task(&mut persistent_tp).await;
             if let Some(session) = session {
                 session.teardown().await;
             }
@@ -733,6 +737,130 @@ impl UdsWorkerHandle {
     }
 }
 
+fn spawn_persistent_tp_task(uds_queue_tx: mpsc::Sender<CanioCmd>) -> PersistentTpTask {
+    let (stop_tx, mut stop_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(time::Duration::from_millis(10));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let _ = uds_queue_tx
+                        .send(CanioCmd::UdsCmdNoResponse(
+                            UDSProtocol::create_tp_msg(false).to_bytes(),
+                        ))
+                        .await;
+                }
+                _ = &mut stop_rx => break,
+            }
+        }
+    });
+    PersistentTpTask { stop_tx, handle }
+}
+
+async fn stop_persistent_tp_task(task: &mut Option<PersistentTpTask>) {
+    if let Some(PersistentTpTask { stop_tx, handle }) = task.take() {
+        let _ = stop_tx.send(());
+        let _ = handle.await;
+    }
+}
+
+async fn worker_download_app_to_target(
+    uds: &mut UdsSession,
+    binary_path: &PathBuf,
+    skip: bool,
+    persistent_tp: &mut Option<PersistentTpTask>,
+) -> UpdateResult {
+    let node_start = Instant::now();
+
+    if skip {
+        let mut file = File::open(binary_path).expect("Binary does not exist!");
+        file.seek(SeekFrom::End(-4)).expect("Seek failed");
+        let mut buffer = [0u8; 4];
+        file.read_exact(&mut buffer).expect("CRC read failed");
+        let app_crc = u32::from_le_bytes(buffer);
+        info!("Application CRC to download: 0x{:08X}", app_crc);
+
+        let crc = match get_app_crc(uds).await {
+            Err(e) => {
+                let node_dur = node_start.elapsed();
+                return UpdateResult {
+                    bin: binary_path.to_path_buf(),
+                    result: FlashStatus::Failed(format!("{:?}", e)),
+                    duration: node_dur,
+                };
+            }
+            Ok(crc) => crc,
+        };
+
+        if crc == app_crc {
+            let node_dur = node_start.elapsed();
+            return UpdateResult {
+                bin: binary_path.to_path_buf(),
+                result: FlashStatus::CrcMatch,
+                duration: node_dur,
+            };
+        } else {
+            info!(
+                "CRC mismatch: node=0x{:08X}, app=0x{:08X}. Downloading...",
+                crc, app_crc
+            );
+        }
+    }
+
+    let restore_persistent_tp_after_download = persistent_tp.is_some();
+    if !restore_persistent_tp_after_download {
+        *persistent_tp = Some(spawn_persistent_tp_task(uds.client.uds_queue_tx.clone()));
+    }
+
+    if !uds.interactive_session {
+        if let Err(_) = uds
+            .client
+            .ecu_reset(SupportedResetTypes::Hard, uds.interactive_session)
+            .await
+        {
+            stop_persistent_tp_task(persistent_tp).await;
+            if restore_persistent_tp_after_download {
+                *persistent_tp = Some(spawn_persistent_tp_task(uds.client.uds_queue_tx.clone()));
+            }
+            let node_dur = node_start.elapsed();
+            return UpdateResult {
+                bin: binary_path.to_path_buf(),
+                result: FlashStatus::Failed("Unable to communicate with ECU".to_string()),
+                duration: node_dur,
+            };
+        }
+    }
+
+    // The bootloader does not tolerate periodic tester present during the actual transfer.
+    stop_persistent_tp_task(persistent_tp).await;
+
+    let result = match uds.file_download(binary_path, 0x08002000).await {
+        Ok(()) => {
+            let node_dur = node_start.elapsed();
+            UpdateResult {
+                bin: binary_path.to_path_buf(),
+                result: FlashStatus::DownloadSuccess,
+                duration: node_dur,
+            }
+        }
+        Err(e) => {
+            let node_dur = node_start.elapsed();
+            UpdateResult {
+                bin: binary_path.to_path_buf(),
+                result: FlashStatus::Failed(format!("Error downloading binary: '{}'", e)),
+                duration: node_dur,
+            }
+        }
+    };
+
+    if restore_persistent_tp_after_download {
+        *persistent_tp = Some(spawn_persistent_tp_task(uds.client.uds_queue_tx.clone()));
+    }
+
+    result
+}
+
 /// CANIO task
 ///
 /// Owns the CAN hardware and handles all transmitting and receiving functions
@@ -749,70 +877,10 @@ async fn tsk_canio(exit: Arc<Mutex<bool>>, mut canio: CANIO<'_>) -> Result<()> {
     Ok(())
 }
 
-/// 10ms(100Hz) periodic task
-///
-/// This task will run at 100Hz in order to handle periodic actions
-async fn tsk_10ms(
-    exit: Arc<Mutex<bool>>,
-    cmd_queue: &mut mpsc::Receiver<PrdCmd>,
-    uds_queue: mpsc::Sender<CanioCmd>,
-) -> Result<()> {
-    debug!("10ms thread starting");
-
-    let mut send_tp = false;
-
-    while !exit.try_lock().is_ok_and(|exit| *exit) {
-        if let Ok(cmd) = cmd_queue.try_recv() {
-            match cmd {
-                PrdCmd::PersistentTesterPresent(state) => {
-                    if state {
-                        info!("Enabling persistent TP");
-                    } else {
-                        info!("Disabling persistent TP");
-                    }
-                    send_tp = state
-                }
-            }
-        } else {
-            if send_tp {
-                let _ = uds_queue
-                    .send(CanioCmd::UdsCmdNoResponse(
-                        UDSProtocol::create_tp_msg(false).to_bytes(),
-                    ))
-                    .await;
-            }
-        }
-
-        tokio::time::sleep(time::Duration::from_millis(10)).await;
-    }
-
-    debug!("10ms thread exiting");
-    Ok(())
-}
-
 impl UdsClient {
     /// Create a UDS client
-    pub fn new(cmd_queue_tx: mpsc::Sender<PrdCmd>, uds_queue_tx: mpsc::Sender<CanioCmd>) -> Self {
-        Self {
-            cmd_queue_tx,
-            uds_queue_tx,
-        }
-    }
-
-    /// Send a cmd to the 10ms periodic task
-    async fn send_cmd(&mut self, cmd: PrdCmd) -> Result<(), mpsc::error::SendError<PrdCmd>> {
-        self.cmd_queue_tx.send(cmd).await
-    }
-
-    pub async fn start_persistent_tp(&mut self) -> Result<()> {
-        Ok(self.send_cmd(PrdCmd::PersistentTesterPresent(true)).await?)
-    }
-
-    pub async fn stop_persistent_tp(&mut self) -> Result<()> {
-        info!("Stopping persistent TP");
-        Ok(self
-            .send_cmd(PrdCmd::PersistentTesterPresent(false))
-            .await?)
+    pub fn new(uds_queue_tx: mpsc::Sender<CanioCmd>) -> Self {
+        Self { uds_queue_tx }
     }
 
     pub async fn read_current_session(&mut self) -> Result<CurrentDiagnosticSession> {
@@ -1159,7 +1227,7 @@ impl UdsClient {
         let buf = [UdsCommand::RequestTransferExit.into()];
         debug!("Stopping UDS transfer: {:02x?}", buf);
 
-        let resp = CanioCmd::send_recv(&buf, self.uds_queue_tx.clone(), 50).await?;
+        let resp = CanioCmd::send_recv(&buf, self.uds_queue_tx.clone(), 1000).await?;
         debug!("Transfer stop response: {:02x?}", resp);
 
         Ok(())
@@ -1194,11 +1262,6 @@ impl UdsClient {
     /// Starts by telling the device to erase the current app, then starts the app download, and lastly
     /// starts actually transferring the app
     pub async fn app_download(&mut self, file: PathBuf, address: u32) -> Result<()> {
-        // disable tester present. bootloader is not currently robust to having tester present enabled
-        // during an app download
-        self.send_cmd(PrdCmd::PersistentTesterPresent(false))
-            .await?;
-
         // start by erasing the app
         self.app_erase().await?;
 

--- a/drive-stack/ota-agent/src/main.rs
+++ b/drive-stack/ota-agent/src/main.rs
@@ -29,7 +29,7 @@ use tracing_subscriber::EnvFilter;
 use warp::{Filter, http::StatusCode};
 
 #[cfg(target_os = "linux")]
-use conUDS::modules::uds::UdsSession;
+use conUDS::modules::uds::UdsWorkerHandle;
 use conUDS::{FlashStatus, UpdateResult};
 use net_detec::Client as MdnsClient;
 use net_detec::Server as MdnsServer;
@@ -2065,9 +2065,8 @@ async fn uds_ping_handler(state: Arc<AppState>) -> Result<impl warp::Reply, warp
             continue;
         }
 
-        let mut uds = UdsSession::new(&state.can_device, request_id, response_id, false).await;
-        let resp = uds.client.did_read(UDS_DID_CRC).await;
-        uds.teardown().await;
+        let uds = UdsWorkerHandle::new(state.can_device.clone(), request_id, response_id, false);
+        let resp = uds.did_read(UDS_DID_CRC).await;
 
         match resp {
             Ok(bytes) => {
@@ -2130,8 +2129,18 @@ async fn flash_node(
             duration: Duration::from_secs(0),
         };
     }
-    let mut uds = UdsSession::new(bus, request_id, response_id, false).await;
-    let result = uds.download_app_to_target(&binary.into(), !force).await;
+    let uds = UdsWorkerHandle::new(bus.to_string(), request_id, response_id, false);
+    let result = match uds
+        .download_app_to_target(binary.to_path_buf(), !force)
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => UpdateResult {
+            bin: binary.into(),
+            result: FlashStatus::Failed(e.to_string()),
+            duration: Duration::from_secs(0),
+        },
+    };
     unlock_manifest_node(&manifest_path, &node, &lock).await;
 
     result


### PR DESCRIPTION
### Reason for Change

conUDS has historically gone through revisions and interface updates. This has left a less than ideal interface as we scale it to multiple applications. Additionally, race conditions emerge between requested functionality/routines and tester present behaviors. Improve the interface, send responseless tester present seperately to the uds session worker and integrate responseful tester present into the worker itself. Use the worker to drive all transactions and serialize requests and responses from a single handler

### Changes

1. Create a UdsWorker handler as a primary rust interface
2. Transmit response not required tester present seperately to the uds worker
3. Integrate response based tester present into the uds worker
4. Integrate the new interface into the dashboard and ota agen
5. Fix a bug in the UdsSession which impacts flashing when a bootloader is running

### Test Plan

- Flash a controller and stop mid flash so the application is stuck in bootloader
- Ensure a download and skip crc download both succeed :heavy_check_mark: 
- Ensure the ota agent can recover a controller when doing a force and normal ota :heavy_check_mark: 
- Ensure the dashboard responseless tester present doesnt receive messages from the controller uds server :heavy_check_mark: 
- Ensure the dashboard tester present receives a response :heavy_check_mark: 