### PR TITLE
yamcan: Validate ranges not provided with an informed range

### DIFF
--- a/network/definition/data/components/bmsw/bmsw-signals.yaml
+++ b/network/definition/data/components/bmsw/bmsw-signals.yaml
@@ -262,7 +262,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -273,7 +273,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -284,7 +284,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -295,7 +295,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -306,7 +306,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -317,7 +317,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -328,7 +328,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -339,7 +339,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -350,7 +350,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -361,7 +361,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -372,7 +372,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -383,7 +383,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -394,7 +394,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -405,7 +405,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -416,7 +416,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -427,7 +427,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 
@@ -438,7 +438,7 @@ signals:
       bitWidth: 12
       range:
         min: 0
-        max: 81.92
+        max: 81.9
       resolution: 0.020
     continuous: true
 
@@ -449,7 +449,7 @@ signals:
       bitWidth: 12
       range:
         min: 0
-        max: 81.92
+        max: 81.9
       resolution: 0.020
     continuous: true
 
@@ -605,7 +605,7 @@ signals:
       bitWidth: 10
       range:
         min: 0
-        max: 5.12
+        max: 5.115
       resolution: 0.005
     continuous: true
 

--- a/network/definition/data/components/em/em-signals.yaml
+++ b/network/definition/data/components/em/em-signals.yaml
@@ -54,4 +54,4 @@ signals:
       resolution: 1
       range:
         min: 0
-        max: 32
+        max: 31

--- a/network/definition/data/components/pm100dx/pm100dx-signals.yaml
+++ b/network/definition/data/components/pm100dx/pm100dx-signals.yaml
@@ -872,9 +872,6 @@ signals:
     nativeRepresentation:
       bitWidth: 32
       resolution: 0.003
-      range:
-        min: 0
-        max: 4294967295
       endianness: little
       signedness: unsigned
     continuous: true

--- a/network/definition/data/components/vcfront/vcfront-signals.yaml
+++ b/network/definition/data/components/vcfront/vcfront-signals.yaml
@@ -266,7 +266,7 @@ signals:
     description: Driver raw torque request
     unit: Nm
     nativeRepresentation:
-      resolution: 1
+      resolution: 1.5
       bitWidth: 7
       range:
         min: 0

--- a/network/definition/data/templates/signals.yaml
+++ b/network/definition/data/templates/signals.yaml
@@ -14,7 +14,7 @@ signals:
       bitWidth: 8
       range:
         min: 0
-        max: 256
+        max: 255
       resolution: 1
   count9Bit:
     unit: ""
@@ -22,7 +22,7 @@ signals:
       bitWidth: 9
       range:
         min: 0
-        max: 512
+        max: 511
       resolution: 1
   count10Bit:
     unit: ""
@@ -180,7 +180,7 @@ signals:
   linearVelocity:
     unit: 'm/s'
     nativeRepresentation:
-      bitWidth: 10
+      bitWidth: 13
       resolution: 0.01
       range:
         min: 0
@@ -204,7 +204,7 @@ signals:
       resolution: 1
       range:
         min: 0
-        max: 65535
+        max: 1023
   nvmRecordWrites:
     unit: ''
     description: Count of NVM lifetime record writes
@@ -222,7 +222,7 @@ signals:
       resolution: 1
       range:
         min: 0
-        max: 65535
+        max: 255
   nvmFailedCrc:
     unit: ''
     description: Count of NVM failed CRC's

--- a/tools/yamcan/classes/Can.py
+++ b/tools/yamcan/classes/Can.py
@@ -1,4 +1,5 @@
 import copy
+from decimal import Decimal
 from math import ceil, log
 from typing import List, Optional, Set, Tuple
 from schema import Schema, Or, Optional, And
@@ -111,6 +112,22 @@ class NativeRepresentation:
         if self.bit_width is not None and (self.bit_width < 1 or self.bit_width > 64):
             raise Exception(
                 f"Native representation bit width must be between 1 and 64 bits"
+            )
+        elif (
+            self.bit_width
+            and self.range
+            and self.resolution
+            and self.signedness == Signedness.unsigned
+            and (
+                Decimal(2**self.bit_width - 1)
+                < (
+                    (Decimal(str(self.range.max)) - Decimal(str(self.range.min)))
+                    / Decimal(str(self.resolution))
+                )
+            )
+        ):
+            raise Exception(
+                f"Native representation bit width cannot store the range in the provided resolution"
             )
 
 
@@ -248,10 +265,14 @@ class CanSignal(CanObject):
                 if self.unit is None:
                     print(f"Signal {name} is continuous but has no unit defined")
                     valid = False
-                if nat_rep.range is None:
-                    print(f"Signal {name} is continuous but has no range defined")
+                if nat_rep.range is None and not (
+                    nat_rep.bit_width and nat_rep.resolution
+                ):
+                    print(
+                        f"Signal {name} is continuous but has no range defined and cannot infer one from bitWidth and resolution"
+                    )
                     valid = False
-                elif not nat_rep.range.is_valid:
+                elif nat_rep.range is not None and not nat_rep.range.is_valid:
                     # error for this printed from Range class
                     valid = False
             elif dv:
@@ -344,9 +365,16 @@ class CanSignal(CanObject):
                         nat_rep.bit_width = ceil(log(sig_range / nat_rep.resolution, 2))
             elif nat_rep.bit_width:
                 nat_rep.resolution = nat_rep.resolution or 1.0
-                nat_rep.range = Range(
-                    {"min": 0, "max": 2**nat_rep.bit_width * nat_rep.resolution}
-                )
+                if nat_rep.signedness == Signedness.unsigned:
+                    nat_rep.range = Range(
+                        {
+                            "min": 0,
+                            "max": (2**nat_rep.bit_width) * nat_rep.resolution,
+                        }
+                    )
+                else:
+                    half_range = (2 ** (nat_rep.bit_width - 1)) * nat_rep.resolution
+                    nat_rep.range = Range({"min": -half_range, "max": half_range})
         else:
             nat_rep = NativeRepresentation()
             nat_rep.bit_width = 1


### PR DESCRIPTION
### Changes

1. Validate and infer range

### Test Plan

- Create an unpackable signal, ensure that the network build fails :heavy_check_mark: 
