### PR TITLE
yamcan: Identify duplicate discrete value integer values in yamcan

### DIFF
--- a/tools/yamcan/classes/Types.py
+++ b/tools/yamcan/classes/Types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Dict, Literal, Union
+from collections import defaultdict
 
 
 class Continuous(Enum):
@@ -20,6 +21,17 @@ class DiscreteValue:
             or any(not isinstance(v, int) for v in values.values())
         ):
             raise ValueError(f"Values for discrete value {name} must all be ints")
+        # Detect duplicate integer values
+        reverse = defaultdict(list)
+        for k, v in values.items():
+            reverse[v].append(k)
+
+        duplicates = {v: ks for v, ks in reverse.items() if len(ks) > 1}
+        if duplicates:
+            raise ValueError(
+                f"Duplicate integer values in {name}: "
+                + ", ".join(f"{val} -> {keys}" for val, keys in duplicates.items())
+            )
 
         self.name = name
         self.values = values


### PR DESCRIPTION
### Reason for Change

Duplicate values are not currently detected in yamcan discrete values. This only fails subsequent builds because of codegen. Identify these failures and fail the network compilation step.

### Changes

1. Detect duplicate values in yamcan discrete values

### Test Plan

- Add duplicate numerical values, ensure the build fails :heavy_check_mark:
```
File changed: root//tools/yamcan/classes/__pycache__/Types.cpython-312.pyc.132306478112048
Directory changed: root//tools/yamcan/classes/__pycache__/Types.cpython-312.pyc.132306478112048
File changed: root//tools/yamcan/classes/__pycache__/Types.cpython-312.pyc
2 additional file change events
Action failed: root//network:network-default (genrule)
Local command returned non-zero exit code 1
Reproduce locally: `env -C "$(buck2 root --kind project)" -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/root/fe07a702733a9626/ge ...<omitted>... /usr/bin/env bash -e buck-out/v2/art/root/b42aeba648b8c415/network/__network-default__/sh/genrule.sh (run `buck2 l
og what-failed` to get the full command)`
stdout:
Parsing network...
Duplicate integer values in screenAlerts: 10 -> ['IMU_YAW_CALIBRATING', 'RESOLVER_CALIBRATING']
Missing node config file carputerBody.yaml
Warning: No signals found in signal file for node 'carputerVeh'
No messages found in message file for node 'carputerVeh'
Warning: No signals found in signal file for node 'udsClient'
Warning: No signals found in signal file for node 'imu'
Invalid discrete value 'screenAlerts' in signal 'SWS_screenAlert'
stderr:
Traceback (most recent call last):
  File "/home/josh/projects/firmware/buck-out/v2/art/root/b42aeba648b8c415/network/__network-default__/srcs/../../../../b42aeba648b8c415-462c4a1659836f33/tools/yamcan/__yamcan__/srcs/yamcan.py", line 1489, in <module>
    main()
  File "/home/josh/projects/firmware/buck-out/v2/art/root/b42aeba648b8c415/network/__network-default__/srcs/../../../../b42aeba648b8c415-462c4a1659836f33/tools/yamcan/__yamcan__/srcs/yamcan.py", line 1426, in main
    parseNetwork(args, lookup)
  File "/home/josh/projects/firmware/buck-out/v2/art/root/b42aeba648b8c415/network/__network-default__/srcs/../../../../b42aeba648b8c415-462c4a1659836f33/tools/yamcan/__yamcan__/srcs/yamcan.py", line 1233, in parseNetwork
    process_node(node)
  File "/home/josh/projects/firmware/buck-out/v2/art/root/b42aeba648b8c415/network/__network-default__/srcs/../../../../b42aeba648b8c415-462c4a1659836f33/tools/yamcan/__yamcan__/srcs/yamcan.py", line 432, in process_node
    raise Exception(
Exception: Error processing node 'sws' signals, see previous errors...
Build ID: bc2ce21e-4b7b-4b32-b672-a46302611380
Network: Up: 0B  Down: 0B
Analyzing targets.   Remaining     0/186                                                                                                                                              
Executing actions.   Remaining     0/2361                                                                                                                                             5.3s exec time total
Command: run.      Finished 12 local                                                                                                                                                                                                                      
Time elapsed: 1.0s
BUILD FAILED
Failed to build 'root//network:network-default (prelude//platforms:default#b42aeba648b8c415)
```