### PR TITLE
Improve BMSW voltage resoltion

### DIFF
--- a/network/definition/data/components/bmsw/bmsw-signals.yaml
+++ b/network/definition/data/components/bmsw/bmsw-signals.yaml
@@ -28,22 +28,22 @@ signals:
     description: Segment Minimum Cell Voltage
     unit: V
     nativeRepresentation:
-      bitWidth: 10
+      bitWidth: 13
       range:
         min: 0
         max: 5
-      resolution: 0.005
+      resolution: 0.001
     continuous: true
 
   voltageMax:
     description: Segment Maximum Cell Voltage
     unit: V
     nativeRepresentation:
-      bitWidth: 10
+      bitWidth: 13
       range:
         min: 0
         max: 5
-      resolution: 0.005
+      resolution: 0.001
     continuous: true
 
   segmentVoltage:


### PR DESCRIPTION
### Reason for Change

Currently the workers output a 5mV resolution min/max cell voltage which impacts kalman filter accuracy. Change this to a 1mV resolution.
