### PR TITLE
updated battery model current limiting

### DIFF
--- a/components/bms_boss/include/BMS.h
+++ b/components/bms_boss/include/BMS.h
@@ -10,6 +10,7 @@
 #include "stdbool.h"
 #include "stdint.h"
 
+#include "batteryModel.h"
 #include "LIB_Types.h"
 
 #define BMS_MAX_SEGMENTS    8U
@@ -113,6 +114,7 @@ extern nvm_bmsData_S           current_data;
 extern nvm_bmsbContactorData_S contactor_data;
 
 extern BMSB_S                  BMS;
+extern batteryModel_S          bm;
 
 NVM_SIZE_ASSERT(nvm_bmsbContactorData_S, 28U);
 

--- a/components/bms_boss/include/CANIO_componentSpecific.h
+++ b/components/bms_boss/include/CANIO_componentSpecific.h
@@ -46,6 +46,8 @@ CAN_prechargeContactorState_E CANIO_tx_getContactorState(void);
 
 #define set_packChargeLimit(m, b, n, s)                set(m, b, n, s, BMS.charge_limit)
 #define set_packDischargeLimit(m, b, n, s)             set(m, b, n, s, BMS.discharge_limit)
+#define set_maxDischargeModeled(m, b, n, s)            set(m, b, n, s, bm.dischargeLimit)
+#define set_maxChargeModeled(m, b, n, s)               set(m, b, n, s, bm.chargeLimit)
 #define set_packVoltage(m, b, n, s)                    set(m, b, n, s, BMS_VPACK_SOURCE)
 #define set_connectedSegments(m, b, n, s)              set(m, b, n, s, BMS.connected_segments)
 #define set_packVoltageCalculated(m, b, n, s)          set(m, b, n, s, BMS.pack_voltage_calculated)

--- a/components/bms_boss/include/CANIO_componentSpecific.h
+++ b/components/bms_boss/include/CANIO_componentSpecific.h
@@ -46,7 +46,7 @@ CAN_prechargeContactorState_E CANIO_tx_getContactorState(void);
 
 #define set_packChargeLimit(m, b, n, s)                set(m, b, n, s, BMS.charge_limit)
 #define set_packDischargeLimit(m, b, n, s)             set(m, b, n, s, BMS.discharge_limit)
-#define set_maxDischargeModeled(m, b, n, s)            set(m, b, n, s, bm.dischargeLimit)
+#define set_maxDischargeModeled(m, b, n, s)            set(m, b, n, s, bm.dischargeLimit * -1)
 #define set_maxChargeModeled(m, b, n, s)               set(m, b, n, s, bm.chargeLimit)
 #define set_packVoltage(m, b, n, s)                    set(m, b, n, s, BMS_VPACK_SOURCE)
 #define set_connectedSegments(m, b, n, s)              set(m, b, n, s, BMS.connected_segments)

--- a/components/bms_boss/src/batteryModel.c
+++ b/components/bms_boss/src/batteryModel.c
@@ -17,6 +17,12 @@
 #include "lib_interpolation.h"
 
 /******************************************************************************
+ *                              D E F I N E S
+ ******************************************************************************/
+
+#define  RI_SAFETY_FACTOR    1.0f;
+
+/******************************************************************************
  *                             T Y P E D E F S
  ******************************************************************************/
 
@@ -124,8 +130,8 @@ static void current_limit(batteryModel_S* batteryModel, float32_t minCellVoltage
     float32_t RiDischarge = (lib_interpolation_interpolate(batteryModel->config.RiMapDischarge, batteryModel_getSOC(batteryModel) * 100));
     float32_t RiCharge    = (lib_interpolation_interpolate(batteryModel->config.RiMapCharge, batteryModel_getSOC(batteryModel) * 100));
 
-    RiDischarge                  = RiDischarge * 1.0f; // safety factor find maximum deviation from average in cell testing
-    RiCharge                     = RiCharge * 1.0f;    // safety factor find maximum deviation from average in cell testing
+    RiDischarge                  = RiDischarge * RI_SAFETY_FACTOR;
+    RiCharge                     = RiCharge * RI_SAFETY_FACTOR;
 
     batteryModel->dischargeLimit = (batteryModel->config.minCellVoltage - minCellVoltage) / RiDischarge + cellCurrent;
     batteryModel->chargeLimit    = (batteryModel->config.maxCellVoltage - maxCellVoltage) / RiCharge + cellCurrent;

--- a/components/bms_boss/src/batteryModel.c
+++ b/components/bms_boss/src/batteryModel.c
@@ -119,16 +119,16 @@ static void model_state_run(batteryModel_S* batteryModel, float32_t cellVoltage,
     }
 }
 
-static void current_limit(batteryModel_S* batteryModel, float32_t minCellVoltage, float32_t maxCellVoltage)
+static void current_limit(batteryModel_S* batteryModel, float32_t minCellVoltage, float32_t maxCellVoltage, float32_t cellCurrent)
 {
     float32_t RiDischarge = (lib_interpolation_interpolate(batteryModel->config.RiMapDischarge, batteryModel_getSOC(batteryModel) * 100));
     float32_t RiCharge    = (lib_interpolation_interpolate(batteryModel->config.RiMapCharge, batteryModel_getSOC(batteryModel) * 100));
 
-    RiDischarge                  = RiDischarge * 1.2f; // safety factor find maximum deviation from average in cell testing
-    RiCharge                     = RiCharge * 1.2f;    // safety factor find maximum deviation from average in cell testing
+    RiDischarge                  = RiDischarge * 1.0f; // safety factor find maximum deviation from average in cell testing
+    RiCharge                     = RiCharge * 1.0f;    // safety factor find maximum deviation from average in cell testing
 
-    batteryModel->dischargeLimit = (batteryModel->config.minCellVoltage - minCellVoltage) / RiDischarge;
-    batteryModel->chargeLimit    = (batteryModel->config.maxCellVoltage - maxCellVoltage) / RiCharge;
+    batteryModel->dischargeLimit = (batteryModel->config.minCellVoltage - minCellVoltage) / RiDischarge + cellCurrent;
+    batteryModel->chargeLimit    = (batteryModel->config.maxCellVoltage - maxCellVoltage) / RiCharge + cellCurrent;
 
     if (batteryModel->dischargeLimit > 0)
     {
@@ -231,6 +231,6 @@ void batteryModel_run(batteryModel_S* batteryModel, float32_t cellVoltage, float
     else if (batteryModel->state == RUNNING)
     {
         model_state_run(batteryModel, cellVoltage, cellCurrent, dt);
-        current_limit(batteryModel, minCellVoltage, maxCellVoltage);
+        current_limit(batteryModel, minCellVoltage, maxCellVoltage, cellCurrent);
     }
 }

--- a/network/definition/data/components/bmsb/bmsb-message.yaml
+++ b/network/definition/data/components/bmsb/bmsb-message.yaml
@@ -168,3 +168,12 @@ messages:
     id: 0x7c0
     signals:
       targetBalancingVoltage:
+      
+  batteryModel:
+    description: BMS Tractive System Battery Model information
+    cycleTimeMs: 100
+    id: 0x7a2
+    sourceBuses: veh
+    signals:
+      maxDischargeModeled:
+      maxChargeModeled:

--- a/network/definition/data/components/bmsb/bmsb-message.yaml
+++ b/network/definition/data/components/bmsb/bmsb-message.yaml
@@ -168,7 +168,7 @@ messages:
     id: 0x7c0
     signals:
       targetBalancingVoltage:
-      
+
   batteryModel:
     description: BMS Tractive System Battery Model information
     cycleTimeMs: 100

--- a/network/definition/data/components/bmsb/bmsb-signals.yaml
+++ b/network/definition/data/components/bmsb/bmsb-signals.yaml
@@ -225,6 +225,32 @@ signals:
       signedness: unsigned
     continuous: true
 
+  maxDischargeModeled:
+    unit: 'A'
+    description: BMS Battery Model Discharge Limit Raw
+    nativeRepresentation:
+      endianness: little
+      bitWidth: 14
+      resolution: 0.1
+      range:
+        min: 0
+        max: 1000
+      signedness: unsigned
+    continuous: true
+
+  maxChargeModeled:
+    unit: 'A'
+    description: BMS Battery Model Charge Limit Raw
+    nativeRepresentation:
+      endianness: little
+      bitWidth: 10
+      resolution: 0.1
+      range:
+        min: 0
+        max: 75
+      signedness: unsigned
+    continuous: true
+
   packRH:
     description: The relative humidity at the BMSB
     unit: "%"


### PR DESCRIPTION
### Reason for Change

Current limiting formula of battery model is more accurate. The result is now added onto the existing pack current.
