### PR TITLE
Make launch and apps rules legal again

### DIFF
--- a/components/vc/front/FeatureSels.yaml
+++ b/components/vc/front/FeatureSels.yaml
@@ -10,7 +10,7 @@ features:
   app_uds: true
   feature_brakepedal_from_pressure: true
   feature_vehicleState_mode: follower
-  feature_wiggly_pedal: true
+  feature_wiggly_pedal: false
   feature_vehicleSpeed_leader: true
   nvm_lib_enabled: true
   nvm_flash_backed: true

--- a/components/vc/front/src/bppc.c
+++ b/components/vc/front/src/bppc.c
@@ -88,26 +88,18 @@ static void bppc_periodic_100Hz(void)
     {
         const float32_t brake_pos = drv_pedalMonitor_getPedalPosition(BRAKE_CHANNEL);
         const float32_t accelerator_pos = apps_getPedalPosition();
-        const bool in_launch_control = torque_isLaunching();
 
         bppc_data.position = brake_pos;
 
-        if (in_launch_control == false)
+        if ((accelerator_pos > 0.25f) && (brake_pos > 0.10f))
         {
-            if ((accelerator_pos > 0.25f) && (brake_pos > 0.10f))
-            {
-                state = BPPC_FAULT;
-            }
-            else if ((bppc_data.state == BPPC_FAULT) && (brake_pos <= 0.10f))
-            {
-                state = BPPC_FAULT_LATCHED;
-            }
-            else if ((accelerator_pos < 0.05f) || (bppc_data.state == BPPC_OK))
-            {
-                state = BPPC_OK;
-            }
+            state = BPPC_FAULT;
         }
-        else
+        else if ((bppc_data.state == BPPC_FAULT) && (brake_pos <= 0.10f))
+        {
+            state = BPPC_FAULT_LATCHED;
+        }
+        else if ((accelerator_pos < 0.05f) || (bppc_data.state == BPPC_OK))
         {
             state = BPPC_OK;
         }

--- a/components/vc/front/src/torque.c
+++ b/components/vc/front/src/torque.c
@@ -48,7 +48,8 @@
 #define LC_REJECTED_MS 2000
 #define LC_BRAKE_THRESHOLD 0.30
 #define LC_BRAKE_THRESHOLD_LAUNCH 0.05
-#define LC_THROTTLE_THRESHOLD 0.50
+#define LC_THROTTLE_THRESHOLD 0.15
+#define LC_THROTTLE_DISABLE_HYST 0.05
 #define LC_THROTTLE_START_CUTOFF 0.10
 
 #define TC_MAX 0.7f
@@ -99,6 +100,7 @@ static struct
 
     torque_launchControlState_E launchControlState;
     torque_tractionControlState_E tractionControlState;
+    float32_t acceleratorMaxLaunchValue;
 
     uint32_t  lastTimeampMS;
     float32_t slipRear;
@@ -202,7 +204,7 @@ static float32_t evaluate_torque_max(void)
     return torque_request_max;
 }
 
-static void evaluate_launch_control(float32_t accelerator_position, float32_t brake_position)
+static void evaluate_launch_control(float32_t accelerator_position, float32_t brake_position, bool bppc_ok)
 {
     bool launchRejected = false;
 
@@ -228,7 +230,8 @@ static void evaluate_launch_control(float32_t accelerator_position, float32_t br
                 else if (launch_control_request_rising)
                 {
                     if ((brake_position > LC_BRAKE_THRESHOLD) &&
-                        (accelerator_position < LC_THROTTLE_START_CUTOFF))
+                        (accelerator_position < LC_THROTTLE_START_CUTOFF) &&
+                        bppc_ok)
                     {
                         torque_data.launchControlState = LC_STATE_HOLDING;
                         drv_timer_stop(&torque_data.launch_control_timer);
@@ -246,10 +249,16 @@ static void evaluate_launch_control(float32_t accelerator_position, float32_t br
             {
                 torque_data.launchControlState = LC_STATE_INACTIVE;
             }
+            else if (!bppc_ok)
+            {
+                torque_data.launchControlState = LC_STATE_REJECTED;
+                drv_timer_start(&torque_data.launch_control_timer, LC_REJECTED_MS);
+            }
             else if (accelerator_position > LC_THROTTLE_THRESHOLD)
             {
                 drv_timer_start(&torque_data.launch_control_timer, LC_SETTLING_MS);
                 torque_data.launchControlState = LC_STATE_SETTLING;
+                torque_data.acceleratorMaxLaunchValue = 0.0f;
             }
             break;
         case LC_STATE_SETTLING:
@@ -257,6 +266,11 @@ static void evaluate_launch_control(float32_t accelerator_position, float32_t br
             {
                 torque_data.launchControlState = LC_STATE_PRELOAD;
                 drv_timer_stop(&torque_data.launch_control_timer);
+            }
+            else if (!bppc_ok)
+            {
+                torque_data.launchControlState = LC_STATE_REJECTED;
+                drv_timer_start(&torque_data.launch_control_timer, LC_REJECTED_MS);
             }
             else if (accelerator_position < LC_THROTTLE_THRESHOLD)
             {
@@ -272,16 +286,32 @@ static void evaluate_launch_control(float32_t accelerator_position, float32_t br
             {
                 torque_data.launchControlState = LC_STATE_INACTIVE;
             }
+            else if (!bppc_ok)
+            {
+                torque_data.launchControlState = LC_STATE_REJECTED;
+                drv_timer_start(&torque_data.launch_control_timer, LC_REJECTED_MS);
+            }
             else if (brake_position < LC_BRAKE_THRESHOLD_LAUNCH)
             {
                 torque_data.launchControlState = LC_STATE_LAUNCH;
             }
+
+            torque_data.acceleratorMaxLaunchValue = accelerator_position;
             break;
         case LC_STATE_LAUNCH:
-            if ((accelerator_position < LC_THROTTLE_THRESHOLD) ||
-                (brake_position > LC_BRAKE_THRESHOLD))
+            if (!bppc_ok)
+            {
+                torque_data.launchControlState = LC_STATE_REJECTED;
+                drv_timer_start(&torque_data.launch_control_timer, LC_REJECTED_MS);
+            }
+            else if ((accelerator_position < torque_data.acceleratorMaxLaunchValue - LC_THROTTLE_DISABLE_HYST) ||
+                     (brake_position > LC_BRAKE_THRESHOLD))
             {
                 torque_data.launchControlState = LC_STATE_INACTIVE;
+            }
+            else if (accelerator_position > torque_data.acceleratorMaxLaunchValue)
+            {
+                torque_data.acceleratorMaxLaunchValue = accelerator_position;
             }
             break;
         default:
@@ -290,6 +320,7 @@ static void evaluate_launch_control(float32_t accelerator_position, float32_t br
 #else
     UNUSED(accelerator_position);
     UNUSED(brake_position);
+    UNUSED(bppc_ok);
 #endif
 
     app_faultManager_setFaultState(FM_FAULT_VCFRONT_LAUNCHREJECTED, launchRejected);
@@ -724,19 +755,12 @@ static void torque_periodic_100Hz(void)
     evaluate_slip_request();
     evaluate_preload_torque();
 
-    evaluate_launch_control(accelerator_position, brake_position);
+    evaluate_launch_control(accelerator_position, brake_position, bppc_ok);
     torque_data.torqueReduction = evaluate_traction_control();
 
     float32_t torque_request_max = evaluate_torque_max();
-
-    if (torque_data.race_mode != RACEMODE_ENABLED)
-    {
-        torque_request_max = DEFAULT_TORQUE_PITS;
-    }
-    if (torque_data.gear != GEAR_F)
-    {
-        torque_request_max = DEFAULT_TORQUE_LIMIT_REVERSE;
-    }
+    torque_request_max = torque_data.race_mode != RACEMODE_ENABLED ? DEFAULT_TORQUE_PITS : torque_request_max;
+    torque_request_max = torque_data.gear != GEAR_F ? DEFAULT_TORQUE_LIMIT_REVERSE : torque_request_max;
 
     if (gear_change || mode_change || !bppc_ok)
     {
@@ -757,13 +781,12 @@ static void torque_periodic_100Hz(void)
     }
     else if (torque_data.launchControlState == LC_STATE_PRELOAD)
     {
-        torque = torque_data.torquePreload;
-        torque = lib_rateLimit_linear_update(&torque_data.preloadRateLimit, torque);
+        torque = lib_rateLimit_linear_update(&torque_data.preloadRateLimit, torque_data.torquePreload);
         torque_data.launchRateLimit.y_n = torque;
     }
     else if (torque_data.launchControlState == LC_STATE_LAUNCH)
     {
-        torque = lib_rateLimit_linear_update(&torque_data.launchRateLimit, torque);
+        torque = lib_rateLimit_linear_update(&torque_data.launchRateLimit, torque_request_max);
         torque_data.torqueRateLimit.y_n = torque;
     }
     else


### PR DESCRIPTION
### Reason for Change

We have shit that breaks the rules, so lets start to stop breaking the rules.

### Changes

1. Disable feature wiggly pedal
2. Make launch control rules legal

### Test Plan

- Ensure launch control sequence functions
- Ensure driver exits launch when coming off the pedal
- Ensure preload and launch torque is driver driven
- Ensure 11% pedal pot difference results in an apps fault