### PR TITLE
Implement regen

### DIFF
--- a/components/sws/include/CANIO_componentSpecific.h
+++ b/components/sws/include/CANIO_componentSpecific.h
@@ -75,6 +75,7 @@
 #define set_requestTorqueInc(m,b,n,s)        set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_TORQUE_INC)            ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_requestTorqueDec(m,b,n,s)        set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_TORQUE_DEC)            ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_requestLaunchControl(m,b,n,s)    set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_LAUNCH_CONTROL)        ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
+#define set_requestRegenEnabled(m,b,n,s)     set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_REGEN)                 ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_requestTractionControl(m,b,n,s)  set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_TC)                    ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_requestPreloadTorqueInc(m,b,n,s) set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_PRELOAD_TORQUE_INC)    ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
 #define set_requestPreloadTorqueDec(m,b,n,s) set(m,b,n,s, driverInput_getDigital(DRIVERINPUT_REQUEST_PRELOAD_TORQUE_DEC)    ? CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)

--- a/components/vc/front/src/torque.c
+++ b/components/vc/front/src/torque.c
@@ -52,6 +52,12 @@
 #define LC_THROTTLE_DISABLE_HYST 0.05
 #define LC_THROTTLE_START_CUTOFF 0.10
 
+#define REGEN_BRAKE_START_THRESH 0.10f
+#define REGEN_BRAKE_STOP_THRESH 0.05f
+#define REGEN_ACCEL_CUTOFF 0.15f
+#define REGEN_MAX_TORQUE_N 50
+#define REGEN_SPEED_CUTOFF_MPS 1.38f // Rules limitation to regen
+
 #define TC_MAX 0.7f
 #define TC_MIN 0.0f
 #define TC_TARGET_SLIP 0.10f
@@ -92,6 +98,8 @@ static struct
     bool gear_change_active;
     bool torque_control_request_active;
     bool race_mode_change_active;
+    bool regenEnabled;
+    bool isRegenerating;
 
     drv_timer_S torque_change_timer;
     drv_timer_S launch_control_timer;
@@ -382,6 +390,44 @@ static float32_t evaluate_traction_control(void)
 
     torque_data.slipRear = slip;
     return multiplier;
+}
+
+static void evaluateRegenEnabled(float32_t accelPosition, float32_t brakePosition)
+{
+#if FEATURE_IS_ENABLED(FEATURE_TRACTION_CONTROL)
+    CAN_digitalStatus_E regenEnabled = CAN_DIGITALSTATUS_SNA;
+    bool requested = (CANRX_get_signal(VEH, SWS_requestRegenEnabled, &regenEnabled) != CANRX_MESSAGE_SNA) &&
+                     (regenEnabled == CAN_DIGITALSTATUS_ON);
+    const float32_t vehicleSpeed = app_vehicleSpeed_getVehicleSpeed();
+
+    torque_data.regenEnabled = requested && (torque_data.gear == GEAR_F) &&
+                               (vehicleSpeed > REGEN_SPEED_CUTOFF_MPS) &&
+                               (accelPosition < REGEN_ACCEL_CUTOFF);
+#else
+    torque_data.regenEnabled = false;
+#endif
+
+    if (torque_data.regenEnabled)
+    {
+        if (torque_data.isRegenerating)
+        {
+            if (brakePosition < REGEN_BRAKE_STOP_THRESH)
+            {
+                torque_data.isRegenerating = false;
+            }
+        }
+        else
+        {
+            if (brakePosition > REGEN_BRAKE_START_THRESH)
+            {
+                torque_data.isRegenerating = true;
+            }
+        }
+    }
+    else
+    {
+        torque_data.isRegenerating = false;
+    }
 }
 
 static void evaluate_slip_request(void)
@@ -756,6 +802,7 @@ static void torque_periodic_100Hz(void)
     evaluate_preload_torque();
 
     evaluate_launch_control(accelerator_position, brake_position, bppc_ok);
+    evaluateRegenEnabled(accelerator_position, brake_position);
     torque_data.torqueReduction = evaluate_traction_control();
 
     float32_t torque_request_max = evaluate_torque_max();
@@ -768,6 +815,7 @@ static void torque_periodic_100Hz(void)
     }
 
     float32_t torque = (bppc_ok) ? accelerator_position * torque_request_max : 0.0f;
+    const float32_t regenTorque = REGEN_MAX_TORQUE_N * brake_position;
     torque_data.torqueDriverInput = torque;
     torque_data.torqueCorrection = torque_data.torqueReduction * torque;
 
@@ -791,11 +839,12 @@ static void torque_periodic_100Hz(void)
     }
     else
     {
-        torque -= torque_data.torqueCorrection;
+        torque = !torque_data.isRegenerating ? torque - torque_data.torqueCorrection : -regenTorque;
         torque = lib_rateLimit_linear_update(&torque_data.torqueRateLimit, torque);
     }
 
-    torque_data.torque = SATURATE(ABSOLUTE_MIN_TORQUE, torque, ABSOLUTE_MAX_TORQUE);
+    const float32_t minTorque = torque_data.gear == GEAR_F ? -REGEN_MAX_TORQUE_N : ABSOLUTE_MIN_TORQUE;
+    torque_data.torque = SATURATE(minTorque, torque, ABSOLUTE_MAX_TORQUE);
 }
 
 /******************************************************************************

--- a/components/vc/rear/src/mcManager.c
+++ b/components/vc/rear/src/mcManager.c
@@ -221,11 +221,14 @@ static void mcManager_periodic_100Hz(void)
         mcManager_data.direction = MCMANAGER_FORWARD;
     }
 
-    const float32_t min_torque = mcManager_data.lash_enabled ? LASH_TORQUE : 0.0f;
+    const bool isRegenTorque = torque_command < 0.0f;
+    const float32_t min_torque = mcManager_data.lash_enabled ? (!isRegenTorque ? LASH_TORQUE : -LASH_TORQUE) : 0.0f;
+    const float32_t maxLimit = !isRegenTorque ? mcManager_data.torque_limit : min_torque;
+    const float32_t minLimit = !isRegenTorque ? min_torque : -mcManager_data.torque_limit;
 
     mcManager_data.last_contactor_state = contactor_state;
     mcManager_data.enable = enable;
-    torque_command = SATURATE(min_torque, torque_command, mcManager_data.torque_limit);
+    torque_command = SATURATE(minLimit, torque_command, maxLimit);
     lib_rateLimit_linear_update(&mcManager_data.torque_command, torque_command);
 }
 

--- a/components/vc/shared/features/VC_FeatureDefs.yaml
+++ b/components/vc/shared/features/VC_FeatureDefs.yaml
@@ -5,3 +5,4 @@ defs:
   reverse:
   launch_control:
   traction_control:
+  regen:

--- a/components/vc/shared/features/VC_FeatureSels.yaml
+++ b/components/vc/shared/features/VC_FeatureSels.yaml
@@ -3,3 +3,4 @@ features:
   feature_reverse: true
   feature_launch_control: true
   feature_traction_control: true
+  feature_regen: true

--- a/network/definition/data/components/sws/sws-message.yaml
+++ b/network/definition/data/components/sws/sws-message.yaml
@@ -54,6 +54,7 @@ messages:
       requestScreen:
       requestLaunchControl:
       requestTractionControl:
+      requestRegenEnabled:
       requestPreloadTorqueInc:
       requestPreloadTorqueDec:
       requestCrashReset:

--- a/network/definition/data/components/sws/sws-signals.yaml
+++ b/network/definition/data/components/sws/sws-signals.yaml
@@ -85,6 +85,9 @@ signals:
   requestTractionControl:
     description: Status of traction control request
     discreteValues: digitalStatus
+  requestRegenEnabled:
+    description: Status of regen request
+    discreteValues: digitalStatus
   requestSlipInc:
     description: Status of slip increase request
     discreteValues: digitalStatus

--- a/network/definition/data/components/vcfront/vcfront-rx.yaml
+++ b/network/definition/data/components/vcfront/vcfront-rx.yaml
@@ -19,5 +19,3 @@ signals:
     sourceBuses: veh
   VCPDU_safetyReset:
     sourceBuses: veh
-  SWS_requestCalibSteerAngle:
-    sourceBuses: veh


### PR DESCRIPTION
### Reason for Change

We didnt have regen, now we do ts

### Changes

1. Bringup support to enable/disable regen from the steering wheel
2. Support regen in torque manager
3. Support regen in mcmanager

### Test Plan

- Ensure car doesnt regen when stopped and on brake
- Ensure no regen when regen is disabled
- Ensure torque manager transitions in and out of regen as expected by pedal state
