### PR TITLE
mcManager/resolver calibration: Target angle based on motor physical direction

### DIFF
--- a/components/vc/rear/src/mcManager.c
+++ b/components/vc/rear/src/mcManager.c
@@ -227,7 +227,6 @@ static void mcManager_periodic_100Hz(void)
     app_faultManager_setFaultState(FM_FAULT_VCREAR_MCCALIBRATINGRESOLVER, mcManager_data.calibrating);
     mcManager_data.tempTsCap = drv_tempSensors_getChannelTemperatureDegC(DRV_TEMPSENSORS_CHANNEL_TS_CAP);
 
-    const bool motorSpinningPhysicallyForward = motor_rpm > 0;
     motor_rpm                = (int16_t)((motor_rpm < 0) ? -motor_rpm : motor_rpm);
     mcManager_data.axle_rpm  = (uint16_t)(motor_rpm / DRIVETRAIN_MULTIPLIER);
 
@@ -395,7 +394,7 @@ static void mcManager_periodic_100Hz(void)
 
                 if (motor_rpm < 1000)
                 {
-                    const float32_t targetDelta      = motorSpinningPhysicallyForward ? 90.0f : -90.0f;
+                    const float32_t targetDelta      = MOTOR_BACKWARDS ? -90.0f : 90.0f;
                     const float32_t measuredDelta    = lib_simpleFilter_cumAvgF_average(&calibrationData.deltaFilteredMeasuredAvg);
                     const float32_t calibrationDelta = measuredDelta - targetDelta;
 


### PR DESCRIPTION
### Reason for Change

Once https://github.com/concordia-fsae/firmware/pull/606 merged and changed the representation of the pm100dx motor speed with respect to the controllers, it broke the tuning of the motor controller resolver. This tuned the motor controller 180deg from its intended reference point, causing the motor to spin in reverse when driven forward.

Since we always command the motor in the "car forward" frame based on its mechanical implementation, base the target angle on the compile time motor orientation.

### Changes

1. Set target based on mechanical motor orientation

### Test Plan

- Run 2x resolver calibrations, ensure the motor ends calibrated and spins in the vehicle forward direction :white_check_mark: 
