### PR TITLE
bmsw: Update max chip when starting parasitic measurement

### DIFF
--- a/components/bms_worker/src/BatteryMonitoring.c
+++ b/components/bms_worker/src/BatteryMonitoring.c
@@ -334,6 +334,7 @@ static void BMS100Hz_PRD()
         max_chip.config.output.output.cell = BMS_CONFIGURED_SERIES_CELLS - 1;    /**< Prepare for next step */
         BMS.delayed_measurement            = true;
         BMS.state                          = BMS_PARASITIC_MEASUREMENT;
+        MAX_readWriteToChip();
     }
     else if (BMS.state == BMS_SAMPLING)
     {


### PR DESCRIPTION
### Reason for Change

Fix bug which allows cell overcharge