### PR TITLE
Fix GNSS and vehicleSpeed

### DIFF
--- a/components/shared/code/app/app_gps.c
+++ b/components/shared/code/app/app_gps.c
@@ -26,7 +26,7 @@
  ******************************************************************************/
 
 #define BUFFER_SIZE 2048U
-#define MAX_NMEA_SENTENCE 82U
+#define MAX_NMEA_SENTENCE 83U
 #define GPS_TIMEOUT_MS 2000U
 
 #define GPS_DEVICE_ERROR FM_FAULT_VCFRONT_GPSDEVICEERROR
@@ -110,6 +110,7 @@ static void updateGPS(void)
     gps.time.month = gps.currentGPS.month;
     gps.time.year = gps.currentGPS.year;
     gps.time.hours = gps.currentGPS.hours;
+    gps.time.minutes = gps.currentGPS.minutes;
     gps.time.seconds = gps.currentGPS.seconds;
 
     gps.gpsQuality = gps.currentGPS.fix;

--- a/components/shared/code/app/app_vehicleSpeed.c
+++ b/components/shared/code/app/app_vehicleSpeed.c
@@ -85,6 +85,7 @@ typedef struct
     bool odoSaved;
     bool wasValidGPS;
     uint64_t lastFrontWheelSampleBaseTick;
+    uint16_t countGgaPoses;
 #endif // FEATURE_VEHICLEPEED_LEADER
 } vehicle_S;
 
@@ -296,6 +297,7 @@ static void calculateVehicleSpeed(void)
     float32_t accelLon = 0.0f;
     float32_t anglePitch = 0.0f;
     int16_t motor_rpm = 0;
+    const uint16_t ggaPoses = app_gps_getSentenceCountGga();
     const bool accelValid = (CANRX_IMU_LON(&accelLon) == CANRX_MESSAGE_VALID);
     const bool angleValid = (CANRX_IMU_ANGLEPITCH(&anglePitch) == CANRX_MESSAGE_VALID);
     const bool motorValid = (CANRX_MOTOR_SPEED(&motor_rpm) == CANRX_MESSAGE_VALID);
@@ -319,10 +321,11 @@ static void calculateVehicleSpeed(void)
             speed = app_gps_getHeadingRef()->speedMps;
             vehicle.lpfSpeed.y = motorInReverse ? -speed : speed;
         }
-        else
+        else if (ggaPoses != vehicle.countGgaPoses)
         {
             const float32_t tmp = app_gps_getHeadingRef()->speedMps;
             speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, motorInReverse ? -tmp : tmp);
+            vehicle.countGgaPoses = ggaPoses;
         }
     }
     if (hasValidFrontWheelReference() && getFreshFrontWheelReference(&frontWheelSampleBaseTick))

--- a/components/shared/code/app/app_vehicleSpeed.c
+++ b/components/shared/code/app/app_vehicleSpeed.c
@@ -83,7 +83,7 @@ typedef struct
 #if FEATURE_IS_ENABLED(FEATURE_VEHICLESPEED_LEADER)
     lib_simpleFilter_lpf_S lpfSpeed;
     bool odoSaved;
-    bool wasValidGPS;
+    float32_t gpsMps;
     uint64_t lastFrontWheelSampleBaseTick;
     uint16_t countGgaPoses;
 #endif // FEATURE_VEHICLEPEED_LEADER
@@ -314,20 +314,16 @@ static void calculateVehicleSpeed(void)
         speed += accelAlongAxis * delta_t;
     }
 
-    if (validGPS)
+    const float32_t gpsMps = app_gps_getHeadingRef()->speedMps;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+    if ((validGPS) && (ggaPoses != vehicle.countGgaPoses) && (gpsMps != vehicle.gpsMps) && (gpsMps > 1.0f))
     {
-        if (!vehicle.wasValidGPS)
-        {
-            speed = app_gps_getHeadingRef()->speedMps;
-            vehicle.lpfSpeed.y = motorInReverse ? -speed : speed;
-        }
-        else if (ggaPoses != vehicle.countGgaPoses)
-        {
-            const float32_t tmp = app_gps_getHeadingRef()->speedMps;
-            speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, motorInReverse ? -tmp : tmp);
-            vehicle.countGgaPoses = ggaPoses;
-        }
+        vehicle.gpsMps = gpsMps;
+        vehicle.countGgaPoses = ggaPoses;
+        speed = lib_simpleFilter_lpf_step(&vehicle.lpfSpeed, motorInReverse ? -gpsMps : gpsMps);
     }
+#pragma GCC diagnostic pop
     if (hasValidFrontWheelReference() && getFreshFrontWheelReference(&frontWheelSampleBaseTick))
     {
         const float32_t tmp = RPM_TO_MPS(frontAxleRpm);
@@ -357,7 +353,6 @@ static void calculateVehicleSpeed(void)
     }
 
     vehicle.lastTimestampMS = currentTime;
-    vehicle.wasValidGPS = validGPS;
     app_faultManager_setFaultState(FM_FAULT_VCFRONT_VEHICLESPEEDDEGRADED, !validGPS || !hasValidFrontWheelReference());
 #else // FEATURE_VEHICLEPEED_LEADER
     float32_t tmp = 0.0f;

--- a/components/vc/front/include/lwgps_opts.h
+++ b/components/vc/front/include/lwgps_opts.h
@@ -135,7 +135,7 @@
  *
  * \note            When not enabled, CRC check is ignored
  */
-#define LWGPS_CFG_CRC 1
+#define LWGPS_CFG_CRC 0
 
 /**
  * \brief           Enables `1` or disables `0` distance and bearing calculation

--- a/components/vc/pdu/src/imu.c
+++ b/components/vc/pdu/src/imu.c
@@ -36,7 +36,7 @@
 #define IMU_TIMEOUT_MS 1000U
 #define IMU_SELFTEST_TIMEOUT_MS 500U
 #define BASELINE_SAMPLES 500U
-#define MADGWICK_BETA 0.01f
+#define MADGWICK_BETA 0.4f
 #define IMU_YAW_CAL_MIN_TILT_DEG 5.0f
 
 #define IMU_SELFTEST_ACCEL_MIN_MPS2 (GRAVITY * 0.040f)
@@ -543,8 +543,8 @@ static void updateMadgwick(lib_madgwick_S* f, lib_madgwick_euler_S* g, lib_madgw
     // Dynamically reduce beta when accel magnitude deviates from 1g.
     LIB_LINALG_GETNORM_CVEC((drv_imu_vector_S*)a, &norm);
     const float32_t delta = fabsf(norm - GRAVITY) / GRAVITY;
-    const float32_t bandStart = 0.05f; // full correction within +/-5%
-    const float32_t bandEnd = 0.25f;   // min correction beyond +/-10%
+    const float32_t bandStart = 0.01f; // full correction within +/-1%
+    const float32_t bandEnd = 0.10f;   // min correction beyond +/-10%
     const float32_t minScale = 0.001f;  // keep some correction
     float32_t scale = 1.0f;
     if (delta > bandStart)
@@ -561,7 +561,7 @@ static void updateMadgwick(lib_madgwick_S* f, lib_madgwick_euler_S* g, lib_madgw
     }
 
     const float32_t baseBeta = f->beta;
-    f->beta = baseBeta * scale;
+    f->beta = baseBeta * scale * scale;
     madgwick_update_imu(f, g, a, dt);
     f->beta = baseBeta;
     imu.lastCycle_us = currentTime;

--- a/network/definition/data/components/pm100dx/pm100dx-signals.yaml
+++ b/network/definition/data/components/pm100dx/pm100dx-signals.yaml
@@ -959,7 +959,7 @@ signals:
     description: Measured Motor Speed
     nativeRepresentation:
       bitWidth: 16
-      resolution: 1
+      resolution: -1 # Motor is backward
       range:
         min: -32768
         max: 32767
@@ -971,7 +971,7 @@ signals:
     description: Measured Motor Speed
     nativeRepresentation:
       bitWidth: 16
-      resolution: 1
+      resolution: -1 # Motor is backward
       range:
         min: -32768
         max: 32767


### PR DESCRIPTION
### Changes

1. Fix GGA sentence parsing when satellites are in view
2. Correct motor speed understanding relative to vehicle speed
3. Improve madgwick beta decay to be less bursty during acceleration
4. Update vehicleSpeed when a new gga statement is received and the speed is greater than 1m/s

### Test Plan

- Ensure vehicleSpeed tracks with both GPS speed after update and wheel speed :heavy_check_mark: 
- Ensure vehicle identifies motor controller motor speed as positive when the car is moving forward :heavy_check_mark: 
- Ensure vehicle speed properly identifies when the car is moving in reverse :heavy_check_mark: 
- Ensure vehicleSpeed doesnt drop out when a fix is lost and regained :heavy_check_mark: 
- Ensure vehicleSpeed properly fills in GNSS gaps
