### PR TITLE
vcfront: Keep 5V critical on in sleep for brake feedback

### DIFF
--- a/components/vc/front/src/powerManager.c
+++ b/components/vc/front/src/powerManager.c
@@ -48,7 +48,7 @@ static void powerManager_periodic_10Hz(void)
     // TODO: Improve
     for (uint8_t i = 0; i < DRV_TPS20XX_CHANNEL_COUNT; i++)
     {
-        drv_tps20xx_setEnabled(i, !sleeping);
+        drv_tps20xx_setEnabled(i, !sleeping || (i == DRV_TPS20XX_CHANNEL_5V_CRITICAL));
     }
 
     drv_tps20xx_run();


### PR DESCRIPTION
### Reason for Change

Whoops I broke sleep when I disabled the front 5V critical HSD in sleep. The VC would enter sleep, turn off the 5V HSD, then subsequently the pullup would trip the brake threshold in sleep to wake. This wake event would would subsequently wake the entire vehicle.

### Changes

1. Keep vcfront 5V critical enabled in sleep

### Test Plan

- Ensure vehicle can enter sleep :heavy_check_mark: 
- Ensure vehicle stays in sleep :heavy_check_mark: 
- Press brake pedal, ensure vehicle wakes from sleep :heavy_check_mark: 

<img width="1053" height="851" alt="image" src="https://github.com/user-attachments/assets/201b3013-0aee-4fb4-b4a3-2c925938c985" />
