### PR TITLE
Some more various improvements.

### DIFF
--- a/components/bms_worker/include/CANIO_componentSpecific.h
+++ b/components/bms_worker/include/CANIO_componentSpecific.h
@@ -80,6 +80,9 @@
 #define set_cellVoltage12(m, b, n, s)            set(m,b,n,s, BMS.cells[12].voltage)
 #define set_boardRelativeHumidity(m, b, n, s)    set(m,b,n,s, ENV.values.board.rh)
 #define set_boardAmbientTemp(m, b, n, s)         set(m,b,n,s, ENV.values.board.ambient_temp)
+#if APP_VARIANT_ID == 1U
+#define set_bus7v5Voltage(m, b, n, s)            set(m,b,n,s, drv_inputAD_getAnalogVoltage(DRV_INPUTAD_ANALOG_VSNS_7V5))
+#endif
 #define set_tempMcu(m, b, n, s)                  set(m,b,n,s, drv_tempSensors_getChannelTemperatureDegC(DRV_TEMPSENSORS_CHANNEL_MCU))
 #define set_tempBalancing0(m, b, n, s)           set(m,b,n,s, drv_tempSensors_getChannelTemperatureDegC(DRV_TEMPSENSORS_CHANNEL_BALANCING1))
 #define set_tempBalancing1(m, b, n, s)           set(m,b,n,s, drv_tempSensors_getChannelTemperatureDegC(DRV_TEMPSENSORS_CHANNEL_BALANCING2))
@@ -107,4 +110,3 @@
 #define set_coolPct0(m, b, n, s)                 set(m,b,n,s, (drv_cooling_getPower(&cooling[COOLING_CHANNEL_FAN1]) * 100.0f))
 #define set_coolState0(m, b, n, s)               set(m,b,n,s, (drv_cooling_getState(&cooling[COOLING_CHANNEL_FAN1]) != COOLING_OFF) ? \
                                                                CAN_DIGITALSTATUS_ON : CAN_DIGITALSTATUS_OFF)
-

--- a/components/shared/code/app/app_vehicleSpeed.c
+++ b/components/shared/code/app/app_vehicleSpeed.c
@@ -304,6 +304,7 @@ static void calculateVehicleSpeed(void)
     const bool validGPS = app_gps_isValid();
     const uint16_t frontAxleRpm = app_vehicleSpeed_getAxleSpeedRotational(AXLE_FRONT);
     uint64_t frontWheelSampleBaseTick = 0U;
+    const bool motorInReverse = (motor_rpm < 0) && motorValid;
 
     if (accelValid && angleValid && (delta_t > 0.0f))
     {
@@ -316,18 +317,18 @@ static void calculateVehicleSpeed(void)
         if (!vehicle.wasValidGPS)
         {
             speed = app_gps_getHeadingRef()->speedMps;
-            vehicle.lpfSpeed.y = speed;
+            vehicle.lpfSpeed.y = motorInReverse ? -speed : speed;
         }
         else
         {
             const float32_t tmp = app_gps_getHeadingRef()->speedMps;
-            speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, tmp);
+            speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, motorInReverse ? -tmp : tmp);
         }
     }
     if (hasValidFrontWheelReference() && getFreshFrontWheelReference(&frontWheelSampleBaseTick))
     {
         const float32_t tmp = RPM_TO_MPS(frontAxleRpm);
-        speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, tmp);
+        speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, motorInReverse ? -tmp : tmp);
         vehicle.lastFrontWheelSampleBaseTick = frontWheelSampleBaseTick;
     }
 

--- a/components/vc/front/include/Module_componentSpecific.h
+++ b/components/vc/front/include/Module_componentSpecific.h
@@ -23,6 +23,7 @@ extern const ModuleDesc_S CANIO_rx;
 extern const ModuleDesc_S UDS_desc;
 extern const ModuleDesc_S apps_desc;
 extern const ModuleDesc_S bppc_desc;
+extern const ModuleDesc_S vd_desc;
 extern const ModuleDesc_S torque_desc;
 extern const ModuleDesc_S powerManager_desc;
 extern const ModuleDesc_S cockpitLights_desc;
@@ -30,7 +31,6 @@ extern const ModuleDesc_S brakePressure_desc;
 extern const ModuleDesc_S steeringAngle_desc;
 extern const ModuleDesc_S shockpot_desc;
 extern const ModuleDesc_S sys_desc;
-extern const ModuleDesc_S vd_desc;
 extern const ModuleDesc_S CANIO_tx;
 
 /******************************************************************************
@@ -44,6 +44,7 @@ typedef enum
     MODULE_APPS,
     MODULE_BPPC,
     MODULE_VEHICLESTATE,
+    MODULE_VD,
     MODULE_TORQUE,
     MODULE_POWERMANAGER,
     MODULE_COCKPITLIGHTS,
@@ -53,7 +54,6 @@ typedef enum
     MODULE_STEERINGANGLE,
     MODULE_SHOCKPOT,
     MODULE_SYS,
-    MODULE_VD,
     MODULE_CANIO_tx,
     MODULE_CNT,
 } Module_tasks_E;

--- a/components/vc/front/src/Module_componentSpecific.c
+++ b/components/vc/front/src/Module_componentSpecific.c
@@ -27,6 +27,7 @@ const ModuleDesc_S* modules[MODULE_CNT] = {
     &apps_desc,
     &bppc_desc,
     &app_vehicleState_desc,
+    &vd_desc,
     &torque_desc,
     &powerManager_desc,
     &cockpitLights_desc,
@@ -36,7 +37,6 @@ const ModuleDesc_S* modules[MODULE_CNT] = {
     &steeringAngle_desc,
     &shockpot_desc,
     &sys_desc,
-    &vd_desc,
     &CANIO_tx,
 };
 

--- a/network/definition/data/components/bmsw/bmsw-message.yaml
+++ b/network/definition/data/components/bmsw/bmsw-message.yaml
@@ -135,6 +135,7 @@ messages:
     signals:
       boardRelativeHumidity:
       boardAmbientTemp:
+      bus7v5Voltage:
       tempMcu:
       tempBalancing0:
       tempBalancing1:

--- a/network/definition/data/components/bmsw/bmsw-signals.yaml
+++ b/network/definition/data/components/bmsw/bmsw-signals.yaml
@@ -474,6 +474,10 @@ signals:
         max: 127
     continuous: true
 
+  bus7v5Voltage:
+    description: Segment worker 7V5 bus voltage
+    template: voltsPrecise
+
   tempMcu:
     description: Segment worker microcontroller temperature
     unit: degC
@@ -640,4 +644,3 @@ signals:
   dbgThermVoltage9:
     template: dbgThermVoltage
     description: Raw thermistor voltage 9
-


### PR DESCRIPTION
### Changes

1. When moving in reverse, we only have a positive wheel speed reference. Due to this, identify the driving direction of the vehicle based off the rear axle rpm, and then filter with the negative of the GPS and wheelspeed values.
1. VD is an input to the torque manager, so correct this
1. Transmit bmsw 7V5 voltage metrics

### Test Plan

- Ensure signals are present :heavy_check_mark: 
- Ensure signals are accurate :heavy_check_mark: 
