### PR TITLE
Bringup baseline sim

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -2,7 +2,6 @@ name: Formatting
 
 on:
   pull_request:
-    branches: [master, comp*]
 
 jobs:
   pre-commit:
@@ -13,6 +12,10 @@ jobs:
       - name: Install pixi
         run: |
           curl -fsSL https://pixi.sh/install.sh | sh && echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: Install shell formatter
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shfmt
       - name: Install formatters
         run: |
           python -m pip install --upgrade pip prek

--- a/.github/workflows/standard_checks.yml
+++ b/.github/workflows/standard_checks.yml
@@ -2,7 +2,6 @@ name: 'Build All Firmware'
 
 on:
   pull_request:
-    branches: [master, comp*]
   push:
     branches: [master, comp*]
 
@@ -19,9 +18,9 @@ jobs:
           buck2_version="$(awk -F'=' '/^buck2_version/ {gsub(/[[:space:]]/, "", $2); print $2}' .buckleconfig.toml)"
           echo "buck2_version=$buck2_version" >> "$GITHUB_OUTPUT"
       - name: Install Buck2
-        uses: dtolnay/install-buck2@latest
+        uses: concordia-fsae/install-buck2@latest
         with:
-          version: ${{ steps.buck2_version.outputs.buck2_version }}
+          release: ${{ steps.buck2_version.outputs.buck2_version }}
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,13 @@ repos:
     hooks:
       - id: taplo-format
         files: \.toml$
-  - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+  - repo: local
     hooks:
       - id: shfmt
+        name: shfmt
+        language: system
+        entry: shfmt
+        args: [-w]
         files: \.sh$
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17

--- a/components/shared/BUCK
+++ b/components/shared/BUCK
@@ -5,7 +5,7 @@ shared_sels = glob(["**/*FeatureSels.yaml"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/..."],
+        visibility = ["PUBLIC"],
     )
     for file in shared_sels
 ]
@@ -14,7 +14,7 @@ shared_defs = glob(["**/*FeatureDefs.yaml"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/..."],
+        visibility = ["PUBLIC"],
     )
     for file in shared_defs
 ]

--- a/components/shared/code/BUCK
+++ b/components/shared/code/BUCK
@@ -5,7 +5,7 @@ srcs = glob(["**/*.c", "**/*_FeatureDefs.yaml"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/...", "//drive-stack/..."],
+        visibility = ["PUBLIC"],
     )
     for file in srcs
 ]

--- a/components/shared/code/RTOS/BUCK
+++ b/components/shared/code/RTOS/BUCK
@@ -5,7 +5,7 @@ srcs = glob(["*.c"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/...", "//sil/..."],
+        visibility = ["//components/...", "//sim/..."],
     )
     for file in srcs
 ]

--- a/components/shared/code/RTOS/BUCK
+++ b/components/shared/code/RTOS/BUCK
@@ -5,7 +5,7 @@ srcs = glob(["*.c"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/..."],
+        visibility = ["//components/...", "//sil/..."],
     )
     for file in srcs
 ]

--- a/components/vc/front/BUCK
+++ b/components/vc/front/BUCK
@@ -171,6 +171,19 @@ export_file(
     visibility = ["//components/vc/front/tests/..."],
 )
 
+[
+    export_file(
+        name = file,
+        src = file,
+        visibility = ["//sil/..."],
+    )
+    for file in [
+        "FeatureDefs.yaml",
+        "FeatureSels.yaml",
+        "variants.yaml",
+    ]
+]
+
 compiler_flags += ["-include", "BuildDefines.h"]
 
 generate_code(

--- a/components/vc/shared/BUCK
+++ b/components/vc/shared/BUCK
@@ -5,7 +5,7 @@ srcs = glob(["**/*.c", "**/*.h"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/...", "//sil/..."],
+        visibility = ["//components/...", "//sim/..."],
     )
     for file in srcs
 ]

--- a/components/vc/shared/BUCK
+++ b/components/vc/shared/BUCK
@@ -5,7 +5,7 @@ srcs = glob(["**/*.c", "**/*.h"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/..."],
+        visibility = ["//components/...", "//sil/..."],
     )
     for file in srcs
 ]

--- a/components/vc/shared/features/BUCK
+++ b/components/vc/shared/features/BUCK
@@ -3,7 +3,7 @@ shared_sels = glob(["**/*FeatureSels.yaml"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/vc/..."],
+        visibility = ["PUBLIC"],
     )
     for file in shared_sels
 ]
@@ -12,7 +12,7 @@ shared_defs = glob(["**/*FeatureDefs.yaml"])
     export_file(
         name = file,
         src = file,
-        visibility = ["//components/vc/..."],
+        visibility = ["PUBLIC"],
     )
     for file in shared_defs
 ]

--- a/sim/infra/BUCK
+++ b/sim/infra/BUCK
@@ -1,0 +1,18 @@
+export_file(
+    name = "pyproject",
+    src = "pyproject.toml",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "uv-lock",
+    src = "uv.lock",
+    visibility = ["PUBLIC"],
+)
+
+genrule(
+    name = "uv-project",
+    out = "uv-project",
+    cmd = "mkdir -p $OUT && cp $(location :pyproject) $OUT/pyproject.toml && cp $(location :uv-lock) $OUT/uv.lock",
+    visibility = ["PUBLIC"],
+)

--- a/sim/infra/defs.bzl
+++ b/sim/infra/defs.bzl
@@ -1,0 +1,377 @@
+load("@prelude//:rules.bzl", __rules__ = "rules")
+load("//components/vehicle_platform:platforms.bzl", "platform_output_name", "platform_target_label")
+
+RIG_RUNTIME_ENV = "RIG_RUNTIME_RS"
+RIG_RUNTIME_SRC = "//sim/infra/runtime:runtime-src"
+RIG_RUNTIME_RUST_ENV = {
+    "RIG_RUNTIME_RUST_APP_RS": "//sim/infra/runtime:rust/app.rs",
+    "RIG_RUNTIME_RUST_CAN_RS": "//sim/infra/runtime:rust/can.rs",
+    "RIG_RUNTIME_RUST_CORE_RS": "//sim/infra/runtime:rust/core.rs",
+    "RIG_RUNTIME_RUST_DATAPATH_RS": "//sim/infra/runtime:rust/datapath.rs",
+    "RIG_RUNTIME_RUST_FAULTS_RS": "//sim/infra/runtime:rust/faults.rs",
+    "RIG_RUNTIME_RUST_FFI_RS": "//sim/infra/runtime:rust/ffi.rs",
+    "RIG_RUNTIME_RUST_IO_RS": "//sim/infra/runtime:rust/io.rs",
+    "RIG_RUNTIME_RUST_MODEL_RS": "//sim/infra/runtime:rust/model.rs",
+    "RIG_RUNTIME_RUST_MODULE_DESC_RS": "//sim/infra/runtime:rust/module_desc.rs",
+    "RIG_RUNTIME_RUST_NVM_RS": "//sim/infra/runtime:rust/nvm.rs",
+    "RIG_RUNTIME_RUST_RT_CONTROLLER_RS": "//sim/infra/runtime:rust/rt_controller.rs",
+    "RIG_RUNTIME_RUST_SPI_RS": "//sim/infra/runtime:rust/spi.rs",
+    "RIG_RUNTIME_RUST_TIMER_RS": "//sim/infra/runtime:rust/timer.rs",
+}
+
+_DEFAULT_MODEL_C_FLAGS = [
+    "-std=c11",
+    "-Wall",
+    "-Wextra",
+    "-include",
+    "BuildDefines.h",
+    "-include",
+    "Utility.h",
+    "-include",
+    "string.h",
+    "-Wno-unused-parameter",
+]
+
+_RIG_RUNTIME_MODULE_SRCS = {
+    "core": ["//sim/infra/runtime:c/src/core.c"],
+    "faults": ["//sim/infra/runtime:c/src/faults.c"],
+    "io": ["//sim/infra/runtime:c/src/io.c"],
+    "peripherals": ["//sim/infra/runtime:c/src/peripherals.c"],
+    "spi": ["//sim/infra/runtime:c/src/spi.c"],
+    "time": ["//sim/infra/runtime:c/src/time.c"],
+}
+
+def rig_runtime_srcs(modules: list[str]):
+    srcs = []
+    for module in modules:
+        if module not in _RIG_RUNTIME_MODULE_SRCS:
+            fail("unknown rig runtime module '{}'; expected one of {}".format(module, _RIG_RUNTIME_MODULE_SRCS.keys()))
+        srcs += _RIG_RUNTIME_MODULE_SRCS[module]
+    return srcs
+
+def rig_platforms_from_variants(platform_variants):
+    return [
+        platform
+        for platform, _variant in platform_variants
+    ]
+
+def rig_model_python(
+        name: str = "python",
+        srcs: list[str] = [],
+        visibility: list[str] | None = None):
+    __rules__["filegroup"](
+        name = name,
+        srcs = srcs,
+        visibility = visibility,
+    )
+
+def rig_model_c_support(
+        name: str = "model-c-support",
+        srcs: list[str] = [],
+        deps: list[str] = [],
+        compiler_flags: list[str] | None = None,
+        visibility: list[str] | None = None,
+        **kwargs):
+    __rules__["cxx_library"](
+        name = name,
+        srcs = srcs,
+        compiler_flags = compiler_flags if compiler_flags else _DEFAULT_MODEL_C_FLAGS,
+        header_namespace = "",
+        deps = deps,
+        preferred_linkage = "static",
+        visibility = visibility,
+        **kwargs
+    )
+
+def _rust_link_args(link_deps: list[str], extra_link_args: list[str]):
+    return " ".join([
+        "-C link-arg=$(location {})".format(dep)
+        for dep in link_deps
+    ] + [
+        "-C link-arg={}".format(arg)
+        for arg in extra_link_args
+    ])
+
+def _rust_genrule_env(rust_env: dict[str, str]):
+    return " ".join([
+        "{}=$PWD/$(location {})".format(name, target)
+        for name, target in rust_env.items()
+    ])
+
+def _rust_test_env(rust_env: dict[str, str]):
+    return {
+        name: "$(location {})".format(target)
+        for name, target in rust_env.items()
+    }
+
+def _bindgen_allowlist_args(
+        allowlist_types: list[str],
+        allowlist_functions: list[str],
+        allowlist_vars: list[str]):
+    return " ".join(
+        ["--allowlist-type {}".format(item) for item in allowlist_types] +
+        ["--allowlist-function {}".format(item) for item in allowlist_functions] +
+        ["--allowlist-var {}".format(item) for item in allowlist_vars]
+    )
+
+def _bindgen_header_lines(include_headers: list[str]):
+    return " ".join([
+        "printf '#include \"%s\"\\n' \"{}\" >> $WRAPPER;".format(header)
+        for header in include_headers
+    ])
+
+def rig_bindgen(
+        name: str,
+        out: str,
+        include_headers: list[str],
+        deps: list[str] = [],
+        headers: dict[str, str] = {},
+        allowlist_types: list[str] = [],
+        allowlist_functions: list[str] = [],
+        allowlist_vars: list[str] = [],
+        bindgen_flags: list[str] = [],
+        clang_flags: list[str] = [],
+        visibility: list[str] | None = None):
+    context_name = name + "-c-context"
+
+    __rules__["cxx_library"](
+        name = context_name,
+        header_namespace = "",
+        headers = headers,
+        exported_deps = deps,
+    )
+
+    clang_arg_string = " ".join(clang_flags)
+    __rules__["genrule"](
+        name = name,
+        out = out,
+        cmd = "WRAPPER=$TMP/bindgen-wrapper.h; " +
+              ": > $WRAPPER; " +
+              _bindgen_header_lines(include_headers) +
+              "bindgen $WRAPPER " +
+              _bindgen_allowlist_args(allowlist_types, allowlist_functions, allowlist_vars) +
+              " " +
+              " ".join(bindgen_flags) +
+              " -- " +
+              "$(cppflags :{}) ".format(context_name) +
+              clang_arg_string +
+              " > $OUT; " +
+              "sed -i 's/^extern \"C\"/unsafe extern \"C\"/' $OUT",
+        visibility = visibility,
+    )
+
+def rig_feature_consts(
+        name: str = "features-rs",
+        out: str = "features.rs",
+        deps: list[str] = [],
+        allowlist_vars: list[str] = [],
+        bindgen_flags: list[str] = [],
+        clang_flags: list[str] = [],
+        visibility: list[str] | None = None):
+    rig_bindgen(
+        name = name,
+        out = out,
+        include_headers = [
+            "FeatureDefines_generated.h",
+        ],
+        deps = deps,
+        allowlist_vars = allowlist_vars,
+        bindgen_flags = [
+            "--no-layout-tests",
+        ] + bindgen_flags,
+        clang_flags = clang_flags,
+        visibility = visibility,
+    )
+
+def rig_python_enums(
+        name: str,
+        out: str,
+        include_headers: list[str],
+        deps: list[str] = [],
+        headers: dict[str, str] = {},
+        c_enums: list[str] = [],
+        rust_sources: list[str] = [],
+        rust_enums: list[str] = [],
+        clang_flags: list[str] = [],
+        visibility: list[str] | None = None):
+    context_name = name + "-c-context"
+
+    __rules__["cxx_library"](
+        name = context_name,
+        header_namespace = "",
+        headers = headers,
+        exported_deps = deps,
+    )
+
+    __rules__["genrule"](
+        name = name,
+        out = out,
+        cmd = "PROJECT=$PWD/$(location //sim/infra:uv-project); " +
+              "WRAPPER=$TMP/python-enums-wrapper.h; " +
+              ": > $WRAPPER; " +
+              _bindgen_header_lines(include_headers) +
+              "UV_INDEX_URL=https://pypi.org/simple " +
+              "UV_DEFAULT_INDEX=https://pypi.org/simple " +
+              "PIP_INDEX_URL=https://pypi.org/simple " +
+              "UV_PROJECT_ENVIRONMENT=/tmp/firmware-sim-rig-venv " +
+              "uv run --locked --project $PROJECT python $(location //sim/infra/rig:gen-python-enums) " +
+              "--c-wrapper $WRAPPER " +
+              " ".join(["--c-enum '{}'".format(item) for item in c_enums]) +
+              " " +
+              " ".join(["--rust-source $(location {})".format(item) for item in rust_sources]) +
+              " " +
+              " ".join(["--rust-enum '{}'".format(item) for item in rust_enums]) +
+              " " +
+              "--out $OUT -- " +
+              "$(cppflags :{}) ".format(context_name) +
+              " ".join(clang_flags),
+        visibility = visibility,
+    )
+
+def rig_python_model(
+        name: str,
+        out: str,
+        rust_source: str,
+        class_name: str,
+        symbol_prefix: str,
+        buck_target: str,
+        env_var: str,
+        enum_env_var: str,
+        enum_target: str,
+        visibility: list[str] | None = None):
+    __rules__["genrule"](
+        name = name,
+        out = out,
+        cmd = "python3 $(location //sim/infra/rig:gen-python-model) " +
+              "--rust-source $(location {}) ".format(rust_source) +
+              "--out $OUT " +
+              "--class-name '{}' ".format(class_name) +
+              "--symbol-prefix '{}' ".format(symbol_prefix) +
+              "--buck-target '{}' ".format(buck_target) +
+              "--env-var '{}' ".format(env_var) +
+              "--enum-env-var '{}' ".format(enum_env_var) +
+              "--enum-target '{}'".format(enum_target),
+        visibility = visibility,
+    )
+
+def rig_embedded_rust_model(
+        name: str = "sil-so",
+        crate: str = "",
+        crate_root: str = "src/lib.rs",
+        out: str = "",
+        link_deps: list[str] = [],
+        test_name: str = "test",
+        test_deps: list[str] | None = None,
+        src_target_name: str = "rust-wrapper-src",
+        extra_link_args: list[str] | None = None,
+        rust_env: dict[str, str] = {},
+        visibility: list[str] | None = None,
+        test_visibility: list[str] | None = None):
+    __rules__["export_file"](
+        name = src_target_name,
+        src = crate_root,
+    )
+
+    __rules__["genrule"](
+        name = name,
+        out = out if out else "lib{}.so".format(crate),
+        cmd = _rust_genrule_env({RIG_RUNTIME_ENV: RIG_RUNTIME_SRC} | RIG_RUNTIME_RUST_ENV | rust_env) +
+              " " +
+              "rustc --edition=2024 --crate-name {} --crate-type cdylib ".format(crate) +
+              "$(location :{}) ".format(src_target_name) +
+              "-o $OUT " +
+              _rust_link_args(link_deps, extra_link_args if extra_link_args else ["-lm"]),
+        visibility = visibility,
+    )
+
+    __rules__["rust_test"](
+        name = test_name,
+        crate = crate,
+        crate_root = crate_root,
+        edition = "2024",
+        srcs = [crate_root],
+        env = _rust_test_env({RIG_RUNTIME_ENV: RIG_RUNTIME_SRC} | RIG_RUNTIME_RUST_ENV | rust_env),
+        deps = test_deps if test_deps != None else link_deps,
+        visibility = test_visibility if test_visibility != None else visibility,
+    )
+
+def rig_embedded_rust_model_platform_aliases(
+        name: str,
+        actual: str,
+        platforms,
+        visibility: list[str] | None = None):
+    [
+        native.configured_alias(
+            name = "{}-{}".format(name, platform_output_name(platform)),
+            actual = actual,
+            platform = platform_target_label(platform),
+            visibility = visibility,
+        )
+        for platform in platforms
+    ]
+
+def rig_platform_sim_lib_env(
+        env_prefix: str,
+        model_target: str,
+        platforms) -> dict[str, str]:
+    return {
+        "{}_{}_SIM_LIB".format(env_prefix, platform_output_name(platform).upper()): "$(location {}:sil-so-{})".format(model_target, platform_output_name(platform))
+        for platform in platforms
+    }
+
+def rig_platform_sim_lib_resources(
+        model_target: str,
+        platforms) -> list[str]:
+    return [
+        "{}:sil-so-{}".format(model_target, platform_output_name(platform))
+        for platform in platforms
+    ]
+
+def rig_platform_variants_env(platforms) -> dict[str, str]:
+    return {
+        "SIM_PLATFORM_VARIANTS": ",".join([
+            platform_output_name(platform)
+            for platform in platforms
+        ]),
+    }
+
+def rig_pytest(
+        name: str,
+        test_file: str,
+        env: dict[str, str] = {},
+        resources: list[str] = [],
+        visibility: list[str] | None = None):
+    uv_runner_name = name + "-uv-runner"
+
+    __rules__["genrule"](
+        name = uv_runner_name,
+        out = "uv-runner",
+        cmd = "printf '%s\n' '#!/usr/bin/env bash' 'project=$1' 'shift' 'exec uv run --locked --project \"$project\" \"$@\"' > $OUT && chmod +x $OUT",
+        executable = True,
+    )
+
+    __rules__["sh_test"](
+        name = name,
+        args = [
+            "$(location //sim/infra:uv-project)",
+            "python",
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-vv",
+            "--durations=10",
+            test_file,
+        ],
+        env = {
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONPATH": ".",
+            "PIP_INDEX_URL": "https://pypi.org/simple",
+            "UV_DEFAULT_INDEX": "https://pypi.org/simple",
+            "UV_INDEX_URL": "https://pypi.org/simple",
+            "UV_PROJECT_ENVIRONMENT": "/tmp/firmware-sim-rig-venv",
+        } | env,
+        resources = ["//sim/infra:uv-project"] + resources,
+        test = ":" + uv_runner_name,
+        visibility = visibility,
+    )

--- a/sim/infra/pyproject.toml
+++ b/sim/infra/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "rig"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["clang==18.1.8", "pytest>=8"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/sim/infra/runtime/BUCK
+++ b/sim/infra/runtime/BUCK
@@ -1,0 +1,31 @@
+export_file(
+    name = "runtime-src",
+    src = "rust/lib.rs",
+    visibility = ["PUBLIC"],
+)
+
+[
+    export_file(
+        name = file,
+        src = file,
+        visibility = ["PUBLIC"],
+    )
+    for file in glob(["c/src/*.c", "rust/*.rs"])
+]
+
+export_file(
+    name = "c/src/runtime_state.h",
+    src = "c/src/runtime_state.h",
+    visibility = ["PUBLIC"],
+)
+
+prebuilt_cxx_library(
+    name = "headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = {
+        header.removeprefix("c/include/"): header
+        for header in glob(["c/include/**/*.h"])
+    },
+    visibility = ["PUBLIC"],
+)

--- a/sim/infra/runtime/c/include/FreeRTOS.h
+++ b/sim/infra/runtime/c/include/FreeRTOS.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef uint32_t StackType_t;
+typedef uint32_t UBaseType_t;
+
+typedef struct
+{
+    uint32_t opaque;
+} StaticTask_t;
+
+typedef void* TaskHandle_t;
+
+#define pdFALSE    0
+#define pdTRUE     1

--- a/sim/infra/runtime/c/include/FreeRTOS_SWI.h
+++ b/sim/infra/runtime/c/include/FreeRTOS_SWI.h
@@ -1,0 +1,5 @@
+#pragma once
+
+static inline void RTOS_SWI_Init(void)
+{
+}

--- a/sim/infra/runtime/c/include/event_groups.h
+++ b/sim/infra/runtime/c/include/event_groups.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef void*    EventGroupHandle_t;
+typedef uint32_t EventBits_t;

--- a/sim/infra/runtime/c/include/rig_runtime.h
+++ b/sim/infra/runtime/c/include/rig_runtime.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "drv_inputAD.h"
+#include "HW_adc.h"
+#include "HW_gpio.h"
+#include "LIB_Types.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct
+{
+    uint32_t id;
+    uint8_t  len;
+    uint8_t  data[8];
+} rig_can_packet_S;
+
+#define RIG_SPI_TRANSACTION_MAX_BYTES    256U
+
+typedef struct
+{
+    int32_t   port;
+    int32_t   channel;
+    float32_t value;
+    uint64_t  timestamp_ns;
+} rig_timer_channel_event_S;
+
+typedef struct
+{
+    int32_t   channel;
+    float32_t value;
+    uint64_t  timestamp_ns;
+} rig_timer_capture_event_S;
+
+typedef struct
+{
+    int32_t  device;
+    uint16_t tx_len;
+    uint16_t rx_len;
+    uint8_t  tx_data[RIG_SPI_TRANSACTION_MAX_BYTES];
+    uint8_t  rx_data[RIG_SPI_TRANSACTION_MAX_BYTES];
+    uint64_t timestamp_ns;
+} rig_spi_transaction_S;
+
+void      rig_runtime_reset(void);
+void      rig_runtime_advance_time_ns(uint64_t elapsed_ns);
+uint64_t  rig_runtime_get_time_ns(void);
+
+void      rig_runtime_set_analog_input(drv_inputAD_channelAnalog_E channel, float32_t voltage);
+float32_t rig_runtime_get_analog_input(drv_inputAD_channelAnalog_E channel);
+
+void      rig_runtime_set_digital_io(HW_GPIO_pinmux_E channel, bool state);
+bool      rig_runtime_get_digital_io(HW_GPIO_pinmux_E channel);
+
+bool      rig_runtime_get_fault(int fault);
+
+uint8_t   rig_runtime_can_bus_count(void);
+bool      rig_runtime_can_push_rx(uint8_t bus, const rig_can_packet_S* packet);
+bool      rig_runtime_can_pop_rx(uint8_t bus, rig_can_packet_S* packet);
+bool      rig_runtime_can_push_tx(uint8_t bus, const rig_can_packet_S* packet);
+bool      rig_runtime_can_pop_tx(uint8_t bus, rig_can_packet_S* packet);
+uint32_t  rig_runtime_can_rx_count(uint8_t bus);
+uint32_t  rig_runtime_can_tx_count(uint8_t bus);
+void      rig_runtime_can_notify_rx(uint8_t bus);
+
+bool      rig_runtime_timer_push_duty_input(const rig_timer_channel_event_S* event);
+bool      rig_runtime_timer_latest_duty_input(int32_t port, int32_t channel, float32_t* value);
+bool      rig_runtime_timer_push_frequency_input(const rig_timer_channel_event_S* event);
+bool      rig_runtime_timer_latest_frequency_input(int32_t port, int32_t channel, float32_t* value);
+bool      rig_runtime_timer_push_capture_input(const rig_timer_capture_event_S* event);
+bool      rig_runtime_timer_latest_capture_input(int32_t channel, float32_t* value);
+bool      rig_runtime_timer_push_duty_output(const rig_timer_channel_event_S* event);
+bool      rig_runtime_timer_pop_duty_output(int32_t port, int32_t channel, rig_timer_channel_event_S* event);
+uint32_t  rig_runtime_timer_duty_output_count(int32_t port, int32_t channel);
+bool      rig_runtime_timer_push_frequency_output(const rig_timer_channel_event_S* event);
+bool      rig_runtime_timer_pop_frequency_output(int32_t port, int32_t channel, rig_timer_channel_event_S* event);
+uint32_t  rig_runtime_timer_frequency_output_count(int32_t port, int32_t channel);
+
+bool      rig_runtime_spi_push_input(const rig_spi_transaction_S* transaction);
+bool      rig_runtime_spi_pop_input(int32_t device, rig_spi_transaction_S* transaction);
+bool      rig_runtime_spi_push_output(const rig_spi_transaction_S* transaction);
+bool      rig_runtime_spi_pop_output(int32_t device, rig_spi_transaction_S* transaction);
+uint32_t  rig_runtime_spi_output_count(int32_t device);

--- a/sim/infra/runtime/c/include/semphr.h
+++ b/sim/infra/runtime/c/include/semphr.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "task.h"

--- a/sim/infra/runtime/c/include/stm32f1xx.h
+++ b/sim/infra/runtime/c/include/stm32f1xx.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef struct
+{
+    uint32_t unused;
+} GPIO_TypeDef;
+
+typedef struct
+{
+    uint32_t unused;
+} TIM_HandleTypeDef;
+
+typedef struct
+{
+    uint32_t unused;
+} ADC_HandleTypeDef;
+
+typedef struct
+{
+    uint32_t unused;
+} CAN_HandleTypeDef;
+
+typedef struct
+{
+    uint32_t unused;
+} UART_HandleTypeDef;
+
+typedef struct
+{
+    uint32_t unused;
+} DMA_HandleTypeDef;
+
+typedef struct
+{
+    uint32_t PLLState;
+    uint32_t PLLSource;
+    uint32_t PLLMUL;
+} RCC_PLLInitTypeDef;
+
+typedef struct
+{
+    uint32_t           OscillatorType;
+    uint32_t           HSEState;
+    uint32_t           HSEPredivValue;
+    uint32_t           HSIState;
+    RCC_PLLInitTypeDef PLL;
+} RCC_OscInitTypeDef;
+
+typedef struct
+{
+    uint32_t ClockType;
+    uint32_t SYSCLKSource;
+    uint32_t AHBCLKDivider;
+    uint32_t APB1CLKDivider;
+    uint32_t APB2CLKDivider;
+} RCC_ClkInitTypeDef;
+
+typedef struct
+{
+    uint32_t PeriphClockSelection;
+    uint32_t AdcClockSelection;
+} RCC_PeriphCLKInitTypeDef;
+
+#define HAL_OK                     0
+#define HAL_UART_ERROR_PE          0x00000001U
+#define HAL_UART_ERROR_NE          0x00000002U
+#define HAL_UART_ERROR_FE          0x00000004U
+#define HAL_UART_ERROR_ORE         0x00000008U
+#define RCC_OSCILLATORTYPE_HSE     0x00000001U
+#define RCC_HSE_ON                 1U
+#define RCC_HSE_PREDIV_DIV1        1U
+#define RCC_HSI_ON                 1U
+#define RCC_PLL_ON                 1U
+#define RCC_PLLSOURCE_HSE          1U
+#define RCC_PLL_MUL8               8U
+#define RCC_CLOCKTYPE_HCLK         0x00000001U
+#define RCC_CLOCKTYPE_SYSCLK       0x00000002U
+#define RCC_CLOCKTYPE_PCLK1        0x00000004U
+#define RCC_CLOCKTYPE_PCLK2        0x00000008U
+#define RCC_SYSCLKSOURCE_PLLCLK    1U
+#define RCC_SYSCLK_DIV1            1U
+#define RCC_HCLK_DIV1              1U
+#define RCC_HCLK_DIV2              2U
+#define RCC_PERIPHCLK_ADC          1U
+#define RCC_ADCPCLK2_DIV8          8U
+#define FLASH_LATENCY_2            2U
+
+static inline int HAL_RCC_OscConfig(RCC_OscInitTypeDef* config)
+{
+    (void)config;
+    return HAL_OK;
+}
+
+static inline int HAL_RCC_ClockConfig(RCC_ClkInitTypeDef* config, uint32_t latency)
+{
+    (void)config;
+    (void)latency;
+    return HAL_OK;
+}
+
+static inline int HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef* config)
+{
+    (void)config;
+    return HAL_OK;
+}
+
+static inline void __disable_irq(void)
+{
+}

--- a/sim/infra/runtime/c/include/stm32f1xx_ll_spi.h
+++ b/sim/infra/runtime/c/include/stm32f1xx_ll_spi.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "stm32f1xx.h"
+
+typedef struct
+{
+    uint32_t unused;
+} SPI_TypeDef;

--- a/sim/infra/runtime/c/include/task.h
+++ b/sim/infra/runtime/c/include/task.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <stdint.h>
+
+#define pdMS_TO_TICKS(ms)        (ms)
+#define portMAX_DELAY            UINT32_MAX
+#define taskSCHEDULER_RUNNING    1
+#define errQUEUE_FULL            0
+
+typedef void* QueueHandle_t;
+
+typedef struct
+{
+    uint32_t opaque;
+} StaticQueue_t;
+
+extern uint32_t    HW_TIM_getTimeMS(void);
+
+static inline void vTaskStartScheduler(void)
+{
+}
+
+static inline void vTaskDelay(uint32_t ticks)
+{
+    (void)ticks;
+}
+
+static inline uint32_t xTaskGetTickCount(void)
+{
+    return HW_TIM_getTimeMS();
+}
+
+static inline TaskHandle_t xTaskGetCurrentTaskHandle(void)
+{
+    return (TaskHandle_t)0;
+}
+
+static inline uint32_t ulTaskGetRunTimePercent(TaskHandle_t task)
+{
+    (void)task;
+    return 0;
+}
+
+static inline UBaseType_t uxTaskGetStackHighWaterMark(TaskHandle_t task)
+{
+    (void)task;
+    return 0;
+}
+
+static inline int xTaskGetSchedulerState(void)
+{
+    return taskSCHEDULER_RUNNING;
+}
+
+static inline uint32_t ulTaskNotifyTake(uint32_t clear_on_exit, uint32_t ticks_to_wait)
+{
+    (void)clear_on_exit;
+    (void)ticks_to_wait;
+    return 0;
+}
+
+static inline int xTaskNotifyGive(TaskHandle_t task)
+{
+    (void)task;
+    return pdTRUE;
+}
+
+static inline void taskENTER_CRITICAL(void)
+{
+}
+
+static inline void taskEXIT_CRITICAL(void)
+{
+}
+
+static inline QueueHandle_t xQueueCreateStatic(
+    UBaseType_t  queue_length,
+    UBaseType_t  item_size,
+    uint8_t      * storage,
+    StaticQueue_t* queue)
+{
+    (void)queue_length;
+    (void)item_size;
+    (void)storage;
+    return queue;
+}
+
+static inline int xQueuePeek(QueueHandle_t queue, void* item, uint32_t ticks)
+{
+    (void)queue;
+    (void)item;
+    (void)ticks;
+    return pdFALSE;
+}
+
+static inline int xQueueReceive(QueueHandle_t queue, void* item, uint32_t ticks)
+{
+    (void)queue;
+    (void)item;
+    (void)ticks;
+    return pdFALSE;
+}
+
+static inline int xQueueSend(QueueHandle_t queue, const void* item, uint32_t ticks)
+{
+    (void)queue;
+    (void)item;
+    (void)ticks;
+    return pdTRUE;
+}
+
+static inline UBaseType_t uxQueueMessagesWaiting(QueueHandle_t queue)
+{
+    (void)queue;
+    return 0;
+}

--- a/sim/infra/runtime/c/src/core.c
+++ b/sim/infra/runtime/c/src/core.c
@@ -1,0 +1,32 @@
+#include "rig_runtime.h"
+
+#include "runtime_state.h"
+
+#include "CAN/CAN.h"
+#include "lib_nvm.h"
+
+#include <string.h>
+
+rig_runtime_state_S rig_runtime;
+RTOS_swiHandle_T    rig_runtime_swi_handles[RTOS_SWI_PRI_COUNT][RTOS_SWI_MAX_PER_PRI];
+uint8_t             rig_runtime_swi_count[RTOS_SWI_PRI_COUNT];
+
+RTOS_swiHandle_T    * CANRX_swi;
+RTOS_swiHandle_T    * CANTX_swi;
+RTOS_swiHandle_T    * NVM_swi;
+
+void rig_runtime_reset(void)
+{
+    memset(&rig_runtime,            0x00, sizeof(rig_runtime));
+    memset(rig_runtime_swi_handles, 0x00, sizeof(rig_runtime_swi_handles));
+    memset(rig_runtime_swi_count,   0x00, sizeof(rig_runtime_swi_count));
+    CANRX_swi = NULL;
+    CANTX_swi = NULL;
+    NVM_swi   = NULL;
+#if FEATURE_IS_ENABLED(FEATURE_CANRX_SWI)
+    CANRX_swi = SWI_create(RTOS_SWI_PRI_0, &CANRX_SWI);
+#endif
+#if FEATURE_IS_ENABLED(FEATURE_CANTX_SWI)
+    CANTX_swi = SWI_create(RTOS_SWI_PRI_0, &CANTX_SWI);
+#endif
+}

--- a/sim/infra/runtime/c/src/faults.c
+++ b/sim/infra/runtime/c/src/faults.c
@@ -1,0 +1,8 @@
+#include "rig_runtime.h"
+
+#include "app_faultManager.h"
+
+bool rig_runtime_get_fault(int fault)
+{
+    return ((fault >= 0) && (fault < FM_FAULT_COUNT)) ? app_faultManager_getFaultState((FM_fault_E)fault) : false;
+}

--- a/sim/infra/runtime/c/src/io.c
+++ b/sim/infra/runtime/c/src/io.c
@@ -1,0 +1,103 @@
+#include "rig_runtime.h"
+
+#include "runtime_state.h"
+
+#include "drv_inputAD_private.h"
+#include "HW.h"
+
+void drv_vn9008_run(void) __attribute__((weak));
+
+void rig_runtime_set_analog_input(drv_inputAD_channelAnalog_E channel, float32_t voltage)
+{
+    if (channel < ADC_BANK1_CHANNEL_COUNT)
+    {
+        rig_runtime.bank1[channel] = voltage;
+    }
+    else
+    {
+        const uint8_t bank2_channel = (uint8_t)channel - ADC_BANK1_CHANNEL_COUNT;
+        if (bank2_channel < ADC_BANK2_CHANNEL_COUNT)
+        {
+            rig_runtime.bank2[bank2_channel] = voltage;
+        }
+    }
+
+    drv_inputAD_private_setAnalogVoltage(channel, voltage);
+    if (drv_vn9008_run != NULL)
+    {
+        drv_vn9008_run();
+    }
+}
+
+float32_t rig_runtime_get_analog_input(drv_inputAD_channelAnalog_E channel)
+{
+    if (channel < ADC_BANK1_CHANNEL_COUNT)
+    {
+        return rig_runtime.bank1[channel];
+    }
+
+    const uint8_t bank2_channel = (uint8_t)channel - ADC_BANK1_CHANNEL_COUNT;
+    return (bank2_channel < ADC_BANK2_CHANNEL_COUNT) ? rig_runtime.bank2[bank2_channel] : 0.0f;
+}
+
+void rig_runtime_set_digital_io(HW_GPIO_pinmux_E channel, bool state)
+{
+    if (channel < HW_GPIO_COUNT)
+    {
+        rig_runtime.gpio[channel] = state;
+    }
+}
+
+bool rig_runtime_get_digital_io(HW_GPIO_pinmux_E channel)
+{
+    return (channel < HW_GPIO_COUNT) ? rig_runtime.gpio[channel] : false;
+}
+
+HW_StatusTypeDef_E HW_ADC_init(void)
+{
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_ADC_deInit(void)
+{
+    return HW_OK;
+}
+
+void HW_ADC_unpackADCBuffer(void)
+{
+}
+
+float32_t HW_ADC_getVFromBank1Channel(HW_adcChannels_bank1_E channel)
+{
+    return (channel < ADC_BANK1_CHANNEL_COUNT) ? rig_runtime.bank1[channel] : 0.0f;
+}
+
+float32_t HW_ADC_getVFromBank2Channel(HW_adcChannels_bank2_E channel)
+{
+    return (channel < ADC_BANK2_CHANNEL_COUNT) ? rig_runtime.bank2[channel] : 0.0f;
+}
+
+HW_StatusTypeDef_E HW_GPIO_init(void)
+{
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_GPIO_deInit(void)
+{
+    return HW_OK;
+}
+
+bool HW_GPIO_readPin(HW_GPIO_pinmux_E pin)
+{
+    return rig_runtime_get_digital_io(pin);
+}
+
+void HW_GPIO_writePin(HW_GPIO_pinmux_E pin, bool state)
+{
+    rig_runtime_set_digital_io(pin, state);
+}
+
+void HW_GPIO_togglePin(HW_GPIO_pinmux_E pin)
+{
+    rig_runtime_set_digital_io(pin, !rig_runtime_get_digital_io(pin));
+}

--- a/sim/infra/runtime/c/src/peripherals.c
+++ b/sim/infra/runtime/c/src/peripherals.c
@@ -1,0 +1,177 @@
+#include "rig_runtime.h"
+
+#include "runtime_state.h"
+
+#include "CAN/CAN.h"
+#include "HW.h"
+#include "HW_can.h"
+#include "HW_flash.h"
+
+typedef enum
+{
+    RIG_HW_UART_PORT_UNUSED = 0U,
+} HW_UART_port_E;
+
+RTOS_swiHandle_T* SWI_create(RTOS_swiPri_E priority, RTOS_swiFn_t handler)
+{
+    if ((priority >= RTOS_SWI_PRI_COUNT) || (rig_runtime_swi_count[priority] >= RTOS_SWI_MAX_PER_PRI))
+    {
+        return NULL;
+    }
+
+    const uint8_t   index    = rig_runtime_swi_count[priority]++;
+    RTOS_swiHandle_T* handle = &rig_runtime_swi_handles[priority][index];
+    handle->handler  = handler;
+    handle->priority = priority;
+    handle->event    = 1UL << index;
+    return handle;
+}
+
+void SWI_invoke(RTOS_swiHandle_T* handle)
+{
+    if ((handle != NULL) && (handle->handler != NULL))
+    {
+        handle->handler();
+    }
+}
+
+bool SWI_invokeFromISR(RTOS_swiHandle_T* handle)
+{
+    SWI_invoke(handle);
+    return true;
+}
+
+void SWI_disable(void)
+{
+}
+
+void SWI_enable(void)
+{
+}
+
+HW_StatusTypeDef_E HW_CAN_start(CAN_bus_E bus)
+{
+    (void)bus;
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_CAN_stop(CAN_bus_E bus)
+{
+    (void)bus;
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_CAN_sendMsgOnPeripheral(CAN_bus_E bus, CAN_TxMessage_T msg)
+{
+    rig_can_packet_S packet = {
+        .id  = msg.id,
+        .len = msg.lengthBytes,
+    };
+
+    packet.data[0] = msg.data.u8[0];
+    packet.data[1] = msg.data.u8[1];
+    packet.data[2] = msg.data.u8[2];
+    packet.data[3] = msg.data.u8[3];
+    packet.data[4] = msg.data.u8[4];
+    packet.data[5] = msg.data.u8[5];
+    packet.data[6] = msg.data.u8[6];
+    packet.data[7] = msg.data.u8[7];
+    return rig_runtime_can_push_tx((uint8_t)bus, &packet) ? HW_OK : HW_ERROR;
+}
+
+void HW_CAN_activateFifoNotifications(CAN_bus_E bus, CAN_RxFifo_E rxFifo)
+{
+    (void)bus;
+    (void)rxFifo;
+}
+
+void rig_runtime_can_notify_rx(uint8_t bus)
+{
+#if FEATURE_IS_ENABLED(FEATURE_CANRX_SWI)
+    CANRX_notify((CAN_bus_E)bus, CAN_RX_FIFO_0);
+#else
+    (void)bus;
+#endif
+}
+
+bool HW_CAN_sendMsg(CAN_bus_E bus, CAN_data_T data, uint32_t id, uint8_t len)
+{
+    const CAN_TxMessage_T msg = {
+        .id          = id,
+        .IDE         = CAN_IDENTIFIER_STD,
+        .RTR         = CAN_REMOTE_TRANSMISSION_REQUEST_DATA,
+        .lengthBytes = len,
+        .data        = data,
+    };
+
+    return HW_CAN_sendMsgOnPeripheral(bus, msg) == HW_OK;
+}
+
+bool HW_CAN_getRxMessage(CAN_bus_E bus, CAN_RxFifo_E rxFifo, CAN_RxMessage_T* rx)
+{
+    (void)rxFifo;
+    rig_can_packet_S packet = { 0U };
+    if ((rx == NULL) || !rig_runtime_can_pop_rx((uint8_t)bus, &packet))
+    {
+        return false;
+    }
+
+    rx->id               = packet.id;
+    rx->IDE              = CAN_IDENTIFIER_STD;
+    rx->RTR              = CAN_REMOTE_TRANSMISSION_REQUEST_DATA;
+    rx->lengthBytes      = packet.len;
+    rx->data.u8[0]       = packet.data[0];
+    rx->data.u8[1]       = packet.data[1];
+    rx->data.u8[2]       = packet.data[2];
+    rx->data.u8[3]       = packet.data[3];
+    rx->data.u8[4]       = packet.data[4];
+    rx->data.u8[5]       = packet.data[5];
+    rx->data.u8[6]       = packet.data[6];
+    rx->data.u8[7]       = packet.data[7];
+    rx->timestamp        = (uint16_t)(rig_runtime.time_ns / 1000000ULL);
+    rx->filterMatchIndex = 0U;
+    return true;
+}
+
+HW_StatusTypeDef_E HW_UART_startDMARX(HW_UART_port_E port, uint32_t* data, uint32_t size)
+{
+    (void)port;
+    (void)data;
+    (void)size;
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_UART_stopDMA(HW_UART_port_E port)
+{
+    (void)port;
+    return HW_OK;
+}
+
+uint32_t FLASH_getPageSize(void)
+{
+    return 1024U;
+}
+
+bool FLASH_erasePages(uint32_t pageAddr, uint16_t pages)
+{
+    (void)pageAddr;
+    (void)pages;
+    return true;
+}
+
+bool FLASH_writeHalfwords(uint32_t addr, uint16_t* data, uint16_t dataLen)
+{
+    (void)addr;
+    (void)data;
+    (void)dataLen;
+    return true;
+}
+
+bool HW_mcuShuttingDown(void)
+{
+    return false;
+}
+
+void HW_systemHardReset(void)
+{
+}

--- a/sim/infra/runtime/c/src/runtime_state.h
+++ b/sim/infra/runtime/c/src/runtime_state.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "FreeRTOS_SWI.h"
+#include "HW_adc.h"
+#include "HW_gpio.h"
+#include "LIB_Types.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct
+{
+    float32_t bank1[ADC_BANK1_CHANNEL_COUNT];
+    float32_t bank2[ADC_BANK2_CHANNEL_COUNT];
+    bool      gpio[HW_GPIO_COUNT];
+    uint64_t  time_ns;
+} rig_runtime_state_S;
+
+extern rig_runtime_state_S rig_runtime;
+extern RTOS_swiHandle_T    rig_runtime_swi_handles[RTOS_SWI_PRI_COUNT][RTOS_SWI_MAX_PER_PRI];
+extern uint8_t             rig_runtime_swi_count[RTOS_SWI_PRI_COUNT];

--- a/sim/infra/runtime/c/src/spi.c
+++ b/sim/infra/runtime/c/src/spi.c
@@ -1,0 +1,141 @@
+#include "HW_spi.h"
+
+#include "rig_runtime.h"
+#include "runtime_state.h"
+
+#include "string.h"
+
+static uint16_t rig_spi_clamped_len(uint16_t len)
+{
+    return (len > RIG_SPI_TRANSACTION_MAX_BYTES) ? RIG_SPI_TRANSACTION_MAX_BYTES : len;
+}
+
+static void rig_spi_copy_tx(rig_spi_transaction_S* transaction, const uint8_t* data, uint16_t len)
+{
+    const uint16_t copy_len = rig_spi_clamped_len(len);
+
+    if ((data != NULL) && (copy_len > 0U))
+    {
+        memcpy(transaction->tx_data, data, copy_len);
+    }
+}
+
+static void rig_spi_fill_rx_from_model(HW_spi_device_E dev, uint8_t* data, uint16_t len)
+{
+    if ((data == NULL) || (len == 0U))
+    {
+        return;
+    }
+
+    rig_spi_transaction_S rx_transaction = { 0 };
+    if (rig_runtime_spi_pop_input((int32_t)dev, &rx_transaction))
+    {
+        const uint16_t copy_len = (rx_transaction.rx_len < len) ? rx_transaction.rx_len : len;
+        if (copy_len > 0U)
+        {
+            memcpy(data, rx_transaction.rx_data, copy_len);
+        }
+        if (copy_len < len)
+        {
+            memset(&data[copy_len], 0xFF, (size_t)(len - copy_len));
+        }
+        return;
+    }
+
+    memset(data, 0xFF, len);
+}
+
+HW_StatusTypeDef_E HW_SPI_init(void)
+{
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_SPI_init_componentSpecific(void)
+{
+    return HW_OK;
+}
+
+HW_StatusTypeDef_E HW_SPI_deInit(void)
+{
+    return HW_OK;
+}
+
+bool HW_SPI_lock(HW_spi_device_E dev)
+{
+    (void)dev;
+    return true;
+}
+
+bool HW_SPI_release(HW_spi_device_E dev)
+{
+    (void)dev;
+    return true;
+}
+
+bool HW_SPI_transmit(HW_spi_device_E dev, uint8_t* data, uint16_t len)
+{
+    rig_spi_transaction_S transaction = {
+        .device       = (int32_t)dev,
+        .tx_len       = rig_spi_clamped_len(len),
+        .rx_len       =                       0U,
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    rig_spi_copy_tx(&transaction, data, len);
+    (void)rig_runtime_spi_push_output(&transaction);
+    return true;
+}
+
+bool HW_SPI_receive(HW_spi_device_E dev, uint8_t* data, uint16_t len)
+{
+    const rig_spi_transaction_S transaction = {
+        .device       = (int32_t)dev,
+        .tx_len       =                       0U,
+        .rx_len       = rig_spi_clamped_len(len),
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    (void)rig_runtime_spi_push_output(&transaction);
+    rig_spi_fill_rx_from_model(dev, data, len);
+    return true;
+}
+
+bool HW_SPI_transmitReceive(HW_spi_device_E dev, uint8_t* rwData, uint16_t len)
+{
+    rig_spi_transaction_S transaction = {
+        .device       = (int32_t)dev,
+        .tx_len       = rig_spi_clamped_len(len),
+        .rx_len       = rig_spi_clamped_len(len),
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    rig_spi_copy_tx(&transaction, rwData, len);
+    (void)rig_runtime_spi_push_output(&transaction);
+    rig_spi_fill_rx_from_model(dev, rwData, len);
+    return true;
+}
+
+bool HW_SPI_transmitReceiveAsym(HW_spi_device_E dev, uint8_t* wData, uint16_t wLen, uint8_t* rData, uint16_t rLen)
+{
+    rig_spi_transaction_S transaction = {
+        .device       = (int32_t)dev,
+        .tx_len       = rig_spi_clamped_len(wLen),
+        .rx_len       = rig_spi_clamped_len(rLen),
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    rig_spi_copy_tx(&transaction, wData, wLen);
+    (void)rig_runtime_spi_push_output(&transaction);
+    rig_spi_fill_rx_from_model(dev, rData, rLen);
+    return true;
+}
+
+bool HW_SPI_dmaTransmitReceive(HW_spi_device_E dev, uint8_t* rwData, uint16_t len)
+{
+    return HW_SPI_transmitReceive(dev, rwData, len);
+}
+
+bool HW_SPI_dmaTransmitReceiveAsym(HW_spi_device_E dev, uint8_t* wData, uint16_t wLen, uint8_t* rData, uint16_t rLen)
+{
+    return HW_SPI_transmitReceiveAsym(dev, wData, wLen, rData, rLen);
+}

--- a/sim/infra/runtime/c/src/time.c
+++ b/sim/infra/runtime/c/src/time.c
@@ -1,0 +1,79 @@
+#include "rig_runtime.h"
+
+#include "runtime_state.h"
+
+#include "HW_tim.h"
+
+void rig_runtime_advance_time_ns(uint64_t elapsed_ns)
+{
+    rig_runtime.time_ns += elapsed_ns;
+}
+
+uint32_t HW_TIM_getTimeMS(void)
+{
+    return (uint32_t)(rig_runtime.time_ns / 1000000ULL);
+}
+
+uint64_t rig_runtime_get_time_ns(void)
+{
+    return rig_runtime.time_ns;
+}
+
+uint64_t HW_TIM_getBaseTick(void)
+{
+    return rig_runtime.time_ns / 1000ULL;
+}
+
+float32_t HW_TIM_getFreq(HW_TIM_channelFreq_E channel)
+{
+    float32_t value = 0.0f;
+
+    (void)rig_runtime_timer_latest_capture_input((int32_t)channel, &value);
+    return value;
+}
+
+uint64_t HW_TIM_getLastCaptureBaseTick(HW_TIM_channelFreq_E channel)
+{
+    (void)channel;
+    return HW_TIM_getBaseTick();
+}
+
+void HW_TIM_setDuty(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t percentage)
+{
+    const rig_timer_channel_event_S event = {
+        .port         = (int32_t)port,
+        .channel      = (int32_t)channel,
+        .value        = percentage,
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    (void)rig_runtime_timer_push_duty_output(&event);
+}
+
+void HW_TIM_setFreqHz(HW_TIM_port_E port, HW_TIM_channel_E channel, float32_t hz)
+{
+    const rig_timer_channel_event_S event = {
+        .port         = (int32_t)port,
+        .channel      = (int32_t)channel,
+        .value        = hz,
+        .timestamp_ns = rig_runtime.time_ns,
+    };
+
+    (void)rig_runtime_timer_push_frequency_output(&event);
+}
+
+float32_t HW_TIM_getDuty(HW_TIM_port_E port, HW_TIM_channel_E channel)
+{
+    float32_t value = 0.0f;
+
+    (void)rig_runtime_timer_latest_duty_input((int32_t)port, (int32_t)channel, &value);
+    return value;
+}
+
+float32_t HW_TIM_getFreqHz(HW_TIM_port_E port, HW_TIM_channel_E channel)
+{
+    float32_t value = 0.0f;
+
+    (void)rig_runtime_timer_latest_frequency_input((int32_t)port, (int32_t)channel, &value);
+    return value;
+}

--- a/sim/infra/runtime/rust/app.rs
+++ b/sim/infra/runtime/rust/app.rs
@@ -1,0 +1,26 @@
+#[repr(C)]
+pub struct AppDesc {
+    pub app_start: u32,
+    pub app_end: u32,
+    pub app_crc_location: u32,
+    pub app_component_id: u16,
+    pub app_variant_id: u16,
+}
+
+impl AppDesc {
+    pub const fn new(
+        app_start: u32,
+        app_end: u32,
+        app_crc_location: u32,
+        app_component_id: u16,
+        app_variant_id: u16,
+    ) -> Self {
+        Self {
+            app_start,
+            app_end,
+            app_crc_location,
+            app_component_id,
+            app_variant_id,
+        }
+    }
+}

--- a/sim/infra/runtime/rust/can.rs
+++ b/sim/infra/runtime/rust/can.rs
@@ -1,0 +1,674 @@
+use std::collections::VecDeque;
+use std::sync::{LazyLock, Mutex};
+
+unsafe extern "C" {
+    fn rig_runtime_can_notify_rx(bus: u8);
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanPacket {
+    pub id: u32,
+    pub len: u8,
+    pub data: [u8; 8],
+}
+
+impl CanPacket {
+    pub fn new(id: u32, data: [u8; 8], len: u8) -> Self {
+        Self { id, len, data }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanEvent {
+    pub bus: u8,
+    pub timestamp_ns: u64,
+    pub packet: CanPacket,
+}
+
+#[derive(Default)]
+struct CanRuntime {
+    rx: Vec<VecDeque<CanPacket>>,
+    tx: Vec<VecDeque<CanEvent>>,
+    network: Option<CanNetwork>,
+}
+
+impl CanRuntime {
+    fn configure(&mut self, bus_count: u8) {
+        self.rx = vec![VecDeque::new(); bus_count as usize];
+        self.tx = vec![VecDeque::new(); bus_count as usize];
+    }
+
+    fn reset(&mut self) {
+        self.rx.clear();
+        self.tx.clear();
+        self.network = None;
+    }
+
+    fn bus_count(&self) -> u8 {
+        self.rx.len() as u8
+    }
+
+    fn push_rx(&mut self, bus: u8, packet: CanPacket) -> bool {
+        self.rx
+            .get_mut(bus as usize)
+            .map(|queue| queue.push_back(packet))
+            .is_some()
+    }
+
+    fn pop_rx(&mut self, bus: u8) -> Option<CanPacket> {
+        self.rx.get_mut(bus as usize).and_then(VecDeque::pop_front)
+    }
+
+    fn push_tx(&mut self, bus: u8, packet: CanPacket, timestamp_ns: u64) -> bool {
+        self.tx
+            .get_mut(bus as usize)
+            .map(|queue| {
+                queue.push_back(CanEvent {
+                    bus,
+                    timestamp_ns,
+                    packet,
+                })
+            })
+            .is_some()
+    }
+
+    fn pop_tx(&mut self, bus: u8) -> Option<CanEvent> {
+        self.tx.get_mut(bus as usize).and_then(VecDeque::pop_front)
+    }
+
+    fn rx_count(&self, bus: u8) -> u32 {
+        self.rx
+            .get(bus as usize)
+            .map(VecDeque::len)
+            .unwrap_or_default() as u32
+    }
+
+    fn tx_count(&self, bus: u8) -> u32 {
+        self.tx
+            .get(bus as usize)
+            .map(VecDeque::len)
+            .unwrap_or_default() as u32
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanMessageDescriptor {
+    pub bus: u8,
+    pub id: u32,
+    pub len: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanSignalDescriptor {
+    pub bus: u8,
+    pub message_id: u32,
+    pub kind: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanEnumValueDescriptor {
+    pub raw: i32,
+}
+
+pub type CanBusNameFn = fn(u8) -> Option<&'static str>;
+pub type CanMessageCountFn = fn() -> u32;
+pub type CanMessageDescriptorFn = fn(u32) -> Option<CanMessageDescriptor>;
+pub type CanMessageNameFn = fn(u32) -> Option<&'static str>;
+pub type CanSignalCountFn = fn() -> u32;
+pub type CanSignalDescriptorFn = fn(u32) -> Option<CanSignalDescriptor>;
+pub type CanSignalStringFn = fn(u32) -> Option<&'static str>;
+pub type CanEnumValueCountFn = fn() -> u32;
+pub type CanEnumValueDescriptorFn = fn(u32) -> Option<CanEnumValueDescriptor>;
+pub type CanEnumValueStringFn = fn(u32) -> Option<&'static str>;
+pub type CanDecodeSignalFn = fn(u8, &CanPacket, &str) -> Option<f64>;
+pub type CanEncodeSignalFn = fn(u8, &str, &str, f64, &mut CanPacket) -> bool;
+
+#[derive(Clone, Copy)]
+pub struct CanNetwork {
+    pub bus_count: fn() -> u8,
+    pub bus_name: CanBusNameFn,
+    pub message_count: CanMessageCountFn,
+    pub message_descriptor: CanMessageDescriptorFn,
+    pub message_name: CanMessageNameFn,
+    pub tx_message_count: CanMessageCountFn,
+    pub tx_message_descriptor: CanMessageDescriptorFn,
+    pub tx_message_name: CanMessageNameFn,
+    pub signal_count: CanSignalCountFn,
+    pub signal_descriptor: CanSignalDescriptorFn,
+    pub signal_message_name: CanSignalStringFn,
+    pub signal_name: CanSignalStringFn,
+    pub signal_unit: CanSignalStringFn,
+    pub signal_enum_name: CanSignalStringFn,
+    pub tx_signal_count: CanSignalCountFn,
+    pub tx_signal_descriptor: CanSignalDescriptorFn,
+    pub tx_signal_message_name: CanSignalStringFn,
+    pub tx_signal_name: CanSignalStringFn,
+    pub tx_signal_unit: CanSignalStringFn,
+    pub tx_signal_enum_name: CanSignalStringFn,
+    pub enum_value_count: CanEnumValueCountFn,
+    pub enum_value_descriptor: CanEnumValueDescriptorFn,
+    pub enum_value_enum_name: CanEnumValueStringFn,
+    pub enum_value_label: CanEnumValueStringFn,
+    pub decode_signal: CanDecodeSignalFn,
+    pub encode_signal: CanEncodeSignalFn,
+}
+
+static CAN_RUNTIME: LazyLock<Mutex<CanRuntime>> =
+    LazyLock::new(|| Mutex::new(CanRuntime::default()));
+
+pub fn configure(bus_count: u8) {
+    CAN_RUNTIME.lock().unwrap().configure(bus_count);
+}
+
+pub fn configure_network(network: CanNetwork) {
+    let mut runtime = CAN_RUNTIME.lock().unwrap();
+    runtime.configure((network.bus_count)());
+    runtime.network = Some(network);
+}
+
+pub fn reset() {
+    CAN_RUNTIME.lock().unwrap().reset();
+}
+
+pub fn bus_count() -> u8 {
+    CAN_RUNTIME.lock().unwrap().bus_count()
+}
+
+pub fn send(bus: u8, packet: &CanPacket) -> bool {
+    if CAN_RUNTIME.lock().unwrap().push_rx(bus, *packet) {
+        unsafe { rig_runtime_can_notify_rx(bus) };
+        true
+    } else {
+        false
+    }
+}
+
+pub fn recv_event(bus: u8) -> Option<CanEvent> {
+    CAN_RUNTIME.lock().unwrap().pop_tx(bus)
+}
+
+pub fn recv(bus: u8) -> Option<CanPacket> {
+    recv_event(bus).map(|event| event.packet)
+}
+
+pub fn rx_count(bus: u8) -> u32 {
+    CAN_RUNTIME.lock().unwrap().rx_count(bus)
+}
+
+pub fn tx_count(bus: u8) -> u32 {
+    CAN_RUNTIME.lock().unwrap().tx_count(bus)
+}
+
+fn with_network<T>(default: T, f: impl FnOnce(CanNetwork) -> T) -> T {
+    CAN_RUNTIME
+        .lock()
+        .unwrap()
+        .network
+        .map(f)
+        .unwrap_or(default)
+}
+
+pub fn codegen_bus_count() -> u8 {
+    with_network(0, |network| (network.bus_count)())
+}
+
+pub fn codegen_bus_name(bus: u8) -> Option<&'static str> {
+    with_network(None, |network| (network.bus_name)(bus))
+}
+
+pub fn codegen_message_count() -> u32 {
+    with_network(0, |network| (network.message_count)())
+}
+
+pub fn codegen_message_descriptor(index: u32) -> Option<CanMessageDescriptor> {
+    with_network(None, |network| (network.message_descriptor)(index))
+}
+
+pub fn codegen_message_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.message_name)(index))
+}
+
+pub fn codegen_tx_message_count() -> u32 {
+    with_network(0, |network| (network.tx_message_count)())
+}
+
+pub fn codegen_tx_message_descriptor(index: u32) -> Option<CanMessageDescriptor> {
+    with_network(None, |network| (network.tx_message_descriptor)(index))
+}
+
+pub fn codegen_tx_message_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.tx_message_name)(index))
+}
+
+pub fn codegen_signal_count() -> u32 {
+    with_network(0, |network| (network.signal_count)())
+}
+
+pub fn codegen_signal_descriptor(index: u32) -> Option<CanSignalDescriptor> {
+    with_network(None, |network| (network.signal_descriptor)(index))
+}
+
+pub fn codegen_signal_message_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.signal_message_name)(index))
+}
+
+pub fn codegen_signal_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.signal_name)(index))
+}
+
+pub fn codegen_signal_unit(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.signal_unit)(index))
+}
+
+pub fn codegen_signal_enum_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.signal_enum_name)(index))
+}
+
+pub fn codegen_tx_signal_count() -> u32 {
+    with_network(0, |network| (network.tx_signal_count)())
+}
+
+pub fn codegen_tx_signal_descriptor(index: u32) -> Option<CanSignalDescriptor> {
+    with_network(None, |network| (network.tx_signal_descriptor)(index))
+}
+
+pub fn codegen_tx_signal_message_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.tx_signal_message_name)(index))
+}
+
+pub fn codegen_tx_signal_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.tx_signal_name)(index))
+}
+
+pub fn codegen_tx_signal_unit(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.tx_signal_unit)(index))
+}
+
+pub fn codegen_tx_signal_enum_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.tx_signal_enum_name)(index))
+}
+
+pub fn codegen_enum_value_count() -> u32 {
+    with_network(0, |network| (network.enum_value_count)())
+}
+
+pub fn codegen_enum_value_descriptor(index: u32) -> Option<CanEnumValueDescriptor> {
+    with_network(None, |network| (network.enum_value_descriptor)(index))
+}
+
+pub fn codegen_enum_value_enum_name(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.enum_value_enum_name)(index))
+}
+
+pub fn codegen_enum_value_label(index: u32) -> Option<&'static str> {
+    with_network(None, |network| (network.enum_value_label)(index))
+}
+
+pub fn decode_signal(bus: u8, packet: &CanPacket, signal_name: &str) -> Option<f64> {
+    with_network(None, |network| {
+        (network.decode_signal)(bus, packet, signal_name)
+    })
+}
+
+pub fn encode_signal(
+    bus: u8,
+    message_name: &str,
+    signal_name: &str,
+    value: f64,
+    packet: &mut CanPacket,
+) -> bool {
+    with_network(false, |network| {
+        (network.encode_signal)(bus, message_name, signal_name, value, packet)
+    })
+}
+
+#[macro_export]
+macro_rules! rig_yamcan_network {
+    ($network:ident, $model:ident, $decode:ident, $yamcan:ident) => {
+        const $network: $crate::rig_runtime::CanNetwork = $crate::rig_runtime::CanNetwork {
+            bus_count: rig_can_bus_count,
+            bus_name: rig_can_bus_name,
+            message_count: rig_can_message_count,
+            message_descriptor: rig_can_message_descriptor,
+            message_name: rig_can_message_name,
+            tx_message_count: rig_can_tx_message_count,
+            tx_message_descriptor: rig_can_tx_message_descriptor,
+            tx_message_name: rig_can_tx_message_name,
+            signal_count: rig_can_signal_count,
+            signal_descriptor: rig_can_signal_descriptor,
+            signal_message_name: rig_can_signal_message_name,
+            signal_name: rig_can_signal_name,
+            signal_unit: rig_can_signal_unit,
+            signal_enum_name: rig_can_signal_enum_name,
+            tx_signal_count: rig_can_tx_signal_count,
+            tx_signal_descriptor: rig_can_tx_signal_descriptor,
+            tx_signal_message_name: rig_can_tx_signal_message_name,
+            tx_signal_name: rig_can_tx_signal_name,
+            tx_signal_unit: rig_can_tx_signal_unit,
+            tx_signal_enum_name: rig_can_tx_signal_enum_name,
+            enum_value_count: rig_can_enum_value_count,
+            enum_value_descriptor: rig_can_enum_value_descriptor,
+            enum_value_enum_name: rig_can_enum_value_enum_name,
+            enum_value_label: rig_can_enum_value_label,
+            decode_signal: rig_can_decode_signal,
+            encode_signal: rig_can_encode_signal,
+        };
+
+        fn rig_bus_from_raw(bus: u8) -> Option<$model::Bus> {
+            <$decode::GeneratedNetwork as $yamcan::NetworkDecoder>::buses()
+                .get(bus as usize)
+                .map(|desc| desc.name)
+        }
+
+        fn rig_bus_to_raw(bus: $model::Bus) -> Option<u8> {
+            <$decode::GeneratedNetwork as $yamcan::NetworkDecoder>::buses()
+                .iter()
+                .position(|desc| desc.name == bus)
+                .map(|index| index as u8)
+        }
+
+        fn rig_signal_kind_to_raw(kind: $yamcan::SignalKind) -> u8 {
+            match kind {
+                $yamcan::SignalKind::Numeric => 0,
+                $yamcan::SignalKind::Boolean => 1,
+                $yamcan::SignalKind::Enum => 2,
+            }
+        }
+
+        fn rig_can_bus_count() -> u8 {
+            <$decode::GeneratedNetwork as $yamcan::NetworkDecoder>::buses().len() as u8
+        }
+
+        fn rig_can_bus_name(bus: u8) -> Option<&'static str> {
+            rig_bus_from_raw(bus).map(<$model::Bus as $yamcan::NetworkBus>::as_str)
+        }
+
+        fn rig_can_message_count() -> u32 {
+            $model::message_descriptors().len() as u32
+        }
+
+        fn rig_can_message_descriptor(
+            index: u32,
+        ) -> Option<$crate::rig_runtime::CanMessageDescriptor> {
+            let Some(message) = $model::message_descriptors().get(index as usize) else {
+                return None;
+            };
+            let Some(bus) = rig_bus_to_raw(message.bus) else {
+                return None;
+            };
+
+            Some($crate::rig_runtime::CanMessageDescriptor {
+                bus,
+                id: message.id,
+                len: message.len,
+            })
+        }
+
+        fn rig_can_message_name(index: u32) -> Option<&'static str> {
+            $model::message_descriptors()
+                .get(index as usize)
+                .map(|message| message.name)
+        }
+
+        fn rig_can_tx_message_count() -> u32 {
+            $model::tx_message_descriptors().len() as u32
+        }
+
+        fn rig_can_tx_message_descriptor(
+            index: u32,
+        ) -> Option<$crate::rig_runtime::CanMessageDescriptor> {
+            let Some(message) = $model::tx_message_descriptors().get(index as usize) else {
+                return None;
+            };
+            let Some(bus) = rig_bus_to_raw(message.bus) else {
+                return None;
+            };
+
+            Some($crate::rig_runtime::CanMessageDescriptor {
+                bus,
+                id: message.id,
+                len: message.len,
+            })
+        }
+
+        fn rig_can_tx_message_name(index: u32) -> Option<&'static str> {
+            $model::tx_message_descriptors()
+                .get(index as usize)
+                .map(|message| message.name)
+        }
+
+        fn rig_can_signal_count() -> u32 {
+            $model::signal_descriptors().len() as u32
+        }
+
+        fn rig_can_signal_descriptor(
+            index: u32,
+        ) -> Option<$crate::rig_runtime::CanSignalDescriptor> {
+            let Some(signal) = $model::signal_descriptors().get(index as usize) else {
+                return None;
+            };
+            let Some(bus) = rig_bus_to_raw(signal.bus) else {
+                return None;
+            };
+
+            Some($crate::rig_runtime::CanSignalDescriptor {
+                bus,
+                message_id: signal.message_id,
+                kind: rig_signal_kind_to_raw(signal.kind),
+            })
+        }
+
+        fn rig_can_signal_message_name(index: u32) -> Option<&'static str> {
+            $model::signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.message_name)
+        }
+
+        fn rig_can_signal_name(index: u32) -> Option<&'static str> {
+            $model::signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.signal_name)
+        }
+
+        fn rig_can_signal_unit(index: u32) -> Option<&'static str> {
+            $model::signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.unit.unwrap_or(""))
+        }
+
+        fn rig_can_signal_enum_name(index: u32) -> Option<&'static str> {
+            $model::signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.enum_name.unwrap_or(""))
+        }
+
+        fn rig_can_tx_signal_count() -> u32 {
+            $model::tx_signal_descriptors().len() as u32
+        }
+
+        fn rig_can_tx_signal_descriptor(
+            index: u32,
+        ) -> Option<$crate::rig_runtime::CanSignalDescriptor> {
+            let Some(signal) = $model::tx_signal_descriptors().get(index as usize) else {
+                return None;
+            };
+            let Some(bus) = rig_bus_to_raw(signal.bus) else {
+                return None;
+            };
+
+            Some($crate::rig_runtime::CanSignalDescriptor {
+                bus,
+                message_id: signal.message_id,
+                kind: rig_signal_kind_to_raw(signal.kind),
+            })
+        }
+
+        fn rig_can_tx_signal_message_name(index: u32) -> Option<&'static str> {
+            $model::tx_signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.message_name)
+        }
+
+        fn rig_can_tx_signal_name(index: u32) -> Option<&'static str> {
+            $model::tx_signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.signal_name)
+        }
+
+        fn rig_can_tx_signal_unit(index: u32) -> Option<&'static str> {
+            $model::tx_signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.unit.unwrap_or(""))
+        }
+
+        fn rig_can_tx_signal_enum_name(index: u32) -> Option<&'static str> {
+            $model::tx_signal_descriptors()
+                .get(index as usize)
+                .map(|signal| signal.enum_name.unwrap_or(""))
+        }
+
+        fn rig_can_enum_value_count() -> u32 {
+            $model::enum_value_descriptors().len() as u32
+        }
+
+        fn rig_can_enum_value_descriptor(
+            index: u32,
+        ) -> Option<$crate::rig_runtime::CanEnumValueDescriptor> {
+            let enum_value = $model::enum_value_descriptors().get(index as usize)?;
+            Some($crate::rig_runtime::CanEnumValueDescriptor {
+                raw: enum_value.raw,
+            })
+        }
+
+        fn rig_can_enum_value_enum_name(index: u32) -> Option<&'static str> {
+            $model::enum_value_descriptors()
+                .get(index as usize)
+                .map(|enum_value| enum_value.enum_name)
+        }
+
+        fn rig_can_enum_value_label(index: u32) -> Option<&'static str> {
+            $model::enum_value_descriptors()
+                .get(index as usize)
+                .map(|enum_value| enum_value.label)
+        }
+
+        fn rig_can_decode_signal(
+            bus: u8,
+            packet: &$crate::rig_runtime::CanPacket,
+            signal_name: &str,
+        ) -> Option<f64> {
+            let Some(bus) = rig_bus_from_raw(bus) else {
+                return None;
+            };
+
+            $model::decode_transmitted_signal(bus, packet.id, packet.data, signal_name)
+                .map(|measurement| measurement.value)
+        }
+
+        fn rig_can_encode_signal(
+            bus: u8,
+            message_name: &str,
+            signal_name: &str,
+            value: f64,
+            packet: &mut $crate::rig_runtime::CanPacket,
+        ) -> bool {
+            let Some(bus) = rig_bus_from_raw(bus) else {
+                return false;
+            };
+
+            let Some(message) =
+                $model::encode_transmitted_signal(bus, message_name, &mut packet.data, signal_name, value)
+            else {
+                return false;
+            };
+            packet.id = message.id;
+            packet.len = message.len;
+            true
+        }
+    };
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_bus_count() -> u8 {
+    bus_count()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_push_rx(bus: u8, packet: *const CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+    send(bus, unsafe { &*packet })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_pop_rx(bus: u8, packet: *mut CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+
+    match CAN_RUNTIME.lock().unwrap().pop_rx(bus) {
+        Some(next) => {
+            unsafe { *packet = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_push_tx(bus: u8, packet: *const CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+    let timestamp_ns = unsafe { super::ffi::rig_runtime_get_time_ns() };
+    CAN_RUNTIME
+        .lock()
+        .unwrap()
+        .push_tx(bus, unsafe { *packet }, timestamp_ns)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_pop_tx(bus: u8, packet: *mut CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+
+    match recv(bus) {
+        Some(next) => {
+            unsafe { *packet = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_pop_tx_event(bus: u8, event: *mut CanEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+
+    match recv_event(bus) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_rx_count(bus: u8) -> u32 {
+    rx_count(bus)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_can_tx_count(bus: u8) -> u32 {
+    tx_count(bus)
+}

--- a/sim/infra/runtime/rust/core.rs
+++ b/sim/infra/runtime/rust/core.rs
@@ -1,0 +1,3 @@
+pub fn reset() {
+    unsafe { super::ffi::rig_runtime_reset() };
+}

--- a/sim/infra/runtime/rust/datapath.rs
+++ b/sim/infra/runtime/rust/datapath.rs
@@ -1,0 +1,54 @@
+use std::collections::VecDeque;
+
+pub trait DataPathEvent: Clone + Copy {
+    type Channel: Eq + Clone + Copy;
+
+    fn channel(&self) -> Self::Channel;
+}
+
+#[derive(Debug)]
+pub struct DataPath<Event: DataPathEvent> {
+    channel: Event::Channel,
+    pending: VecDeque<Event>,
+    latest: Option<Event>,
+}
+
+impl<Event: DataPathEvent> DataPath<Event> {
+    pub fn new(channel: Event::Channel) -> Self {
+        Self {
+            channel,
+            pending: VecDeque::new(),
+            latest: None,
+        }
+    }
+
+    pub fn channel(&self) -> Event::Channel {
+        self.channel
+    }
+
+    pub fn clear(&mut self) {
+        self.pending.clear();
+        self.latest = None;
+    }
+
+    pub fn push(&mut self, event: Event) -> bool {
+        if event.channel() != self.channel {
+            return false;
+        }
+        self.latest = Some(event);
+        self.pending.push_back(event);
+        true
+    }
+
+    pub fn pop(&mut self) -> Option<Event> {
+        self.pending.pop_front()
+    }
+
+    pub fn count(&self) -> u32 {
+        self.pending.len() as u32
+    }
+
+    pub fn latest(&self) -> Option<Event> {
+        self.latest
+    }
+}

--- a/sim/infra/runtime/rust/faults.rs
+++ b/sim/infra/runtime/rust/faults.rs
@@ -1,0 +1,3 @@
+pub fn get(fault: i32) -> bool {
+    unsafe { super::ffi::rig_runtime_get_fault(fault) }
+}

--- a/sim/infra/runtime/rust/ffi.rs
+++ b/sim/infra/runtime/rust/ffi.rs
@@ -1,0 +1,11 @@
+unsafe extern "C" {
+    pub(super) fn rig_runtime_reset();
+    pub(super) fn rig_runtime_advance_time_ns(elapsed_ns: u64);
+    pub(super) fn rig_runtime_get_time_ns() -> u64;
+    pub(super) fn HW_TIM_getTimeMS() -> u32;
+    pub(super) fn rig_runtime_set_analog_input(channel: i32, voltage: f32);
+    pub(super) fn rig_runtime_get_analog_input(channel: i32) -> f32;
+    pub(super) fn rig_runtime_set_digital_io(channel: i32, state: bool);
+    pub(super) fn rig_runtime_get_digital_io(channel: i32) -> bool;
+    pub(super) fn rig_runtime_get_fault(fault: i32) -> bool;
+}

--- a/sim/infra/runtime/rust/io.rs
+++ b/sim/infra/runtime/rust/io.rs
@@ -1,0 +1,15 @@
+pub fn set_analog_input(channel: i32, voltage: f32) {
+    unsafe { super::ffi::rig_runtime_set_analog_input(channel, voltage) };
+}
+
+pub fn get_analog_input(channel: i32) -> f32 {
+    unsafe { super::ffi::rig_runtime_get_analog_input(channel) }
+}
+
+pub fn set_digital(channel: i32, state: bool) {
+    unsafe { super::ffi::rig_runtime_set_digital_io(channel, state) };
+}
+
+pub fn get_digital(channel: i32) -> bool {
+    unsafe { super::ffi::rig_runtime_get_digital_io(channel) }
+}

--- a/sim/infra/runtime/rust/lib.rs
+++ b/sim/infra/runtime/rust/lib.rs
@@ -1,0 +1,562 @@
+pub mod app {
+    include!(env!("RIG_RUNTIME_RUST_APP_RS"));
+}
+
+pub mod can {
+    include!(env!("RIG_RUNTIME_RUST_CAN_RS"));
+}
+
+mod ffi {
+    include!(env!("RIG_RUNTIME_RUST_FFI_RS"));
+}
+
+mod core {
+    include!(env!("RIG_RUNTIME_RUST_CORE_RS"));
+}
+
+pub mod datapath {
+    include!(env!("RIG_RUNTIME_RUST_DATAPATH_RS"));
+}
+
+mod faults {
+    include!(env!("RIG_RUNTIME_RUST_FAULTS_RS"));
+}
+
+mod io {
+    include!(env!("RIG_RUNTIME_RUST_IO_RS"));
+}
+
+pub mod model {
+    include!(env!("RIG_RUNTIME_RUST_MODEL_RS"));
+}
+
+pub mod module_desc {
+    include!(env!("RIG_RUNTIME_RUST_MODULE_DESC_RS"));
+}
+
+pub mod nvm {
+    include!(env!("RIG_RUNTIME_RUST_NVM_RS"));
+}
+
+pub mod rt_controller {
+    include!(env!("RIG_RUNTIME_RUST_RT_CONTROLLER_RS"));
+}
+
+pub mod spi {
+    include!(env!("RIG_RUNTIME_RUST_SPI_RS"));
+}
+
+pub mod timer {
+    include!(env!("RIG_RUNTIME_RUST_TIMER_RS"));
+}
+
+pub use app::AppDesc;
+pub use can::{
+    CanEnumValueDescriptor, CanEvent, CanMessageDescriptor, CanNetwork, CanPacket,
+    CanSignalDescriptor,
+};
+pub use model::{NodeModel, NodeTarget};
+pub use module_desc::{ModuleDesc, ModuleTask};
+pub use rt_controller::{
+    PeriodicTask, RTController, Scheduler, TaskCallbacks, TaskFn, MAX_PERIODIC_TASKS,
+};
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::ptr;
+
+unsafe fn write_str(value: &str, out: *mut c_char, out_len: usize) -> bool {
+    if out.is_null() || out_len == 0 || value.len() + 1 > out_len {
+        return false;
+    }
+
+    unsafe {
+        ptr::copy_nonoverlapping(value.as_ptr(), out.cast::<u8>(), value.len());
+        *out.add(value.len()) = 0;
+    }
+    true
+}
+
+unsafe fn c_str_to_str<'a>(value: *const c_char) -> Option<&'a str> {
+    if value.is_null() {
+        return None;
+    }
+    unsafe { CStr::from_ptr(value) }.to_str().ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_set_analog_input(channel: i32, voltage: f32) {
+    io::set_analog_input(channel, voltage);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_get_analog_input(channel: i32) -> f32 {
+    io::get_analog_input(channel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_set_digital_io(channel: i32, state: bool) {
+    io::set_digital(channel, state);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_get_digital_io(channel: i32) -> bool {
+    io::get_digital(channel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_get_fault(fault: i32) -> bool {
+    faults::get(fault)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_bus_count() -> u8 {
+    can::bus_count()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_send(bus: u8, packet: *const CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+    can::send(bus, unsafe { &*packet })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_recv(bus: u8, packet: *mut CanPacket) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+
+    match can::recv(bus) {
+        Some(next) => {
+            unsafe { *packet = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_recv_event(bus: u8, event: *mut CanEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+
+    match can::recv_event(bus) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_rx_count(bus: u8) -> u32 {
+    can::rx_count(bus)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_tx_count(bus: u8) -> u32 {
+    can::tx_count(bus)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_send_duty(event: *const timer::TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    timer::push_duty_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_recv_duty(
+    port: i32,
+    channel: i32,
+    event: *mut timer::TimerChannelEvent,
+) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    match timer::pop_duty_output(port, channel) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_duty_output_count(port: i32, channel: i32) -> u32 {
+    timer::duty_output_count(port, channel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_send_frequency(event: *const timer::TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    timer::push_frequency_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_recv_frequency(
+    port: i32,
+    channel: i32,
+    event: *mut timer::TimerChannelEvent,
+) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    match timer::pop_frequency_output(port, channel) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_frequency_output_count(port: i32, channel: i32) -> u32 {
+    timer::frequency_output_count(port, channel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_timer_send_capture(event: *const timer::TimerCaptureEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    timer::push_capture_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_spi_send(transaction: *const spi::SpiTransaction) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    spi::push_input(unsafe { *transaction })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_spi_recv(device: i32, transaction: *mut spi::SpiTransaction) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    match spi::pop_output(device) {
+        Some(next) => {
+            unsafe { *transaction = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_spi_output_count(device: i32) -> u32 {
+    spi::output_count(device)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_bus_count() -> u8 {
+    can::codegen_bus_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_bus_name(
+    bus: u8,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_bus_name(bus) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_message_count() -> u32 {
+    can::codegen_message_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_message_descriptor(
+    index: u32,
+    out: *mut CanMessageDescriptor,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(descriptor) = can::codegen_message_descriptor(index) else {
+        return false;
+    };
+    unsafe { *out = descriptor };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_message_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_message_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_tx_message_count() -> u32 {
+    can::codegen_tx_message_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_message_descriptor(
+    index: u32,
+    out: *mut CanMessageDescriptor,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(descriptor) = can::codegen_tx_message_descriptor(index) else {
+        return false;
+    };
+    unsafe { *out = descriptor };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_message_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_tx_message_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_signal_count() -> u32 {
+    can::codegen_signal_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_signal_descriptor(
+    index: u32,
+    out: *mut CanSignalDescriptor,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(descriptor) = can::codegen_signal_descriptor(index) else {
+        return false;
+    };
+    unsafe { *out = descriptor };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_signal_message_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_signal_message_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_signal_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_signal_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_signal_unit(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_signal_unit(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_signal_enum_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_signal_enum_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_tx_signal_count() -> u32 {
+    can::codegen_tx_signal_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_signal_descriptor(
+    index: u32,
+    out: *mut CanSignalDescriptor,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(descriptor) = can::codegen_tx_signal_descriptor(index) else {
+        return false;
+    };
+    unsafe { *out = descriptor };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_signal_message_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_tx_signal_message_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_signal_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_tx_signal_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_signal_unit(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_tx_signal_unit(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_tx_signal_enum_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_tx_signal_enum_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_model_can_codegen_enum_value_count() -> u32 {
+    can::codegen_enum_value_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_enum_value_descriptor(
+    index: u32,
+    out: *mut CanEnumValueDescriptor,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(descriptor) = can::codegen_enum_value_descriptor(index) else {
+        return false;
+    };
+    unsafe { *out = descriptor };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_enum_value_enum_name(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_enum_value_enum_name(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_codegen_enum_value_label(
+    index: u32,
+    out: *mut c_char,
+    out_len: usize,
+) -> bool {
+    let Some(name) = can::codegen_enum_value_label(index) else {
+        return false;
+    };
+    unsafe { write_str(name, out, out_len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_decode_signal(
+    bus: u8,
+    packet: *const CanPacket,
+    signal_name: *const c_char,
+    value_out: *mut f64,
+) -> bool {
+    if packet.is_null() || value_out.is_null() {
+        return false;
+    }
+    let Some(signal_name) = (unsafe { c_str_to_str(signal_name) }) else {
+        return false;
+    };
+    let Some(value) = can::decode_signal(bus, unsafe { &*packet }, signal_name) else {
+        return false;
+    };
+    unsafe { *value_out = value };
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rig_model_can_encode_signal(
+    bus: u8,
+    message_name: *const c_char,
+    signal_name: *const c_char,
+    value: f64,
+    packet: *mut CanPacket,
+) -> bool {
+    if packet.is_null() {
+        return false;
+    }
+    let Some(message_name) = (unsafe { c_str_to_str(message_name) }) else {
+        return false;
+    };
+    let Some(signal_name) = (unsafe { c_str_to_str(signal_name) }) else {
+        return false;
+    };
+    can::encode_signal(bus, message_name, signal_name, value, unsafe {
+        &mut *packet
+    })
+}

--- a/sim/infra/runtime/rust/model.rs
+++ b/sim/infra/runtime/rust/model.rs
@@ -1,0 +1,166 @@
+use super::rt_controller::RTController;
+use super::rt_controller::Scheduler;
+
+pub const RIG_MODEL_DATAPATH_TIMER_DUTY: u16 = 1;
+pub const RIG_MODEL_DATAPATH_TIMER_FREQUENCY: u16 = 2;
+pub const RIG_MODEL_DATAPATH_SPI_TRANSACTION: u16 = 3;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ModelDataPathDescriptor {
+    pub interface: u16,
+    pub port: i32,
+    pub channel: i32,
+    pub device: i32,
+}
+
+impl ModelDataPathDescriptor {
+    pub const fn timer_duty(port: i32, channel: i32) -> Self {
+        Self {
+            interface: RIG_MODEL_DATAPATH_TIMER_DUTY,
+            port,
+            channel,
+            device: 0,
+        }
+    }
+
+    pub const fn timer_frequency(port: i32, channel: i32) -> Self {
+        Self {
+            interface: RIG_MODEL_DATAPATH_TIMER_FREQUENCY,
+            port,
+            channel,
+            device: 0,
+        }
+    }
+
+    pub const fn spi_transaction(device: i32) -> Self {
+        Self {
+            interface: RIG_MODEL_DATAPATH_SPI_TRANSACTION,
+            port: 0,
+            channel: 0,
+            device,
+        }
+    }
+}
+
+pub trait NodeTarget {
+    unsafe fn reset_node(&mut self, controller: &mut RTController);
+
+    fn datapath_count(&self) -> u32 {
+        0
+    }
+
+    fn datapath_descriptor(&self, _index: u32) -> Option<ModelDataPathDescriptor> {
+        None
+    }
+}
+
+pub struct NodeModel<Target> {
+    controller: RTController,
+    target: Target,
+}
+
+impl<Target: NodeTarget> NodeModel<Target> {
+    pub const fn new(controller: RTController, target: Target) -> Self {
+        Self { controller, target }
+    }
+
+    pub unsafe fn reset(&mut self) {
+        super::spi::reset();
+        super::timer::reset();
+        self.configure_runtime_datapaths();
+        self.controller.reset_runtime();
+        unsafe { self.target.reset_node(&mut self.controller) };
+        unsafe { self.controller.reset() };
+    }
+
+    pub unsafe fn run_for_ns(&mut self, elapsed_ns: u64) {
+        unsafe { self.controller.run_for_ns(elapsed_ns) };
+    }
+
+    pub fn next_scheduler_step_ns(&self, max_step_ns: u64) -> u64 {
+        self.controller.next_scheduler_step_ns(max_step_ns)
+    }
+
+    pub fn controller(&mut self) -> &mut RTController {
+        &mut self.controller
+    }
+
+    pub fn target(&mut self) -> &mut Target {
+        &mut self.target
+    }
+
+    pub fn datapath_count(&self) -> u32 {
+        self.target.datapath_count()
+    }
+
+    pub fn datapath_descriptor(&self, index: u32) -> Option<ModelDataPathDescriptor> {
+        self.target.datapath_descriptor(index)
+    }
+
+    fn configure_runtime_datapaths(&self) {
+        for index in 0..self.target.datapath_count() {
+            let Some(descriptor) = self.target.datapath_descriptor(index) else {
+                continue;
+            };
+            match descriptor.interface {
+                RIG_MODEL_DATAPATH_TIMER_DUTY => {
+                    super::timer::configure_channel(descriptor.port, descriptor.channel);
+                }
+                RIG_MODEL_DATAPATH_TIMER_FREQUENCY => {
+                    super::timer::configure_channel(descriptor.port, descriptor.channel);
+                }
+                RIG_MODEL_DATAPATH_SPI_TRANSACTION => {
+                    super::spi::configure_device(descriptor.device);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! rig_model_abi {
+    ($model:expr) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn rig_model_new() {
+            unsafe {
+                $model.lock().unwrap().reset();
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn rig_model_run_for(elapsed_ns: u64) {
+            unsafe {
+                $model.lock().unwrap().run_for_ns(elapsed_ns);
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn rig_model_next_scheduler_step(max_step_ns: u64) -> u64 {
+            $model.lock().unwrap().next_scheduler_step_ns(max_step_ns)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn rig_model_datapath_count() -> u32 {
+            $model.lock().unwrap().datapath_count()
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn rig_model_datapath_descriptor(
+            index: u32,
+            out: *mut $crate::rig_runtime::model::ModelDataPathDescriptor,
+        ) -> bool {
+            if out.is_null() {
+                return false;
+            }
+            match $model.lock().unwrap().datapath_descriptor(index) {
+                Some(descriptor) => {
+                    unsafe { *out = descriptor };
+                    true
+                }
+                None => false,
+            }
+        }
+    };
+}

--- a/sim/infra/runtime/rust/module_desc.rs
+++ b/sim/infra/runtime/rust/module_desc.rs
@@ -1,0 +1,28 @@
+pub type ModuleTask = unsafe extern "C" fn();
+
+#[repr(C)]
+pub struct ModuleDesc {
+    pub module_init: Option<ModuleTask>,
+    pub periodic_1khz_clk: Option<ModuleTask>,
+    pub periodic_100hz_clk: Option<ModuleTask>,
+    pub periodic_10hz_clk: Option<ModuleTask>,
+    pub periodic_1hz_clk: Option<ModuleTask>,
+}
+
+impl ModuleDesc {
+    pub const fn new(
+        module_init: Option<ModuleTask>,
+        periodic_1khz_clk: Option<ModuleTask>,
+        periodic_100hz_clk: Option<ModuleTask>,
+        periodic_10hz_clk: Option<ModuleTask>,
+        periodic_1hz_clk: Option<ModuleTask>,
+    ) -> Self {
+        Self {
+            module_init,
+            periodic_1khz_clk,
+            periodic_100hz_clk,
+            periodic_10hz_clk,
+            periodic_1hz_clk,
+        }
+    }
+}

--- a/sim/infra/runtime/rust/nvm.rs
+++ b/sim/infra/runtime/rust/nvm.rs
@@ -1,0 +1,67 @@
+pub type Storage = u16;
+
+pub const STORAGE_WORD_BYTES: usize = core::mem::size_of::<Storage>();
+pub const FEATURE_ENABLED: u32 = 1;
+pub const FLASH_BACKED_BLOCK_COUNT: usize = 2;
+
+unsafe extern "C" {
+    static mut __FLASH_NVM_ORIGIN: Storage;
+    static mut __FLASH_NVM_END: Storage;
+}
+
+pub struct ControllerNvm<const BLOCK_SIZE: usize, const LIB_ENABLED: u32, const FLASH_BACKED: u32>;
+
+impl<const BLOCK_SIZE: usize, const LIB_ENABLED: u32, const FLASH_BACKED: u32>
+    ControllerNvm<BLOCK_SIZE, LIB_ENABLED, FLASH_BACKED>
+{
+    pub const ENABLED: bool = LIB_ENABLED == FEATURE_ENABLED;
+    pub const FLASH_BACKED_ENABLED: bool = FLASH_BACKED == FEATURE_ENABLED;
+    pub const STORAGE_WORD_BYTES: usize = STORAGE_WORD_BYTES;
+    pub const STORAGE_BYTES: usize = if Self::ENABLED && Self::FLASH_BACKED_ENABLED {
+        BLOCK_SIZE * FLASH_BACKED_BLOCK_COUNT
+    } else {
+        0
+    };
+    pub const END_OFFSET_BYTES: usize = if Self::STORAGE_BYTES >= STORAGE_WORD_BYTES {
+        Self::STORAGE_BYTES - STORAGE_WORD_BYTES
+    } else {
+        0
+    };
+
+    pub const fn new() -> Self {
+        if Self::ENABLED {
+            assert!(
+                Self::FLASH_BACKED_ENABLED,
+                "controller NVM model requires NVM_FLASH_BACKED"
+            );
+            assert!(
+                Self::STORAGE_BYTES >= STORAGE_WORD_BYTES,
+                "controller NVM storage must contain at least one storage word"
+            );
+        }
+        Self
+    }
+
+    pub fn reset(&self) {
+        if Self::ENABLED {
+            reset_flash_backed_storage();
+        }
+    }
+}
+
+impl<const BLOCK_SIZE: usize, const LIB_ENABLED: u32, const FLASH_BACKED: u32> Default
+    for ControllerNvm<BLOCK_SIZE, LIB_ENABLED, FLASH_BACKED>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn reset_flash_backed_storage() {
+    unsafe {
+        let origin = core::ptr::addr_of_mut!(__FLASH_NVM_ORIGIN);
+        let end = core::ptr::addr_of_mut!(__FLASH_NVM_END);
+        let len = end.offset_from(origin) as usize + 1;
+        core::ptr::write_bytes(origin, 0xFF, len);
+    }
+}

--- a/sim/infra/runtime/rust/rt_controller.rs
+++ b/sim/infra/runtime/rust/rt_controller.rs
@@ -1,0 +1,207 @@
+pub type TaskFn = unsafe fn();
+
+pub const MAX_PERIODIC_TASKS: usize = 16;
+
+#[derive(Clone, Copy)]
+pub struct PeriodicTask {
+    pub period_ns: u64,
+    pub task: TaskFn,
+}
+
+impl PeriodicTask {
+    pub const fn new(period_ns: u64, task: TaskFn) -> Self {
+        Self { period_ns, task }
+    }
+}
+
+pub struct TaskCallbacks {
+    pub init: TaskFn,
+    pub periodic_tasks: &'static [PeriodicTask],
+}
+
+pub trait Scheduler {
+    unsafe fn reset(&mut self);
+    unsafe fn run_for_ns(&mut self, elapsed_ns: u64);
+}
+
+unsafe extern "C" {
+    fn Module_Init();
+    fn Module_1kHz_TSK();
+    fn Module_100Hz_TSK();
+    fn Module_10Hz_TSK();
+    fn Module_1Hz_TSK();
+}
+
+unsafe fn embedded_module_init() {
+    unsafe { Module_Init() };
+}
+
+unsafe fn embedded_module_tick_1khz() {
+    unsafe { Module_1kHz_TSK() };
+}
+
+unsafe fn embedded_module_tick_100hz() {
+    unsafe { Module_100Hz_TSK() };
+}
+
+unsafe fn embedded_module_tick_10hz() {
+    unsafe { Module_10Hz_TSK() };
+}
+
+unsafe fn embedded_module_tick_1hz() {
+    unsafe { Module_1Hz_TSK() };
+}
+
+const EMBEDDED_MODULE_PERIODIC_TASKS: [PeriodicTask; 4] = [
+    PeriodicTask::new(1_000_000, embedded_module_tick_1khz),
+    PeriodicTask::new(10_000_000, embedded_module_tick_100hz),
+    PeriodicTask::new(100_000_000, embedded_module_tick_10hz),
+    PeriodicTask::new(1_000_000_000, embedded_module_tick_1hz),
+];
+
+const EMBEDDED_MODULE_CALLBACKS: TaskCallbacks = TaskCallbacks {
+    init: embedded_module_init,
+    periodic_tasks: &EMBEDDED_MODULE_PERIODIC_TASKS,
+};
+
+pub struct RTController {
+    callbacks: TaskCallbacks,
+    task_remainders_ns: [u64; MAX_PERIODIC_TASKS],
+}
+
+impl RTController {
+    pub const fn new(callbacks: TaskCallbacks) -> Self {
+        Self {
+            callbacks,
+            task_remainders_ns: [0; MAX_PERIODIC_TASKS],
+        }
+    }
+
+    pub const fn new_embedded_module() -> Self {
+        Self::new(EMBEDDED_MODULE_CALLBACKS)
+    }
+
+    pub fn reset_runtime(&mut self) {
+        super::core::reset();
+        super::can::reset();
+        self.task_remainders_ns = [0; MAX_PERIODIC_TASKS];
+    }
+
+    pub fn advance_time_ns(&self, elapsed_ns: u64) {
+        unsafe { super::ffi::rig_runtime_advance_time_ns(elapsed_ns) };
+    }
+
+    pub fn set_analog_input(&self, channel: i32, voltage: f32) {
+        super::io::set_analog_input(channel, voltage);
+    }
+
+    pub fn get_analog_input(&self, channel: i32) -> f32 {
+        super::io::get_analog_input(channel)
+    }
+
+    pub fn set_digital(&self, channel: i32, state: bool) {
+        super::io::set_digital(channel, state);
+    }
+
+    pub fn get_digital(&self, channel: i32) -> bool {
+        super::io::get_digital(channel)
+    }
+
+    pub fn get_fault(&self, fault: i32) -> bool {
+        super::faults::get(fault)
+    }
+
+    pub fn can_bus_count(&self) -> u8 {
+        super::can::bus_count()
+    }
+
+    pub fn can_send(&self, bus: u8, packet: &super::can::CanPacket) -> bool {
+        super::can::send(bus, packet)
+    }
+
+    pub fn can_recv(&self, bus: u8) -> Option<super::can::CanPacket> {
+        super::can::recv(bus)
+    }
+
+    pub fn can_rx_count(&self, bus: u8) -> u32 {
+        super::can::rx_count(bus)
+    }
+
+    pub fn can_tx_count(&self, bus: u8) -> u32 {
+        super::can::tx_count(bus)
+    }
+}
+
+impl Scheduler for RTController {
+    unsafe fn reset(&mut self) {
+        self.task_remainders_ns = [0; MAX_PERIODIC_TASKS];
+        unsafe { (self.callbacks.init)() };
+    }
+
+    unsafe fn run_for_ns(&mut self, elapsed_ns: u64) {
+        let mut remaining_ns = elapsed_ns;
+
+        while remaining_ns > 0 {
+            let step_ns = self.next_scheduler_step_ns(remaining_ns);
+            unsafe { super::ffi::rig_runtime_advance_time_ns(step_ns) };
+            remaining_ns -= step_ns;
+
+            for index in 0..self.active_periodic_task_count() {
+                let task = self.callbacks.periodic_tasks[index];
+                if task.period_ns == 0 {
+                    continue;
+                }
+                self.task_remainders_ns[index] += step_ns;
+
+                while self.task_remainders_ns[index] >= task.period_ns {
+                    unsafe { (task.task)() };
+                    self.task_remainders_ns[index] -= task.period_ns;
+                }
+            }
+        }
+    }
+}
+
+impl RTController {
+    fn active_periodic_tasks(&self) -> &[PeriodicTask] {
+        &self.callbacks.periodic_tasks[..self.active_periodic_task_count()]
+    }
+
+    fn active_periodic_task_count(&self) -> usize {
+        self.callbacks.periodic_tasks.len().min(MAX_PERIODIC_TASKS)
+    }
+
+    pub fn next_scheduler_step_ns(&self, max_step_ns: u64) -> u64 {
+        let mut next_ns = max_step_ns;
+        for (index, task) in self.active_periodic_tasks().iter().enumerate() {
+            if task.period_ns == 0 {
+                continue;
+            }
+            let remainder = self.task_remainders_ns[index] % task.period_ns;
+            let until_due = task.period_ns - remainder;
+            if until_due < next_ns {
+                next_ns = until_due;
+            }
+        }
+        next_ns
+    }
+}
+
+#[macro_export]
+macro_rules! rig_rt_controller_nvm_storage {
+    ($controller_nvm:ty) => {
+        core::arch::global_asm!(
+            ".pushsection .bss.rig_nvm,\"aw\",@nobits",
+            ".balign 2",
+            ".global __FLASH_NVM_ORIGIN",
+            "__FLASH_NVM_ORIGIN:",
+            ".zero {nvm_end_offset_bytes}",
+            ".global __FLASH_NVM_END",
+            "__FLASH_NVM_END:",
+            ".zero {storage_bytes}",
+            ".popsection",
+            nvm_end_offset_bytes = const <$controller_nvm>::END_OFFSET_BYTES,
+            storage_bytes = const <$controller_nvm>::STORAGE_WORD_BYTES,
+        );
+    };
+}

--- a/sim/infra/runtime/rust/spi.rs
+++ b/sim/infra/runtime/rust/spi.rs
@@ -1,0 +1,206 @@
+use std::sync::{LazyLock, Mutex};
+
+use super::datapath::{DataPath, DataPathEvent};
+
+pub const RIG_SPI_TRANSACTION_MAX_BYTES: usize = 256;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SpiDevice {
+    pub device: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SpiTransaction {
+    pub device: i32,
+    pub tx_len: u16,
+    pub rx_len: u16,
+    pub tx_data: [u8; RIG_SPI_TRANSACTION_MAX_BYTES],
+    pub rx_data: [u8; RIG_SPI_TRANSACTION_MAX_BYTES],
+    pub timestamp_ns: u64,
+}
+
+impl Default for SpiTransaction {
+    fn default() -> Self {
+        Self {
+            device: 0,
+            tx_len: 0,
+            rx_len: 0,
+            tx_data: [0; RIG_SPI_TRANSACTION_MAX_BYTES],
+            rx_data: [0; RIG_SPI_TRANSACTION_MAX_BYTES],
+            timestamp_ns: 0,
+        }
+    }
+}
+
+impl SpiTransaction {
+    fn spi_device(&self) -> SpiDevice {
+        SpiDevice {
+            device: self.device,
+        }
+    }
+}
+
+impl DataPathEvent for SpiTransaction {
+    type Channel = SpiDevice;
+
+    fn channel(&self) -> Self::Channel {
+        self.spi_device()
+    }
+}
+
+#[derive(Debug)]
+struct SpiPeripheral {
+    device: SpiDevice,
+    inputs: DataPath<SpiTransaction>,
+    outputs: DataPath<SpiTransaction>,
+}
+
+impl SpiPeripheral {
+    fn new(device: SpiDevice) -> Self {
+        Self {
+            device,
+            inputs: DataPath::new(device),
+            outputs: DataPath::new(device),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inputs.clear();
+        self.outputs.clear();
+    }
+}
+
+#[derive(Debug, Default)]
+struct SpiModel {
+    peripherals: Vec<SpiPeripheral>,
+}
+
+impl SpiModel {
+    fn reset(&mut self) {
+        for peripheral in &mut self.peripherals {
+            peripheral.reset();
+        }
+    }
+
+    fn peripheral(&mut self, device: SpiDevice) -> &mut SpiPeripheral {
+        if let Some(index) = self
+            .peripherals
+            .iter()
+            .position(|peripheral| peripheral.device == device)
+        {
+            return &mut self.peripherals[index];
+        }
+
+        self.peripherals.push(SpiPeripheral::new(device));
+        self.peripherals.last_mut().unwrap()
+    }
+}
+
+static SPI_MODEL: LazyLock<Mutex<SpiModel>> = LazyLock::new(|| Mutex::new(SpiModel::default()));
+
+pub fn reset() {
+    SPI_MODEL.lock().unwrap().reset();
+}
+
+pub fn configure_device(device: i32) {
+    SPI_MODEL.lock().unwrap().peripheral(SpiDevice { device });
+}
+
+pub fn push_input(transaction: SpiTransaction) -> bool {
+    SPI_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(transaction.spi_device())
+        .inputs
+        .push(transaction)
+}
+
+pub fn pop_input(device: i32) -> Option<SpiTransaction> {
+    SPI_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(SpiDevice { device })
+        .inputs
+        .pop()
+}
+
+pub fn push_output(transaction: SpiTransaction) -> bool {
+    SPI_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(transaction.spi_device())
+        .outputs
+        .push(transaction)
+}
+
+pub fn pop_output(device: i32) -> Option<SpiTransaction> {
+    SPI_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(SpiDevice { device })
+        .outputs
+        .pop()
+}
+
+pub fn output_count(device: i32) -> u32 {
+    SPI_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(SpiDevice { device })
+        .outputs
+        .count()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_spi_push_input(transaction: *const SpiTransaction) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    push_input(unsafe { *transaction })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_spi_pop_input(device: i32, transaction: *mut SpiTransaction) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    match pop_input(device) {
+        Some(next) => {
+            unsafe { *transaction = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_spi_push_output(transaction: *const SpiTransaction) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    push_output(unsafe { *transaction })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_spi_pop_output(
+    device: i32,
+    transaction: *mut SpiTransaction,
+) -> bool {
+    if transaction.is_null() {
+        return false;
+    }
+    match pop_output(device) {
+        Some(next) => {
+            unsafe { *transaction = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_spi_output_count(device: i32) -> u32 {
+    output_count(device)
+}

--- a/sim/infra/runtime/rust/timer.rs
+++ b/sim/infra/runtime/rust/timer.rs
@@ -1,0 +1,413 @@
+use std::sync::{LazyLock, Mutex};
+
+use super::datapath::{DataPath, DataPathEvent};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TimerChannel {
+    pub port: i32,
+    pub channel: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TimerChannelEvent {
+    pub port: i32,
+    pub channel: i32,
+    pub value: f32,
+    pub timestamp_ns: u64,
+}
+
+impl TimerChannelEvent {
+    fn timer_channel(&self) -> TimerChannel {
+        TimerChannel {
+            port: self.port,
+            channel: self.channel,
+        }
+    }
+}
+
+impl DataPathEvent for TimerChannelEvent {
+    type Channel = TimerChannel;
+
+    fn channel(&self) -> Self::Channel {
+        self.timer_channel()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TimerCaptureChannel {
+    pub channel: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TimerCaptureEvent {
+    pub channel: i32,
+    pub value: f32,
+    pub timestamp_ns: u64,
+}
+
+impl TimerCaptureEvent {
+    fn timer_channel(&self) -> TimerCaptureChannel {
+        TimerCaptureChannel {
+            channel: self.channel,
+        }
+    }
+}
+
+impl DataPathEvent for TimerCaptureEvent {
+    type Channel = TimerCaptureChannel;
+
+    fn channel(&self) -> Self::Channel {
+        self.timer_channel()
+    }
+}
+
+#[derive(Debug)]
+struct TimerPeripheral {
+    channel: TimerChannel,
+    duty_inputs: DataPath<TimerChannelEvent>,
+    duty_outputs: DataPath<TimerChannelEvent>,
+    frequency_inputs: DataPath<TimerChannelEvent>,
+    frequency_outputs: DataPath<TimerChannelEvent>,
+}
+
+impl TimerPeripheral {
+    fn new(channel: TimerChannel) -> Self {
+        Self {
+            channel,
+            duty_inputs: DataPath::new(channel),
+            duty_outputs: DataPath::new(channel),
+            frequency_inputs: DataPath::new(channel),
+            frequency_outputs: DataPath::new(channel),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.duty_inputs.clear();
+        self.duty_outputs.clear();
+        self.frequency_inputs.clear();
+        self.frequency_outputs.clear();
+    }
+}
+
+#[derive(Debug)]
+struct TimerCapturePeripheral {
+    capture_inputs: DataPath<TimerCaptureEvent>,
+}
+
+impl TimerCapturePeripheral {
+    fn new(channel: TimerCaptureChannel) -> Self {
+        Self {
+            capture_inputs: DataPath::new(channel),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.capture_inputs.clear();
+    }
+}
+
+#[derive(Debug, Default)]
+struct TimerModel {
+    peripherals: Vec<TimerPeripheral>,
+    capture_peripherals: Vec<TimerCapturePeripheral>,
+}
+
+impl TimerModel {
+    fn reset(&mut self) {
+        for peripheral in &mut self.peripherals {
+            peripheral.reset();
+        }
+        for peripheral in &mut self.capture_peripherals {
+            peripheral.reset();
+        }
+    }
+
+    fn peripheral(&mut self, channel: TimerChannel) -> &mut TimerPeripheral {
+        if let Some(index) = self
+            .peripherals
+            .iter()
+            .position(|peripheral| peripheral.channel == channel)
+        {
+            return &mut self.peripherals[index];
+        }
+
+        self.peripherals.push(TimerPeripheral::new(channel));
+        self.peripherals.last_mut().unwrap()
+    }
+
+    fn capture_peripheral(&mut self, channel: TimerCaptureChannel) -> &mut TimerCapturePeripheral {
+        if let Some(index) = self
+            .capture_peripherals
+            .iter()
+            .position(|peripheral| peripheral.capture_inputs.channel() == channel)
+        {
+            return &mut self.capture_peripherals[index];
+        }
+
+        self.capture_peripherals
+            .push(TimerCapturePeripheral::new(channel));
+        self.capture_peripherals.last_mut().unwrap()
+    }
+}
+
+static TIMER_MODEL: LazyLock<Mutex<TimerModel>> =
+    LazyLock::new(|| Mutex::new(TimerModel::default()));
+
+pub fn reset() {
+    TIMER_MODEL.lock().unwrap().reset();
+}
+
+pub fn configure_channel(port: i32, channel: i32) {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(TimerChannel { port, channel });
+}
+
+pub fn push_duty_input(event: TimerChannelEvent) -> bool {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(event.timer_channel())
+        .duty_inputs
+        .push(event)
+}
+
+pub fn latest_duty_input(port: i32, channel: i32) -> Option<f32> {
+    let mut timer = TIMER_MODEL.lock().unwrap();
+    timer
+        .peripheral(TimerChannel { port, channel })
+        .duty_inputs
+        .latest()
+        .map(|event| event.value)
+}
+
+pub fn push_frequency_input(event: TimerChannelEvent) -> bool {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(event.timer_channel())
+        .frequency_inputs
+        .push(event)
+}
+
+pub fn latest_frequency_input(port: i32, channel: i32) -> Option<f32> {
+    let mut timer = TIMER_MODEL.lock().unwrap();
+    timer
+        .peripheral(TimerChannel { port, channel })
+        .frequency_inputs
+        .latest()
+        .map(|event| event.value)
+}
+
+pub fn push_capture_input(event: TimerCaptureEvent) -> bool {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .capture_peripheral(event.timer_channel())
+        .capture_inputs
+        .push(event)
+}
+
+pub fn latest_capture_input(channel: i32) -> Option<f32> {
+    let mut timer = TIMER_MODEL.lock().unwrap();
+    timer
+        .capture_peripheral(TimerCaptureChannel { channel })
+        .capture_inputs
+        .latest()
+        .map(|event| event.value)
+}
+
+pub fn push_duty_output(event: TimerChannelEvent) -> bool {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(event.timer_channel())
+        .duty_outputs
+        .push(event)
+}
+
+pub fn pop_duty_output(port: i32, channel: i32) -> Option<TimerChannelEvent> {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(TimerChannel { port, channel })
+        .duty_outputs
+        .pop()
+}
+
+pub fn duty_output_count(port: i32, channel: i32) -> u32 {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(TimerChannel { port, channel })
+        .duty_outputs
+        .count()
+}
+
+pub fn push_frequency_output(event: TimerChannelEvent) -> bool {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(event.timer_channel())
+        .frequency_outputs
+        .push(event)
+}
+
+pub fn pop_frequency_output(port: i32, channel: i32) -> Option<TimerChannelEvent> {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(TimerChannel { port, channel })
+        .frequency_outputs
+        .pop()
+}
+
+pub fn frequency_output_count(port: i32, channel: i32) -> u32 {
+    TIMER_MODEL
+        .lock()
+        .unwrap()
+        .peripheral(TimerChannel { port, channel })
+        .frequency_outputs
+        .count()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_push_duty_input(event: *const TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    push_duty_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_latest_duty_input(
+    port: i32,
+    channel: i32,
+    value: *mut f32,
+) -> bool {
+    if value.is_null() {
+        return false;
+    }
+    match latest_duty_input(port, channel) {
+        Some(next) => {
+            unsafe { *value = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_push_frequency_input(event: *const TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    push_frequency_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_latest_frequency_input(
+    port: i32,
+    channel: i32,
+    value: *mut f32,
+) -> bool {
+    if value.is_null() {
+        return false;
+    }
+    match latest_frequency_input(port, channel) {
+        Some(next) => {
+            unsafe { *value = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_push_capture_input(event: *const TimerCaptureEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    push_capture_input(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_latest_capture_input(channel: i32, value: *mut f32) -> bool {
+    if value.is_null() {
+        return false;
+    }
+    match latest_capture_input(channel) {
+        Some(next) => {
+            unsafe { *value = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_push_duty_output(event: *const TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    push_duty_output(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_pop_duty_output(
+    port: i32,
+    channel: i32,
+    event: *mut TimerChannelEvent,
+) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    match pop_duty_output(port, channel) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_duty_output_count(port: i32, channel: i32) -> u32 {
+    duty_output_count(port, channel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_push_frequency_output(event: *const TimerChannelEvent) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    push_frequency_output(unsafe { *event })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_pop_frequency_output(
+    port: i32,
+    channel: i32,
+    event: *mut TimerChannelEvent,
+) -> bool {
+    if event.is_null() {
+        return false;
+    }
+    match pop_frequency_output(port, channel) {
+        Some(next) => {
+            unsafe { *event = next };
+            true
+        }
+        None => false,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rig_runtime_timer_frequency_output_count(port: i32, channel: i32) -> u32 {
+    frequency_output_count(port, channel)
+}

--- a/sim/infra/uv.lock
+++ b/sim/infra/uv.lock
@@ -1,0 +1,165 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "clang"
+version = "18.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/6d/202fe248475f92ab9057a4066d50fe8aaa2def62493894dc9a9814ce8d3b/clang-18.1.8.tar.gz", hash = "sha256:26d11859bab6da8d1fcdb85a244957f6c129a0cd15da2abca3059b054b87635f" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/3c/1bebce0b2588b913b48baea6eac5091c023f03cc0c8ab4b015a8315d0d09/clang-18.1.8-py3-none-any.whl", hash = "sha256:2f6a00126743ee23d8fcd2a2338b42ef4d29897f293ee3a1bc4d5925d8ee875c" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c" },
+]
+
+[[package]]
+name = "rig"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "clang" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "clang", specifier = "==18.1.8" },
+    { name = "pytest", specifier = ">=8" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" },
+]

--- a/tools/feature-tree/defs.bzl
+++ b/tools/feature-tree/defs.bzl
@@ -11,6 +11,7 @@ def generate_feature_tree(
         node_id: int | None = None,
         build_renderer: str = DEFAULT_RENDERER,
         feature_overrides: dict[str, str | int | bool] = {},
+        visibility: list[str] | None = None,
         **kwargs):
     exported_identifier = ".variant-{}"
 
@@ -44,6 +45,7 @@ def generate_feature_tree(
             "BuildDefines_generated.h": ["BuildDefines_generated.h"],
             "FeatureDefines_generated.h": ["FeatureDefines_generated.h"],
         },
+        visibility = visibility,
     )
     __rules__["prebuilt_cxx_library"](
         name = name,
@@ -54,4 +56,5 @@ def generate_feature_tree(
             "BuildDefines_generated.h": ":{}[BuildDefines_generated.h]".format(uv_name),
             "FeatureDefines_generated.h": ":{}[FeatureDefines_generated.h]".format(uv_name),
         },
+        visibility = visibility,
     )

--- a/tools/uv/defs.bzl
+++ b/tools/uv/defs.bzl
@@ -28,7 +28,7 @@ def _uv_tool_impl(ctx: AnalysisContext) -> list[Provider]:
         cmd_args(venv_artifact, format = "cd {} || exit 99", parent = 1),
         cmd_args("uv venv -v --no-project .venv"),
         cmd_args("source .venv/bin/activate"),
-        cmd_args("uv sync -v --active --locked"),
+        cmd_args("uv sync -v --active --frozen"),
     ]
     sh_script = ctx.actions.write(
         "sh/create_venv.sh",

--- a/tools/yamcan/defs.bzl
+++ b/tools/yamcan/defs.bzl
@@ -31,6 +31,7 @@ def _codegen_outs(rust_wrapper: bool = False):
     if rust_wrapper:
         outs["lib.rs"] = ["generated/lib.rs"]
         outs["yamcan.rs"] = ["generated/yamcan.rs"]
+        outs["rust_faults_generated.rs"] = ["generated/rust_faults_generated.rs"]
         outs["rust_model_generated.rs"] = ["generated/rust_model_generated.rs"]
         outs["rust_decode_generated.rs"] = ["generated/rust_decode_generated.rs"]
     return outs
@@ -107,6 +108,7 @@ def generate_rust_library(
         srcs = [
             codegen_target + "[lib.rs]",
             codegen_target + "[yamcan.rs]",
+            codegen_target + "[rust_faults_generated.rs]",
             codegen_target + "[rust_model_generated.rs]",
             codegen_target + "[rust_decode_generated.rs]",
         ],

--- a/tools/yamcan/srcs/rust/lib.rs
+++ b/tools/yamcan/srcs/rust/lib.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::ffi::CString;
 
 mod rust_decode_generated;
+pub mod rust_faults_generated;
 pub mod rust_model_generated;
 pub mod yamcan;
 

--- a/tools/yamcan/srcs/rust/yamcan.rs
+++ b/tools/yamcan/srcs/rust/yamcan.rs
@@ -80,6 +80,14 @@ pub struct SignalDescriptor<B: NetworkBus> {
     pub fqid: &'static str,
     pub unit: Option<&'static str>,
     pub kind: SignalKind,
+    pub enum_name: Option<&'static str>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EnumValueDescriptor {
+    pub enum_name: &'static str,
+    pub label: &'static str,
+    pub raw: i32,
 }
 
 #[derive(Clone, Copy)]
@@ -126,6 +134,17 @@ pub struct SignalAccessor {
 
 pub trait NetworkBus: Copy + Eq + Hash {
     fn as_str(self) -> &'static str;
+}
+
+pub trait GeneratedCanNetwork {
+    type Bus: NetworkBus;
+    type TxSignalDescriptor;
+
+    fn message_descriptors() -> &'static [MessageDescriptor<Self::Bus>];
+    fn signal_descriptors() -> &'static [SignalDescriptor<Self::Bus>];
+    fn tx_message_descriptors() -> &'static [MessageDescriptor<Self::Bus>];
+    fn tx_signal_descriptors() -> &'static [Self::TxSignalDescriptor];
+    fn enum_value_descriptors() -> &'static [EnumValueDescriptor];
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/tools/yamcan/templates/MessageUnpack_generated.h.mako
+++ b/tools/yamcan/templates/MessageUnpack_generated.h.mako
@@ -145,7 +145,7 @@ void CANRX_${bus.upper()}_unpack_${msg_name}(CANRX_${bus.upper()}_signals_S* sig
   index = f'[{offset}U]' if duplicate else ''
 %>\
 
-inline CAN_data_T* CANRX_${bus.upper()}_rawMessage_${message}(void)
+static inline CAN_data_T* CANRX_${bus.upper()}_rawMessage_${message}(void)
 {
     return &CANRX_${bus.upper()}_messages.${msg_name}${index}.raw;
 }
@@ -158,12 +158,12 @@ inline CAN_data_T* CANRX_${bus.upper()}_rawMessage_${message}(void)
   index = f'[{offset}U]' if duplicate else ''
 %>\
 
-inline bool CANRX_${bus.upper()}_rawBridgeWaiting_${message}(void)
+static inline bool CANRX_${bus.upper()}_rawBridgeWaiting_${message}(void)
 {
     return CANRX_${bus.upper()}_messages.${msg_name}${index}.new_message;
 }
 
-inline void CANRX_${bus.upper()}_setRawBridgeWaiting_${message}(bool val)
+static inline void CANRX_${bus.upper()}_setRawBridgeWaiting_${message}(bool val)
 {
     CANRX_${bus.upper()}_messages.${msg_name}${index}.new_message = val;
 }

--- a/tools/yamcan/templates/rust_faults_generated.rs.mako
+++ b/tools/yamcan/templates/rust_faults_generated.rs.mako
@@ -1,0 +1,125 @@
+/*
+ * rust_faults_generated.rs
+ * Generated Rust fault identifiers.
+ */
+
+<%!
+def sanitize_ident(name):
+    chars = []
+    for ch in name:
+        if ch.isalnum():
+            chars.append(ch)
+        else:
+            chars.append("_")
+
+    ident = "".join(chars).strip("_")
+    if not ident:
+        ident = "value"
+    if ident[0].isdigit():
+        ident = "_" + ident
+    return ident
+
+
+def rust_pascal(name):
+    sanitized = sanitize_ident(name)
+    parts = []
+    current = ""
+    for idx, ch in enumerate(sanitized):
+        if ch == "_":
+            if current:
+                parts.append(current)
+                current = ""
+            continue
+        if (
+            current
+            and ch.isupper()
+            and (current[-1].islower() or (idx + 1 < len(sanitized) and sanitized[idx + 1].islower()))
+        ):
+            parts.append(current)
+            current = ch
+            continue
+        current += ch
+
+    if current:
+        parts.append(current)
+
+    if not parts:
+        return "Value"
+    return "".join(part[:1].upper() + part[1:] for part in parts)
+%>
+<%
+faults_sent = []
+faults_received = {}
+
+for node in nodes:
+    for message in node.messages.values():
+        if message.fault_message and not message.from_bridge:
+            for signal, data in message.signal_objs.items():
+                faults_sent.append((data.message_ref.node_ref.name + "_" + data.get_name_nodeless(), int(data.start_bit)))
+    for message, mdata in node.received_msgs.items():
+        if mdata.fault_message:
+            for signal, sdata in mdata.signal_objs.items():
+                faults_received.setdefault(mdata.node_ref.name, []).append((signal, int(sdata.start_bit)))
+
+fault_count = max([index for _, index in faults_sent], default=-1) + 1
+%>\
+%if faults_sent:
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum FmFault {
+  %for fault, index in faults_sent:
+    ${rust_pascal(fault)} = ${index},
+  %endfor
+}
+
+impl FmFault {
+    pub fn from_raw(value: i32) -> Option<Self> {
+        match value {
+        %for fault, index in faults_sent:
+            ${index} => Some(Self::${rust_pascal(fault)}),
+        %endfor
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+        %for fault, index in faults_sent:
+            Self::${rust_pascal(fault)} => "${fault}",
+        %endfor
+        }
+    }
+
+    pub fn as_raw(self) -> i32 {
+        self as i32
+    }
+}
+
+impl core::convert::TryFrom<i32> for FmFault {
+    type Error = i32;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::from_raw(value).ok_or(value)
+    }
+}
+
+impl From<FmFault> for i32 {
+    fn from(value: FmFault) -> Self {
+        value.as_raw()
+    }
+}
+
+pub const FM_FAULT_COUNT: i32 = ${fault_count};
+%else:
+pub const FM_FAULT_COUNT: i32 = 0;
+%endif
+%if faults_received:
+
+pub mod received_fault {
+  %for node, faults in faults_received.items():
+    %for fault, index in faults:
+    pub const ${sanitize_ident(fault).upper()}: i32 = ${index};
+    %endfor
+  %endfor
+}
+%endif

--- a/tools/yamcan/templates/rust_model_generated.rs.mako
+++ b/tools/yamcan/templates/rust_model_generated.rs.mako
@@ -79,6 +79,8 @@ def rust_pascal(name):
 <%
 bus_order = []
 bus_messages = OrderedDict()
+tx_bus_messages = OrderedDict()
+codec_bus_messages = OrderedDict()
 extern_unpacks = OrderedDict()
 extern_getters = OrderedDict()
 base_wrappers = OrderedDict()
@@ -87,14 +89,77 @@ base_value_wrappers = OrderedDict()
 instance_value_wrappers = OrderedDict()
 discrete_enums = OrderedDict()
 
+def codec_signal_entries(message):
+    signal_entries = []
+    for signal in message.signal_objs.values():
+        if signal.validation_role.name != "none":
+            continue
+
+        if signal.discrete_values:
+            enum_type = rust_pascal(signal.discrete_values.name)
+            discrete_enums.setdefault(
+                signal.discrete_values.name,
+                {
+                    "lookup_name": f"yamcan_enum_{signal.discrete_values.name}".lower(),
+                    "type_name": enum_type,
+                    "values": list(signal.discrete_values.values.items()),
+                },
+            )
+            signal_kind = "SignalKind::Enum"
+        elif signal.is_boolean():
+            enum_type = None
+            signal_kind = "SignalKind::Boolean"
+        else:
+            enum_type = None
+            signal_kind = "SignalKind::Numeric"
+
+        signal_entries.append(
+            {
+                "name": signal.name,
+                "enum_name": signal.discrete_values.name if signal.discrete_values else None,
+                "enum_type": enum_type,
+                "unit": signal.unit.name if signal.unit else "",
+                "kind": signal_kind,
+                "start_bit": signal.start_bit,
+                "bit_width": signal.native_representation.bit_width,
+                "scale": float(signal.scale),
+                "offset": float(signal.offset),
+                "signed": "true" if signal.native_representation.signedness.name == "signed" else "false",
+                "min": float(signal.native_representation.range.min),
+                "max": float(signal.native_representation.range.max),
+            }
+        )
+    return signal_entries
+
+def codec_message_entry(bus, message_name, message):
+    checksum = None
+    if message.checksum_sig is not None:
+        checksum = {
+            "start_bit": message.checksum_sig.start_bit,
+            "bit_width": message.checksum_sig.native_representation.bit_width,
+            "crc": message.crc32(),
+        }
+    return {
+        "ident": f"{bus}_{message_name}".upper(),
+        "name": message_name,
+        "id": message.id,
+        "len": message.length_bytes,
+        "checksum": checksum,
+        "signals": codec_signal_entries(message),
+    }
+
 for node in nodes:
     for bus in node.on_buses:
         if bus not in bus_messages:
             bus_messages[bus] = []
             bus_order.append(bus)
+        if bus not in codec_bus_messages:
+            codec_bus_messages[bus] = []
         extern_unpacks.setdefault(bus, f"CANRX_{bus.upper()}_unpackMessage")
 
         seen_message_idents = {message["ident"] for message in bus_messages[bus]}
+        seen_tx_message_idents = {message["ident"] for message in tx_bus_messages.get(bus, [])}
+        seen_codec_message_idents = {message["ident"] for message in codec_bus_messages[bus]}
         for message_name, message in node.received_msgs.items():
             if bus not in message.source_buses:
                 continue
@@ -218,6 +283,7 @@ for node in nodes:
                         "static_ident": signal_static_ident,
                         "enum_lookup_name": enum_lookup_name,
                         "enum_type": enum_type,
+                        "enum_name": signal.discrete_values.name if signal.discrete_values else None,
                         "value_getter_name": value_getter_name,
                         "field_type": field_type,
                         "kind": signal_kind,
@@ -242,6 +308,73 @@ for node in nodes:
                 }
             )
             seen_message_idents.add(msg_ident)
+            if msg_ident not in seen_codec_message_idents:
+                codec_bus_messages[bus].append(codec_message_entry(bus, msg_display, message))
+                seen_codec_message_idents.add(msg_ident)
+
+        if bus not in tx_bus_messages:
+            tx_bus_messages[bus] = []
+        for message_name, message in node.messages.items():
+            if bus not in message.source_buses:
+                continue
+
+            msg_ident = f"{bus}_{message.name}".upper()
+            if msg_ident in seen_tx_message_idents:
+                continue
+
+            signal_entries = []
+            for signal in message.signal_objs.values():
+                if signal.validation_role.name != "none":
+                    continue
+
+                if signal.discrete_values:
+                    enum_type = rust_pascal(signal.discrete_values.name)
+                    discrete_enums.setdefault(
+                        signal.discrete_values.name,
+                        {
+                            "lookup_name": f"yamcan_enum_{signal.discrete_values.name}".lower(),
+                            "type_name": enum_type,
+                            "values": list(signal.discrete_values.values.items()),
+                        },
+                    )
+                    signal_kind = "SignalKind::Enum"
+                elif signal.is_boolean():
+                    enum_type = None
+                    signal_kind = "SignalKind::Boolean"
+                else:
+                    enum_type = None
+                    signal_kind = "SignalKind::Numeric"
+
+                signal_entries.append(
+                    {
+                        "name": signal.name,
+                        "enum_name": signal.discrete_values.name if signal.discrete_values else None,
+                        "enum_type": enum_type,
+                        "unit": signal.unit.name if signal.unit else "",
+                        "kind": signal_kind,
+                        "start_bit": signal.start_bit,
+                        "bit_width": signal.native_representation.bit_width,
+                        "scale": float(signal.scale),
+                        "offset": float(signal.offset),
+                        "signed": "true" if signal.native_representation.signedness.name == "signed" else "false",
+                        "min": float(signal.native_representation.range.min),
+                        "max": float(signal.native_representation.range.max),
+                    }
+                )
+
+            tx_bus_messages[bus].append(
+                {
+                    "ident": msg_ident,
+                    "name": message.name,
+                    "id": message.id,
+                    "len": message.length_bytes,
+                    "signals": signal_entries,
+                }
+            )
+            seen_tx_message_idents.add(msg_ident)
+            if msg_ident not in seen_codec_message_idents:
+                codec_bus_messages[bus].append(codec_message_entry(bus, message.name, message))
+                seen_codec_message_idents.add(msg_ident)
 %>\
 use core::ffi::c_int;
 
@@ -249,6 +382,8 @@ use crate::SignalMeasurement;
 use crate::yamcan::{
     CanData,
     DecodedCanMessage,
+    EnumValueDescriptor,
+    GeneratedCanNetwork,
     MessageDescriptor,
     MessageMetadata,
     NetworkBus,
@@ -518,6 +653,7 @@ static YAMCAN_SIGNALS: &[SignalDescriptor<Bus>] = &[
         fqid: "${bus}/${message["name"]}/${signal["name"]}",
         unit: ${'None' if signal["unit"] == '' else 'Some("' + signal["unit"] + '")'},
         kind: ${signal["kind"]},
+        enum_name: ${'Some("' + signal["enum_name"] + '")' if signal["enum_name"] else 'None'},
     },
     %endfor
   %endfor
@@ -558,5 +694,264 @@ impl DecodedCanMessage for AnyMessage {
   %endfor
 %endfor
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TxSignalDescriptor {
+    pub bus: Bus,
+    pub message_name: &'static str,
+    pub message_id: u32,
+    pub message_len: u8,
+    pub signal_name: &'static str,
+    pub unit: Option${"<"}&'static str>,
+    pub kind: SignalKind,
+    pub enum_name: Option${"<"}&'static str>,
+    pub start_bit: u8,
+    pub bit_width: u8,
+    pub scale: f64,
+    pub offset: f64,
+    pub signed: bool,
+    pub min: f64,
+    pub max: f64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ChecksumDescriptor {
+    pub start_bit: u8,
+    pub bit_width: u8,
+    pub crc: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MessageCodecDescriptor {
+    pub bus: Bus,
+    pub name: &'static str,
+    pub id: u32,
+    pub len: u8,
+    pub checksum: Option<ChecksumDescriptor>,
+}
+
+pub fn tx_message_descriptors() -> &'static [MessageDescriptor<Bus>] {
+    YAMCAN_TX_MESSAGES
+}
+
+pub fn tx_signal_descriptors() -> &'static [TxSignalDescriptor] {
+    YAMCAN_TX_SIGNALS
+}
+
+static YAMCAN_TX_MESSAGES: &[MessageDescriptor<Bus>] = &[
+%for bus in bus_order:
+  %for message in tx_bus_messages.get(bus, []):
+    MessageDescriptor {
+        bus: Bus::${rust_pascal(bus)},
+        name: "${message["name"]}",
+        id: ${message["id"]}u32,
+        len: ${message["len"]}u8,
+    },
+  %endfor
+%endfor
+];
+
+static YAMCAN_TX_SIGNALS: &[TxSignalDescriptor] = &[
+%for bus in bus_order:
+  %for message in tx_bus_messages.get(bus, []):
+    %for signal in message["signals"]:
+    TxSignalDescriptor {
+        bus: Bus::${rust_pascal(bus)},
+        message_name: "${message["name"]}",
+        message_id: ${message["id"]}u32,
+        message_len: ${message["len"]}u8,
+        signal_name: "${signal["name"]}",
+        unit: ${'None' if signal["unit"] == '' else 'Some("' + signal["unit"] + '")'},
+        kind: ${signal["kind"]},
+        enum_name: ${'Some("' + signal["enum_name"] + '")' if signal["enum_name"] else 'None'},
+        start_bit: ${signal["start_bit"]}u8,
+        bit_width: ${signal["bit_width"]}u8,
+        scale: ${signal["scale"]}f64,
+        offset: ${signal["offset"]}f64,
+        signed: ${signal["signed"]},
+        min: ${signal["min"]}f64,
+        max: ${signal["max"]}f64,
+    },
+    %endfor
+  %endfor
+%endfor
+];
+
+static YAMCAN_SIGNAL_CODECS: &[TxSignalDescriptor] = &[
+%for bus in bus_order:
+  %for message in codec_bus_messages[bus]:
+    %for signal in message["signals"]:
+    TxSignalDescriptor {
+        bus: Bus::${rust_pascal(bus)},
+        message_name: "${message["name"]}",
+        message_id: ${message["id"]}u32,
+        message_len: ${message["len"]}u8,
+        signal_name: "${signal["name"]}",
+        unit: ${'None' if signal["unit"] == '' else 'Some("' + signal["unit"] + '")'},
+        kind: ${signal["kind"]},
+        enum_name: ${'Some("' + signal["enum_name"] + '")' if signal["enum_name"] else 'None'},
+        start_bit: ${signal["start_bit"]}u8,
+        bit_width: ${signal["bit_width"]}u8,
+        scale: ${signal["scale"]}f64,
+        offset: ${signal["offset"]}f64,
+        signed: ${signal["signed"]},
+        min: ${signal["min"]}f64,
+        max: ${signal["max"]}f64,
+    },
+    %endfor
+  %endfor
+%endfor
+];
+
+static YAMCAN_MESSAGE_CODECS: &[MessageCodecDescriptor] = &[
+%for bus in bus_order:
+  %for message in codec_bus_messages[bus]:
+    MessageCodecDescriptor {
+        bus: Bus::${rust_pascal(bus)},
+        name: "${message["name"]}",
+        id: ${message["id"]}u32,
+        len: ${message["len"]}u8,
+        checksum: ${"Some(ChecksumDescriptor { start_bit: " + str(message["checksum"]["start_bit"]) + "u8, bit_width: " + str(message["checksum"]["bit_width"]) + "u8, crc: 0x" + format(message["checksum"]["crc"], "x") + "u32 })" if message["checksum"] else "None"},
+    },
+  %endfor
+%endfor
+];
+
+static YAMCAN_ENUM_VALUES: &[EnumValueDescriptor] = &[
+%for enum_name, enum_data in discrete_enums.items():
+  %for label, raw in enum_data["values"]:
+    EnumValueDescriptor {
+        enum_name: "${enum_name}",
+        label: "${label}",
+        raw: ${raw},
+    },
+  %endfor
+%endfor
+];
+
+pub fn enum_value_descriptors() -> &'static [EnumValueDescriptor] {
+    YAMCAN_ENUM_VALUES
+}
+
+fn raw_mask(width: u8) -> u64 {
+    if width >= 64 { u64::MAX } else { (1u64 << width) - 1u64 }
+}
+
+fn raw_signal_value(desc: &TxSignalDescriptor, data: [u8; 8]) -> u64 {
+    (u64::from_le_bytes(data) >> desc.start_bit) & raw_mask(desc.bit_width)
+}
+
+fn decode_signal_value(desc: &TxSignalDescriptor, data: [u8; 8]) -> f64 {
+    let raw = raw_signal_value(desc, data);
+    if desc.signed && desc.bit_width > 0 {
+        let sign_bit = 1u64 << (desc.bit_width - 1);
+        let signed = if (raw & sign_bit) != 0 {
+            (raw | !raw_mask(desc.bit_width)) as i64
+        } else {
+            raw as i64
+        };
+        signed as f64 * desc.scale + desc.offset
+    } else {
+        raw as f64 * desc.scale + desc.offset
+    }
+}
+
+fn encode_signal_value(desc: &TxSignalDescriptor, data: &mut [u8; 8], value: f64) {
+    let clamped = value.max(desc.min).min(desc.max);
+    let raw = ((clamped - desc.offset) / desc.scale) as i64;
+    write_raw_signal_value(desc.start_bit, desc.bit_width, data, raw as u64);
+}
+
+fn write_raw_signal_value(start_bit: u8, bit_width: u8, data: &mut [u8; 8], raw: u64) {
+    let raw = raw & raw_mask(bit_width);
+    let mask = raw_mask(bit_width) << start_bit;
+    let current = u64::from_le_bytes(*data) & !mask;
+    *data = (current | (raw << start_bit)).to_le_bytes();
+}
+
+fn apply_message_checksum(message: &MessageCodecDescriptor, data: &mut [u8; 8]) {
+    let Some(checksum) = message.checksum else {
+        return;
+    };
+
+    write_raw_signal_value(checksum.start_bit, checksum.bit_width, data, 0);
+    let mut calculated = checksum.crc;
+    for byte in data.iter().take(message.len as usize) {
+        calculated = calculated.wrapping_add(*byte as u32);
+    }
+    write_raw_signal_value(
+        checksum.start_bit,
+        checksum.bit_width,
+        data,
+        calculated as u64,
+    );
+}
+
+pub fn decode_transmitted_signal(
+    bus: Bus,
+    message_id: u32,
+    data: [u8; 8],
+    signal_name: &str,
+) -> Option<SignalMeasurement> {
+    let desc = YAMCAN_TX_SIGNALS
+        .iter()
+        .find(|desc| desc.bus == bus && desc.message_id == message_id && desc.signal_name == signal_name)?;
+    Some(SignalMeasurement {
+        name: desc.signal_name.to_string(),
+        value: decode_signal_value(desc, data),
+        unit: desc.unit.map(str::to_string),
+        label: None,
+    })
+}
+
+pub fn encode_transmitted_signal(
+    bus: Bus,
+    message_name: &str,
+    data: &mut [u8; 8],
+    signal_name: &str,
+    value: f64,
+) -> Option<MessageDescriptor<Bus>> {
+    let desc = YAMCAN_SIGNAL_CODECS
+        .iter()
+        .find(|desc| desc.bus == bus && desc.message_name == message_name && desc.signal_name == signal_name)?;
+    encode_signal_value(desc, data, value);
+    let message = YAMCAN_MESSAGE_CODECS
+        .iter()
+        .find(|message| message.bus == bus && message.name == message_name)?;
+    apply_message_checksum(message, data);
+    Some(MessageDescriptor {
+        bus: message.bus,
+        name: message.name,
+        id: message.id,
+        len: message.len,
+    })
+}
+
+pub struct GeneratedCanModel;
+
+impl GeneratedCanNetwork for GeneratedCanModel {
+    type Bus = Bus;
+    type TxSignalDescriptor = TxSignalDescriptor;
+
+    fn message_descriptors() -> &'static [MessageDescriptor<Self::Bus>] {
+        message_descriptors()
+    }
+
+    fn signal_descriptors() -> &'static [SignalDescriptor<Self::Bus>] {
+        signal_descriptors()
+    }
+
+    fn tx_message_descriptors() -> &'static [MessageDescriptor<Self::Bus>] {
+        tx_message_descriptors()
+    }
+
+    fn tx_signal_descriptors() -> &'static [Self::TxSignalDescriptor] {
+        tx_signal_descriptors()
+    }
+
+    fn enum_value_descriptors() -> &'static [EnumValueDescriptor] {
+        enum_value_descriptors()
     }
 }

--- a/tools/yamcan/yamcan.py
+++ b/tools/yamcan/yamcan.py
@@ -1087,6 +1087,7 @@ def codegen(
         ]
         if rust_codegen:
             makos += [
+                ["rust_faults_generated.rs.mako", {"nodes": [can_nodes[node]]}],
                 ["rust_model_generated.rs.mako", {"nodes": [can_nodes[node]]}],
                 [
                     "rust_decode_generated.rs.mako",


### PR DESCRIPTION
### Reason for Change

Introduce the base sim rig runtime and Buck integration needed for stacked embedded-controller simulation work.

### Changes

1. Add the core Rust/Python rig runtime and Buck targets used by later sim model PRs.
2. Add yamcan Rust model codegen plumbing and generated fault enum support.
3. Make standard CI/formatting workflows run on all pull requests in this stack.
4. Keep Buck2 setup on `concordia-fsae/install-buck2@latest` and make `shfmt` deterministic in formatting CI via the system binary.

### Test Plan

- Local: `buckle test sim/tests/...` from the top stack branch
- CI: Formatting
- CI: Build All Firmware

### Stack

Base of the current sim stack. Follow-ups: #648, #650, #651, #652.
