### PR TITLE
Simulate vcfront and vcrear

### DIFF
--- a/.github/workflows/standard_checks.yml
+++ b/.github/workflows/standard_checks.yml
@@ -77,6 +77,31 @@ jobs:
           release: ${{ steps.buck2_version.outputs.buck2_version }}
       - name: Run Component Unit Tests
         run: buck2 test //components/...
+  sim-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Read Buck2 Version
+        id: buck2_version
+        shell: bash
+        run: |
+          buck2_version="$(awk -F'=' '/^buck2_version/ {gsub(/[[:space:]]/, "", $2); print $2}' .buckleconfig.toml)"
+          echo "buck2_version=$buck2_version" >> "$GITHUB_OUTPUT"
+      - name: Install Buck2
+        uses: concordia-fsae/install-buck2@latest
+        with:
+          release: ${{ steps.buck2_version.outputs.buck2_version }}
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Install bindgen dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bindgen clang libclang-dev
+      - name: Run Sim Tests
+        run: buck2 test //sim/tests/...
   cfr-firmware:
     strategy:
       fail-fast: false

--- a/components/shared/code/app/CAN/CANIO-rx.c
+++ b/components/shared/code/app/CAN/CANIO-rx.c
@@ -66,6 +66,23 @@ static bool CANIO_rx_isBufferEmpty(void)
     return canrx.bufferEndIndex == canrx.bufferStartIndex;
 }
 
+#if FEATURE_IS_ENABLED(FEATURE_CANRX_SWI)
+static bool CANIO_rx_anyFifoNotify(void)
+{
+    const uint16_t * fifoNotify = (const uint16_t*)canrx.fifoNotify;
+    const uint16_t wordCount    = (uint16_t)(CAN_BUS_COUNT * WORDS_FROM_COUNT(CAN_RX_FIFO_COUNT));
+
+    for (uint16_t word = 0U; word < wordCount; word++)
+    {
+        if (fifoNotify[word] != 0U)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // FEATURE_CANRX_SWI
+
 /**
  * CANIO_rx_1kHz_PRD
  *
@@ -86,7 +103,7 @@ static void CANIO_rx_1kHz_PRD(void)
     }
 
 #if FEATURE_IS_ENABLED(FEATURE_CANRX_SWI)
-    if (FLAG_any((uint16_t*)&canrx.fifoNotify[CAN_BUS_VEH], CAN_RX_FIFO_COUNT))
+    if (CANIO_rx_anyFifoNotify())
     {
         SWI_invoke(CANRX_swi);
     }

--- a/components/vc/front/BUCK
+++ b/components/vc/front/BUCK
@@ -5,8 +5,9 @@ load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
 load("//drive-stack/ota-agent/defs.bzl", "ota_agent")
 load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
-load("//tools/yamcan/defs.bzl", "generate_code")
+load("//tools/yamcan/defs.bzl", "generate_c_library", "generate_code", "generate_resources")
 load("//tools/hextools/defs.bzl", "inject_crc")
+load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load(
     "//components/vehicle_platform:defs.bzl",
     "add_platform_deploy_targets",
@@ -15,15 +16,13 @@ load(
     "platform_selected_targets",
 )
 load("//components/vehicle_platform:platforms.bzl", "PLATFORMS", "platform_output_name")
+load("//components/vc/front:platforms.bzl", "VCFRONT_PLATFORM_VARIANTS")
 
 TOOLCHAIN = "@toolchains//:gcc-14.2.rel1-arm-none-eabi"
 APP_START_ADDR = 0x08002000
 APP_NAME = "vcfront"
 
-platform_variants = [
-    (PLATFORMS.CFR25, 0),
-    (PLATFORMS.CFR26, 0),
-]
+platform_variants = VCFRONT_PLATFORM_VARIANTS
 
 compiler_flags = [
     "-std=c11",
@@ -165,24 +164,22 @@ prebuilt_cxx_library(
     visibility = ["//components/vc/front/tests/..."],
 )
 
+prebuilt_cxx_library(
+    name = "sil-host-headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = {
+        "shockpot.h": "//components/vc/shared:app/shockpot.h",
+        "brakeTemp.h": "//components/vc/shared:app/brakeTemp.h",
+    } | remap_headers(["include/HW/", "include/"]),
+    visibility = ["//sim/models/controllers/vcfront/..."],
+)
+
 export_file(
     name = "src/torque.c",
     src = "src/torque.c",
     visibility = ["//components/vc/front/tests/..."],
 )
-
-[
-    export_file(
-        name = file,
-        src = file,
-        visibility = ["//sil/..."],
-    )
-    for file in [
-        "FeatureDefs.yaml",
-        "FeatureSels.yaml",
-        "variants.yaml",
-    ]
-]
 
 compiler_flags += ["-include", "BuildDefines.h"]
 
@@ -200,6 +197,135 @@ generate_code(
         "//components/shared/code/RTOS:headers",
         "//components/vc/shared:headers",
     ],
+)
+
+generate_resources(
+    name = "sil-yamcan",
+    network_dep = "//network:network",
+    node = APP_NAME,
+    rust_wrapper = True,
+    visibility = ["//sim/models/controllers/vcfront/..."],
+)
+
+generate_feature_tree(
+    name = "sil-features",
+    variant_id = 0,
+    srcs = {
+        "variants.yaml": "variants.yaml",
+        "STM32F105_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F105_FeatureSels.yaml",
+        "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",
+        "APP_V1_FeatureSels.yaml": "//components/shared:FeatureSels/APP_V1_FeatureSels.yaml",
+        "Application_FeatureDefs.yaml": "//components/shared:FeatureDefs/Application_FeatureDefs.yaml",
+        "SharedApp_FeatureDefs.yaml": "//components/shared/code:SharedApp_FeatureDefs.yaml",
+        "VC_FeatureSels.yaml": "//components/vc/shared/features:VC_FeatureSels.yaml",
+        "VC_FeatureDefs.yaml": "//components/vc/shared/features:VC_FeatureDefs.yaml",
+        "NVM_FeatureDefs.yaml": "//components/shared:FeatureDefs/NVM_FeatureDefs.yaml",
+        "hw_FeatureDefs.yaml": "//components/shared/code:HW/hw_FeatureDefs.yaml",
+        "FeatureDefs.yaml": "FeatureDefs.yaml",
+        "FeatureSels.yaml": "FeatureSels.yaml",
+    },
+    feature_overrides = {
+        "app_variant_id": 0,
+    },
+    visibility = ["//sim/models/controllers/vcfront/..."],
+    vcfront_variant_id = "0U",
+)
+
+generate_c_library(
+    name = "sil-yamcan-c",
+    codegen_target = ":sil-yamcan",
+    library_deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "sil-application",
+    srcs = [
+        "//components/shared/code:DRV/drv_inputAD.c",
+        "//components/shared/code:DRV/drv_io.c",
+        "//components/shared/code:DRV/drv_outputAD.c",
+        "//components/shared/code:DRV/drv_pedalMonitor.c",
+        "//components/shared/code:DRV/drv_timer.c",
+        "//components/shared/code:DRV/drv_tps20xx.c",
+        "//components/shared/code:app/CAN/CANIO-rx.c",
+        "//components/shared/code:app/CAN/CANIO-tx.c",
+        "//components/shared/code:app/app_faultManager.c",
+        "//components/shared/code:app/app_gps.c",
+        "//components/shared/code:app/app_vehicleSpeed.c",
+        "//components/shared/code:app/app_vehicleState.c",
+        "//components/shared/code:libs/LIB_app.c",
+        "//components/shared/code:libs/lib_interpolation.c",
+        "//components/shared/code:libs/lib_nvm.c",
+        "//components/shared/code:libs/lib_pid.c",
+        "//components/shared/code:libs/lib_rateLimit.c",
+        "//components/shared/code:libs/lib_simpleFilter.c",
+        "//components/shared/code/RTOS:Module.c",
+        "src/apps.c",
+        "src/bppc.c",
+        "src/brakePressure.c",
+        "src/CANIO_componentSpecific.c",
+        "src/cockpitLights.c",
+        "src/lib_nvm_componentSpecific.c",
+        "src/Module_componentSpecific.c",
+        "src/powerManager.c",
+        "src/steeringAngle.c",
+        "src/HW/drv_tps20xx_componentSpecific.c",
+        "src/torque.c",
+        "src/uds_componentSpecific.c",
+        "src/vd.c",
+        "src/wheelSpeed_componentSpecific.c",
+        "src/HW/drv_inputAD_componentSpecific.c",
+        "src/HW/drv_outputAD_componentSpecific.c",
+        "src/HW/drv_pedalMonitor_componentSpecific.c",
+        "//components/vc/shared:app/brakeTemp.c",
+        "//components/vc/shared:app/shockpot.c",
+        "//embedded/libs:libcrc.c",
+        ("//embedded/libs:lwgps[lwgps/src/lwgps/lwgps.c]", ["-Wno-conversion"]),
+        "//embedded/libs:isotp-src[isotp.c]",
+        "//embedded/libs/uds:lib_udsServer.c",
+    ],
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+    ],
+    header_namespace = "",
+    headers = {
+        "libcrc.h": "//embedded/libs:libcrc.h",
+        "lwgps.h": "//embedded/libs:lwgps[lwgps/src/include/lwgps/lwgps.h]",
+        "lwgps/lwgps.h": "//embedded/libs:lwgps[lwgps/src/include/lwgps/lwgps.h]",
+        "lwgps/lwgps_opt.h": "//embedded/libs:lwgps[lwgps/src/include/lwgps/lwgps_opt.h]",
+        "isotp.h": "//embedded/libs:isotp-src[include/isotp.h]",
+        "isotp_config.h": "//embedded/libs:isotp-src[include/isotp_config.h]",
+        "isotp_defines.h": "//embedded/libs:isotp-src[include/isotp_defines.h]",
+        "isotp_user.h": "//embedded/libs:isotp-src[include/isotp_user.h]",
+        "lib_uds.h": "//embedded/libs/uds:lib_uds.h",
+    },
+    deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        ":sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["//sim/models/controllers/vcfront/..."],
 )
 
 cxx_library(

--- a/components/vc/front/platforms.bzl
+++ b/components/vc/front/platforms.bzl
@@ -1,0 +1,6 @@
+load("//components/vehicle_platform:platforms.bzl", "PLATFORMS")
+
+VCFRONT_PLATFORM_VARIANTS = [
+    (PLATFORMS.CFR25, 0),
+    (PLATFORMS.CFR26, 0),
+]

--- a/components/vc/front/src/torque.c
+++ b/components/vc/front/src/torque.c
@@ -1450,7 +1450,7 @@ static void torque_periodic_100Hz(void)
     }
 
     const float32_t minTorque = (torque_data.gear == GEAR_F) ? -REGEN_MAX_TORQUE_N : ABSOLUTE_MIN_TORQUE;
-    torque_data.torque = SATURATE(minTorque, torque, ABSOLUTE_MAX_TORQUE);
+    torque_data.torque = (torque_data.state == TORQUE_ACTIVE) ? SATURATE(minTorque, torque, ABSOLUTE_MAX_TORQUE) : 0.0f;
 }
 
 /******************************************************************************

--- a/sim/infra/rig/BUCK
+++ b/sim/infra/rig/BUCK
@@ -1,0 +1,28 @@
+filegroup(
+    name = "rig",
+    srcs = [
+        "__init__.py",
+        "artifacts.py",
+        "can.py",
+        "catalog.py",
+        "datapath.py",
+        "gen_python_enums.py",
+        "gen_python_model.py",
+        "model.py",
+        "pytest.py",
+        "time.py",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "gen-python-enums",
+    src = "gen_python_enums.py",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "gen-python-model",
+    src = "gen_python_model.py",
+    visibility = ["PUBLIC"],
+)

--- a/sim/infra/rig/__init__.py
+++ b/sim/infra/rig/__init__.py
@@ -1,0 +1,102 @@
+from .catalog import ClusterCatalog, ClusterSpec, ClusterSpecFactory, ComponentSpec, NodeSpec
+from .artifacts import (
+    buck_output,
+    load_generated_module,
+    load_shared_library,
+    repo_root,
+    shared_library_mode,
+)
+from .can import (
+    CanBusDescriptor,
+    CanEvent,
+    CanMessageDescriptor,
+    CanPacket,
+    CanSignalDescriptor,
+    DecodedCanMessage,
+    RoutedCanEvent,
+)
+from .datapath import (
+    ComponentDataPathBinding,
+    ComponentDataPathOutput,
+    DataPath,
+    DataPathLink,
+    DataPathRecord,
+    ModelDataPathInputConnector,
+    ModelDataPaths,
+)
+from .can_interface import CanInterface
+from .cluster import (
+    ClusterCanComms,
+    ClusterComms,
+    ClusterDataRoutes,
+    ClusterRig,
+    ClusterSpiComms,
+    ClusterTimerComms,
+)
+from .model import (
+    ComponentRig,
+    ModelRig,
+    extend_model_class,
+)
+from .node import NodeRig
+from .peripherals import (
+    SpiInterface,
+    SpiTransaction,
+    TimerCaptureEvent,
+    TimerChannelEvent,
+    TimerInterface,
+)
+from .time import RunUntilTimeout, duration_to_ns, run_until
+
+
+def cluster_rig_fixture(*args, **kwargs):
+    from .pytest import cluster_rig_fixture as _cluster_rig_fixture
+
+    return _cluster_rig_fixture(*args, **kwargs)
+
+__all__ = [
+    "NodeRig",
+    "CanBusDescriptor",
+    "CanEvent",
+    "CanInterface",
+    "CanMessageDescriptor",
+    "CanPacket",
+    "CanSignalDescriptor",
+    "ClusterCanComms",
+    "ClusterComms",
+    "ClusterDataRoutes",
+    "ClusterRig",
+    "ClusterSpiComms",
+    "ClusterTimerComms",
+    "ComponentDataPathBinding",
+    "ComponentDataPathOutput",
+    "ComponentRig",
+    "DataPath",
+    "DataPathLink",
+    "DataPathRecord",
+    "DecodedCanMessage",
+    "ModelDataPathInputConnector",
+    "ModelDataPaths",
+    "ModelRig",
+    "buck_output",
+    "duration_to_ns",
+    "extend_model_class",
+    "RoutedCanEvent",
+    "RunUntilTimeout",
+    "SpiInterface",
+    "SpiTransaction",
+    "TimerCaptureEvent",
+    "TimerChannelEvent",
+    "TimerInterface",
+    "load_generated_module",
+    "load_shared_library",
+    "repo_root",
+    "run_until",
+    "shared_library_mode",
+    "ClusterCatalog",
+    "ClusterSpec",
+    "ClusterSpecFactory",
+    "ComponentSpec",
+    "NodeSpec",
+    "cluster_rig_fixture",
+]

--- a/sim/infra/rig/__init__.py
+++ b/sim/infra/rig/__init__.py
@@ -1,4 +1,10 @@
-from .catalog import ClusterCatalog, ClusterSpec, ClusterSpecFactory, ComponentSpec, NodeSpec
+from .catalog import (
+    ClusterCatalog,
+    ClusterSpec,
+    ClusterSpecFactory,
+    ComponentSpec,
+    NodeSpec,
+)
 from .artifacts import (
     buck_output,
     load_generated_module,
@@ -53,6 +59,7 @@ def cluster_rig_fixture(*args, **kwargs):
     from .pytest import cluster_rig_fixture as _cluster_rig_fixture
 
     return _cluster_rig_fixture(*args, **kwargs)
+
 
 __all__ = [
     "NodeRig",

--- a/sim/infra/rig/artifacts.py
+++ b/sim/infra/rig/artifacts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import types
+
+
+def repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[3]
+
+
+def buck_output(target: str, root: pathlib.Path | None = None) -> pathlib.Path:
+    root = root or repo_root()
+    result = subprocess.run(
+        ["buckle", "build", "--show-output", target],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    for line in result.stdout.splitlines():
+        if line.startswith(f"root{target} "):
+            return root / line.split(maxsplit=1)[1]
+    raise RuntimeError(f"buckle did not report an output for {target}")
+
+
+def shared_library_mode() -> int:
+    # Controller models intentionally share generic rig_model_* symbol names.
+    # Keep each shared object local so different controllers can coexist in one
+    # Python process without dynamic-loader symbol interposition.
+    mode = getattr(os, "RTLD_LOCAL", ctypes.DEFAULT_MODE)
+    mode |= getattr(os, "RTLD_NOW", 0)
+    mode |= getattr(os, "RTLD_DEEPBIND", 0)
+    return mode
+
+
+def load_shared_library(path: pathlib.Path) -> ctypes.CDLL:
+    return ctypes.CDLL(str(path), mode=shared_library_mode())
+
+
+def load_generated_module(
+    env_var: str, target: str, module_name: str
+) -> types.ModuleType:
+    module_path = os.environ.get(env_var)
+    if module_path is None:
+        raise RuntimeError(
+            f"{env_var} is not configured; build {target} with Buck and pass its output explicitly"
+        )
+    path = pathlib.Path(module_path)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load generated module {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/sim/infra/rig/can.py
+++ b/sim/infra/rig/can.py
@@ -21,10 +21,14 @@ class CanPacket(ctypes.Structure):
     ]
 
     @classmethod
-    def from_payload(cls, frame_id: int, payload: bytes | bytearray | list[int] | tuple[int, ...]):
+    def from_payload(
+        cls, frame_id: int, payload: bytes | bytearray | list[int] | tuple[int, ...]
+    ):
         payload_bytes = bytes(payload)
         if len(payload_bytes) > 8:
-            raise ValueError(f"CAN payload must be at most 8 bytes, got {len(payload_bytes)}")
+            raise ValueError(
+                f"CAN payload must be at most 8 bytes, got {len(payload_bytes)}"
+            )
 
         packet = cls()
         packet.id = ctypes.c_uint32(frame_id).value

--- a/sim/infra/rig/can.py
+++ b/sim/infra/rig/can.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import ctypes
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+SIGNAL_KIND_NAMES = {
+    0: "Numeric",
+    1: "Boolean",
+    2: "Enum",
+}
+
+
+class CanPacket(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_uint32),
+        ("len", ctypes.c_uint8),
+        ("data", ctypes.c_uint8 * 8),
+    ]
+
+    @classmethod
+    def from_payload(cls, frame_id: int, payload: bytes | bytearray | list[int] | tuple[int, ...]):
+        payload_bytes = bytes(payload)
+        if len(payload_bytes) > 8:
+            raise ValueError(f"CAN payload must be at most 8 bytes, got {len(payload_bytes)}")
+
+        packet = cls()
+        packet.id = ctypes.c_uint32(frame_id).value
+        packet.len = len(payload_bytes)
+        for index, value in enumerate(payload_bytes):
+            packet.data[index] = value
+        return packet
+
+    @property
+    def payload(self) -> bytes:
+        return bytes(self.data[: self.len])
+
+
+class CanEvent(ctypes.Structure):
+    _fields_ = [
+        ("bus", ctypes.c_uint8),
+        ("timestamp_ns", ctypes.c_uint64),
+        ("packet", CanPacket),
+    ]
+
+
+@dataclass(frozen=True)
+class CanBusDescriptor:
+    index: int
+    name: str
+
+
+@dataclass(frozen=True)
+class CanMessageDescriptor:
+    bus: int
+    bus_name: str
+    name: str
+    id: int
+    len: int
+
+
+@dataclass(frozen=True)
+class CanSignalDescriptor:
+    bus: int
+    bus_name: str
+    message_name: str
+    message_id: int
+    signal_name: str
+    unit: str | None
+    kind: str
+    enum_name: str | None
+
+
+@dataclass(frozen=True)
+class CanEnumValueDescriptor:
+    enum_name: str
+    label: str
+    raw: int
+
+
+class _CanMessageDescriptorAbi(ctypes.Structure):
+    _fields_ = [
+        ("bus", ctypes.c_uint8),
+        ("id", ctypes.c_uint32),
+        ("len", ctypes.c_uint8),
+    ]
+
+
+class _CanSignalDescriptorAbi(ctypes.Structure):
+    _fields_ = [
+        ("bus", ctypes.c_uint8),
+        ("message_id", ctypes.c_uint32),
+        ("kind", ctypes.c_uint8),
+    ]
+
+
+class _CanEnumValueDescriptorAbi(ctypes.Structure):
+    _fields_ = [
+        ("raw", ctypes.c_int),
+    ]
+
+
+@dataclass(frozen=True)
+class DecodedCanMessage:
+    message: CanMessageDescriptor
+    values: dict[str, object]
+    event: CanEvent | None = None
+
+    def __getitem__(self, signal_name: str) -> object:
+        return self.values[signal_name]
+
+    def __getattr__(self, signal_name: str) -> object:
+        try:
+            return self.values[signal_name]
+        except KeyError as exc:
+            raise AttributeError(signal_name) from exc
+
+
+@dataclass(frozen=True)
+class RoutedCanEvent:
+    node: str
+    bus: CanBusDescriptor
+    event: CanEvent
+
+
+class CanEnumNamespace(Mapping[str, type[IntEnum]]):
+    def __init__(self, enums: Mapping[str, type[IntEnum]]) -> None:
+        self._enums = dict(enums)
+        self._attrs = {
+            python_enum_class_name(enum_name): enum_type
+            for enum_name, enum_type in self._enums.items()
+        }
+
+    def __getitem__(self, enum_name: str) -> type[IntEnum]:
+        try:
+            return self._enums[enum_name]
+        except KeyError:
+            return self._attrs[enum_name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._enums)
+
+    def __len__(self) -> int:
+        return len(self._enums)
+
+    def __getattr__(self, enum_name: str) -> type[IntEnum]:
+        try:
+            return self._attrs[enum_name]
+        except KeyError as exc:
+            raise AttributeError(enum_name) from exc
+
+
+def python_enum_member(label: str) -> str:
+    member = "".join(ch if ch.isalnum() else "_" for ch in label).upper().strip("_")
+    if not member:
+        member = "VALUE"
+    if member[0].isdigit():
+        member = "_" + member
+    return member
+
+
+def python_enum_attr_member(label: str) -> str:
+    member = "".join(ch.lower() if ch.isalnum() else "_" for ch in label).strip("_")
+    if not member:
+        member = "value"
+    if member[0].isdigit():
+        member = "_" + member
+    return member
+
+
+def python_enum_class_name(name: str) -> str:
+    parts = []
+    current = ""
+    for ch in name:
+        if ch.isalnum():
+            current += ch
+            continue
+        if current:
+            parts.append(current)
+            current = ""
+    if current:
+        parts.append(current)
+    return "".join(part[:1].upper() + part[1:] for part in parts) or "GeneratedEnum"

--- a/sim/infra/rig/can_interface.py
+++ b/sim/infra/rig/can_interface.py
@@ -73,7 +73,9 @@ class CanInterface:
     ) -> bool:
         if isinstance(bus_or_message, CanMessageDescriptor):
             if frame_id is not None or payload is not None:
-                raise ValueError("frame_id and payload must not be provided when sending a CAN message descriptor")
+                raise ValueError(
+                    "frame_id and payload must not be provided when sending a CAN message descriptor"
+                )
             packet = self.encode(bus_or_message, **signals)
             return self._model._can_send_packet(
                 bus_or_message.bus,
@@ -161,20 +163,30 @@ class CanInterface:
     ) -> DecodedCanMessage:
         event = packet_or_event if isinstance(packet_or_event, CanEvent) else None
         packet = packet_or_event.packet if event is not None else packet_or_event
-        signals = self._model._signals_for_message(message) if signal_names is None else signal_names
-        raw_values = self._model._can_decode_message_raw(message.bus, packet, tuple(signals))
+        signals = (
+            self._model._signals_for_message(message)
+            if signal_names is None
+            else signal_names
+        )
+        raw_values = self._model._can_decode_message_raw(
+            message.bus, packet, tuple(signals)
+        )
         typed_values = {
             signal_name: self._model._coerce_decoded_can_value(signal_name, value)
             for signal_name, value in raw_values.items()
         }
         return DecodedCanMessage(message=message, values=typed_values, event=event)
 
-    def encode(self, message: CanMessageDescriptor, **signals: float | int | IntEnum) -> CanPacket:
+    def encode(
+        self, message: CanMessageDescriptor, **signals: float | int | IntEnum
+    ) -> CanPacket:
         raw_signals = {
             signal_name: int(value) if isinstance(value, IntEnum) else value
             for signal_name, value in signals.items()
         }
-        return self._model._can_encode_message_raw(message.bus, message.name, **raw_signals)
+        return self._model._can_encode_message_raw(
+            message.bus, message.name, **raw_signals
+        )
 
     def _tx_message_descriptor(
         self,
@@ -187,5 +199,3 @@ class CanInterface:
                 raise ValueError(f"message {message.name!r} is not on bus {bus!r}")
             return message
         return self.tx_message(message, bus=bus)
-
-

--- a/sim/infra/rig/can_interface.py
+++ b/sim/infra/rig/can_interface.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+from .can import (
+    CanBusDescriptor,
+    CanEvent,
+    CanMessageDescriptor,
+    CanPacket,
+    CanSignalDescriptor,
+    DecodedCanMessage,
+)
+
+
+class CanInterface:
+    def __init__(self, model: NodeRig) -> None:
+        self._model = model
+
+    @property
+    def buses(self) -> tuple[CanBusDescriptor, ...]:
+        return self._model._can_buses
+
+    @property
+    def bus_count(self) -> int:
+        return self._model._can_bus_count_value()
+
+    @property
+    def rx_messages(self) -> tuple[CanMessageDescriptor, ...]:
+        return self._model._can_messages
+
+    @property
+    def tx_messages(self) -> tuple[CanMessageDescriptor, ...]:
+        return self._model._can_tx_messages
+
+    @property
+    def rx_signals(self) -> tuple[CanSignalDescriptor, ...]:
+        return self._model._can_signals
+
+    @property
+    def tx_signals(self) -> tuple[CanSignalDescriptor, ...]:
+        return self._model._can_tx_signals
+
+    @property
+    def enums(self) -> CanEnumNamespace:
+        return self._model._can_enums
+
+    def bus(self, bus: int | str | CanBusDescriptor) -> CanBusDescriptor:
+        return self._model._can_bus_descriptor(bus)
+
+    def message(
+        self,
+        name: str,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+        tx: bool = False,
+    ) -> CanMessageDescriptor:
+        return self._model._can_message_descriptor(name, bus=bus, tx=tx)
+
+    def tx_message(
+        self,
+        name: str,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+    ) -> CanMessageDescriptor:
+        return self._model._can_tx_message_descriptor(name, bus=bus)
+
+    def send(
+        self,
+        bus_or_message: int | str | CanBusDescriptor | CanMessageDescriptor,
+        frame_id: int | None = None,
+        payload: bytes | bytearray | list[int] | tuple[int, ...] | None = None,
+        **signals: float | int | IntEnum,
+    ) -> bool:
+        if isinstance(bus_or_message, CanMessageDescriptor):
+            if frame_id is not None or payload is not None:
+                raise ValueError("frame_id and payload must not be provided when sending a CAN message descriptor")
+            packet = self.encode(bus_or_message, **signals)
+            return self._model._can_send_packet(
+                bus_or_message.bus,
+                bus_or_message.id,
+                packet.payload,
+            )
+
+        if frame_id is None or payload is None:
+            raise ValueError("raw CAN send requires bus, frame_id, and payload")
+        if signals:
+            raise ValueError("signal values require sending a CAN message descriptor")
+        return self._model._can_send_packet(bus_or_message, frame_id, payload)
+
+    def recv(self, bus: int | str | CanBusDescriptor) -> CanEvent | None:
+        return self._model._can_recv_event(bus)
+
+    def recv_latest(self, message: CanMessageDescriptor) -> CanEvent | None:
+        return self._model._can_recv_message(message)
+
+    def latest_event(
+        self,
+        message: str | CanMessageDescriptor,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+    ) -> CanEvent | None:
+        descriptor = self._tx_message_descriptor(message, bus=bus)
+        cluster = self._model._cluster_rig
+        node_name = self._model._cluster_node_name
+        if cluster is not None and node_name is not None:
+            return cluster.comm.can.latest_message(
+                node_name,
+                descriptor,
+                bus=descriptor.bus,
+            )
+        return self.recv_latest(descriptor)
+
+    def latest_bus_event(self, bus: int | str | CanBusDescriptor) -> CanEvent | None:
+        bus_descriptor = self.bus(bus)
+        cluster = self._model._cluster_rig
+        node_name = self._model._cluster_node_name
+        if cluster is not None and node_name is not None:
+            return cluster.comm.can.latest_bus_event(node_name, bus_descriptor)
+
+        latest = None
+        while self.tx_count(bus_descriptor):
+            latest = self.recv(bus_descriptor)
+        return latest
+
+    def latest(
+        self,
+        message: str | CanMessageDescriptor,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+        signals: tuple[str, ...] | list[str] | None = None,
+    ) -> DecodedCanMessage | None:
+        descriptor = self._tx_message_descriptor(message, bus=bus)
+        event = self.latest_event(descriptor)
+        if event is None:
+            return None
+        return self.decode(descriptor, event, signals)
+
+    def latest_signal(
+        self,
+        message: str | CanMessageDescriptor,
+        signal: str,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+    ) -> object | None:
+        decoded = self.latest(message, bus=bus, signals=(signal,))
+        if decoded is None:
+            return None
+        return getattr(decoded, signal)
+
+    def rx_count(self, bus: int | str | CanBusDescriptor) -> int:
+        return self._model._can_rx_count_value(bus)
+
+    def tx_count(self, bus: int | str | CanBusDescriptor) -> int:
+        return self._model._can_tx_count_value(bus)
+
+    def decode(
+        self,
+        message: CanMessageDescriptor,
+        packet_or_event: CanPacket | CanEvent,
+        signal_names: tuple[str, ...] | list[str] | None = None,
+    ) -> DecodedCanMessage:
+        event = packet_or_event if isinstance(packet_or_event, CanEvent) else None
+        packet = packet_or_event.packet if event is not None else packet_or_event
+        signals = self._model._signals_for_message(message) if signal_names is None else signal_names
+        raw_values = self._model._can_decode_message_raw(message.bus, packet, tuple(signals))
+        typed_values = {
+            signal_name: self._model._coerce_decoded_can_value(signal_name, value)
+            for signal_name, value in raw_values.items()
+        }
+        return DecodedCanMessage(message=message, values=typed_values, event=event)
+
+    def encode(self, message: CanMessageDescriptor, **signals: float | int | IntEnum) -> CanPacket:
+        raw_signals = {
+            signal_name: int(value) if isinstance(value, IntEnum) else value
+            for signal_name, value in signals.items()
+        }
+        return self._model._can_encode_message_raw(message.bus, message.name, **raw_signals)
+
+    def _tx_message_descriptor(
+        self,
+        message: str | CanMessageDescriptor,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+    ) -> CanMessageDescriptor:
+        if isinstance(message, CanMessageDescriptor):
+            if bus is not None and self._model._coerce_can_bus(bus) != message.bus:
+                raise ValueError(f"message {message.name!r} is not on bus {bus!r}")
+            return message
+        return self.tx_message(message, bus=bus)
+
+

--- a/sim/infra/rig/catalog.py
+++ b/sim/infra/rig/catalog.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol
+
+from .datapath import ComponentDataPathBinding, DataPathLink
+from .cluster import ClusterRig
+from .model import ComponentRig
+from .node import NodeRig
+
+
+class ClusterSpecFactory(Protocol):
+    name: str
+
+    def rig(self) -> ClusterRig:
+        ...
+
+
+class RigNodeSpec(Protocol):
+    name: object
+    components: tuple[ComponentSpec, ...]
+
+    def rig(self) -> object:
+        ...
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    name: object
+    rig_class: type[NodeRig]
+    hardware: str | None = None
+    components: tuple[ComponentSpec, ...] = ()
+
+    def rig(self) -> NodeRig:
+        return self.rig_class(self.library_path())
+
+    def library_path(self) -> str | None:
+        env_prefix = rig_node_name(self.name).upper()
+        if self.hardware is not None:
+            hardware_env = f"{env_prefix}_{self.hardware.upper()}_SIM_LIB"
+            library_path = os.environ.get(hardware_env)
+            if library_path is not None:
+                return library_path
+            raise RuntimeError(
+                f"missing {hardware_env} for {self.name} {self.hardware} model"
+            )
+        return os.environ.get(f"{env_prefix}_SIM_LIB")
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    rig_class: type[ComponentRig]
+    parameters: dict[str, object] = field(default_factory=dict)
+    bindings: tuple[ComponentDataPathBinding, ...] = ()
+
+    def rig(self) -> ComponentRig:
+        return self.rig_class(**self.parameters)
+
+
+@dataclass(frozen=True)
+class ClusterSpec:
+    name: str
+    nodes: tuple[RigNodeSpec, ...]
+    hardware: str | None = None
+    features: frozenset[str] = frozenset()
+    datapath_links: tuple[DataPathLink, ...] = ()
+
+    def rig(self) -> ClusterRig:
+        nodes = {}
+        components: list[tuple[str, ComponentSpec, ComponentRig]] = []
+        for node in self.nodes:
+            node_name = rig_node_name(node.name)
+            nodes[node_name] = node.rig()
+            components.extend(
+                (node_name, component, component.rig())
+                for component in node.components
+            )
+
+        rig = ClusterRig(
+            name=self.name,
+            hardware=self.hardware,
+            features=self.features,
+            components=tuple(component_rig for _, _, component_rig in components),
+            **nodes,
+        )
+        for owner_node, component, component_rig in components:
+            owner = rig.nodes[owner_node]
+            owner.configure_model_outputs_for(component_rig)
+            for binding in component.bindings:
+                binding.bind(owner, component_rig)
+        rig.comm.connect_node_interfaces()
+        for link in self.datapath_links:
+            rig.dataroutes.connect(
+                link.path,
+                source_node=link.source_node,
+                sink_node=link.sink_node,
+            )
+        rig.reset()
+        return rig
+
+    def has_feature(self, feature: str) -> bool:
+        return feature in self.features
+
+
+def rig_node_name(name: object) -> str:
+    if isinstance(name, Enum):
+        return name.name.lower()
+    return str(name)
+
+
+class ClusterCatalog:
+    def __init__(self, *clusters: ClusterSpecFactory) -> None:
+        if not clusters:
+            raise ValueError("ClusterCatalog requires at least one cluster")
+        self.clusters = tuple(clusters)
+        self._clusters_by_name = {cluster.name: cluster for cluster in self.clusters}
+        if len(self._clusters_by_name) != len(self.clusters):
+            raise ValueError("ClusterCatalog cluster names must be unique")
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(cluster.name for cluster in self.clusters)
+
+    def get(self, name: str) -> ClusterSpecFactory:
+        try:
+            return self._clusters_by_name[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"cluster {name!r} is not declared; expected one of {', '.join(self.names)}"
+            ) from exc
+
+    def selected(
+        self,
+        env_var: str = "SIM_CLUSTERS",
+    ) -> tuple[ClusterSpecFactory, ...]:
+        raw_names = os.environ.get(env_var)
+        if raw_names is None:
+            return self.clusters
+        names = tuple(name.strip() for name in raw_names.split(",") if name.strip())
+        return tuple(self.get(name) for name in names) if names else self.clusters
+
+    def pytest_cases(
+        self,
+        *,
+        cluster_env_var: str = "SIM_CLUSTERS",
+    ) -> tuple[ClusterSpecFactory, ...]:
+        return self.selected(cluster_env_var)

--- a/sim/infra/rig/catalog.py
+++ b/sim/infra/rig/catalog.py
@@ -14,16 +14,14 @@ from .node import NodeRig
 class ClusterSpecFactory(Protocol):
     name: str
 
-    def rig(self) -> ClusterRig:
-        ...
+    def rig(self) -> ClusterRig: ...
 
 
 class RigNodeSpec(Protocol):
     name: object
     components: tuple[ComponentSpec, ...]
 
-    def rig(self) -> object:
-        ...
+    def rig(self) -> object: ...
 
 
 @dataclass(frozen=True)
@@ -74,8 +72,7 @@ class ClusterSpec:
             node_name = rig_node_name(node.name)
             nodes[node_name] = node.rig()
             components.extend(
-                (node_name, component, component.rig())
-                for component in node.components
+                (node_name, component, component.rig()) for component in node.components
             )
 
         rig = ClusterRig(

--- a/sim/infra/rig/cluster.py
+++ b/sim/infra/rig/cluster.py
@@ -137,11 +137,7 @@ class ClusterDataRoutes:
         routes: list[_DataPathRoute] = []
         for source_node, links in links_by_source.items():
             source = self._source_for_link(links[0])
-            sinks = tuple(
-                sink
-                for link in links
-                for sink in self._sinks_for_link(link)
-            )
+            sinks = tuple(sink for link in links for sink in self._sinks_for_link(link))
             routes.append(_DataPathRoute(source_node, source, sinks))
         self._route_cache[key] = tuple(routes)
         return self._route_cache[key]
@@ -160,8 +156,7 @@ class ClusterDataRoutes:
                 recv=output.recv,
             )
         raise KeyError(
-            f"node {link.source_node!r} has no output for datapath "
-            f"{link.path!r}"
+            f"node {link.source_node!r} has no output for datapath " f"{link.path!r}"
         )
 
     def _sinks_for_link(self, link: DataPathLink) -> tuple[DataPathSink[object], ...]:
@@ -180,8 +175,7 @@ class ClusterDataRoutes:
             )
         if not sinks:
             raise KeyError(
-                f"node {link.sink_node!r} has no input for datapath "
-                f"{link.path!r}"
+                f"node {link.sink_node!r} has no input for datapath " f"{link.path!r}"
             )
         return tuple(sinks)
 
@@ -258,11 +252,13 @@ class ClusterCanComms:
         return bool(self._cluster.nodes[node].datapaths.inputs(path))
 
     def connect_available_nodes(self) -> None:
-        self.connect_nodes(tuple(
-            node_name
-            for node_name, node in self._cluster.nodes.items()
-            if node.has_can
-        ))
+        self.connect_nodes(
+            tuple(
+                node_name
+                for node_name, node in self._cluster.nodes.items()
+                if node.has_can
+            )
+        )
 
     @property
     def events(self) -> tuple[RoutedCanEvent, ...]:
@@ -273,7 +269,13 @@ class ClusterCanComms:
             bus_name = str(path.parts[1])
             for record in self._dataroutes.records(path):
                 if isinstance(record.payload, CanEvent):
-                    events.append(RoutedCanEvent(record.source, CanBusDescriptor(record.payload.bus, bus_name), record.payload))
+                    events.append(
+                        RoutedCanEvent(
+                            record.source,
+                            CanBusDescriptor(record.payload.bus, bus_name),
+                            record.payload,
+                        )
+                    )
         return tuple(events)
 
     def route(self) -> None:
@@ -335,7 +337,9 @@ class ClusterCanComms:
 
 
 class _TypedClusterComms(Generic[PayloadT]):
-    def __init__(self, dataroutes: ClusterDataRoutes, payload_type: type[PayloadT]) -> None:
+    def __init__(
+        self, dataroutes: ClusterDataRoutes, payload_type: type[PayloadT]
+    ) -> None:
         self._dataroutes = dataroutes
         self._payload_type = payload_type
 
@@ -390,7 +394,6 @@ class ClusterComms:
         self._dataroutes.connect_available_paths()
 
 
-
 class ClusterRig:
     def __init__(
         self,
@@ -435,7 +438,9 @@ class ClusterRig:
             library_path = getattr(node, "library_path", None)
             if library_path is None:
                 continue
-            nodes_by_library.setdefault(pathlib.Path(library_path).resolve(), []).append(node_name)
+            nodes_by_library.setdefault(
+                pathlib.Path(library_path).resolve(), []
+            ).append(node_name)
 
         duplicates = {
             library_path: node_names
@@ -510,7 +515,9 @@ class ClusterRig:
         message: str | None = None,
     ) -> int:
         return run_until(
-            lambda delta_ns: self.run_for(delta_ns, unit="ns", step=delta_ns, step_unit="ns"),
+            lambda delta_ns: self.run_for(
+                delta_ns, unit="ns", step=delta_ns, step_unit="ns"
+            ),
             predicate,
             timeout_ns=duration_to_ns(timeout, unit=unit),
             step_ns=duration_to_ns(step, unit=step_unit or unit),
@@ -537,9 +544,7 @@ class ClusterRig:
 
     def _online_node_instances(self) -> tuple[object, ...]:
         return tuple(
-            node
-            for name, node in self._rig_nodes.items()
-            if self._online_nodes[name]
+            node for name, node in self._rig_nodes.items() if self._online_nodes[name]
         )
 
     def _next_cluster_scheduler_step_ns(
@@ -547,10 +552,14 @@ class ClusterRig:
         max_step_ns: int,
         online_nodes: tuple[object, ...] | None = None,
     ) -> int:
-        online_nodes = self._online_node_instances() if online_nodes is None else online_nodes
+        online_nodes = (
+            self._online_node_instances() if online_nodes is None else online_nodes
+        )
         if not online_nodes:
             return max_step_ns
-        return min(self._node_scheduler_step_ns(node, max_step_ns) for node in online_nodes)
+        return min(
+            self._node_scheduler_step_ns(node, max_step_ns) for node in online_nodes
+        )
 
     def _can_run_isolated_batch(self) -> bool:
         return len(self._online_node_instances()) == 1

--- a/sim/infra/rig/cluster.py
+++ b/sim/infra/rig/cluster.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from .can import CanBusDescriptor, CanEvent, CanMessageDescriptor, RoutedCanEvent
+from .datapath import (
+    DataPath,
+    DataPathLink,
+    DataPathRecord,
+    DataPathSink,
+    DataPathSource,
+    FanoutDataPath,
+    datapath_key,
+)
+from .model import ComponentRig, ModelRig
+from .peripherals import SpiTransaction, TimerChannelEvent
+from .time import duration_to_ns, run_until
+
+
+PayloadT = TypeVar("PayloadT")
+
+
+@dataclass(frozen=True)
+class _DataPathRoute:
+    source_node: str
+    source: DataPathSource[object]
+    sinks: tuple[DataPathSink[object], ...]
+
+
+class ClusterDataRoutes:
+    def __init__(self, cluster: ClusterRig) -> None:
+        self._cluster = cluster
+        self._fanouts: dict[str, FanoutDataPath[object]] = {}
+        self._paths: dict[str, DataPath] = {}
+        self._links: list[DataPathLink] = []
+        self._route_cache: dict[str, tuple[_DataPathRoute, ...]] = {}
+
+    def register(self, path: DataPath) -> None:
+        self._fanout(path)
+
+    def connect(
+        self,
+        path: DataPath,
+        *,
+        source_node: str,
+        sink_node: str | None = None,
+    ) -> None:
+        if source_node not in self._cluster._rig_nodes:
+            raise KeyError(f"source node {source_node!r} is not in this rig")
+        if sink_node is not None and sink_node not in self._cluster._rig_nodes:
+            raise KeyError(f"sink node {sink_node!r} is not in this rig")
+        link = DataPathLink(
+            path=path,
+            source_node=source_node,
+            sink_node=sink_node,
+        )
+        if link not in self._links:
+            self._links.append(link)
+            self._route_cache.clear()
+        self._fanout(path)
+
+    def connect_available_paths(self) -> None:
+        for source_node, node in self._cluster._rig_nodes.items():
+            for output in node.datapaths.outputs():
+                sink_nodes = tuple(
+                    sink_node
+                    for sink_node, sink in self._cluster._rig_nodes.items()
+                    if sink_node != source_node and sink.datapaths.inputs(output.path)
+                )
+                if not sink_nodes:
+                    self.connect(output.path, source_node=source_node)
+                    continue
+                for sink_node in sink_nodes:
+                    self.connect(
+                        output.path,
+                        source_node=source_node,
+                        sink_node=sink_node,
+                    )
+
+    def route(self, path: DataPath | None = None) -> None:
+        paths = (path,) if path is not None else self.paths
+        for path_name in paths:
+            self._route_path(path_name)
+
+    def reset(self) -> None:
+        for fanout in self._fanouts.values():
+            fanout.clear()
+
+    def clear(self, path: DataPath) -> None:
+        self._fanout(path).clear()
+
+    def records(self, path: DataPath) -> tuple[DataPathRecord[object], ...]:
+        return tuple(self._fanout(path).records)
+
+    @property
+    def paths(self) -> tuple[DataPath, ...]:
+        return tuple(self._paths.values())
+
+    def _fanout(self, path: DataPath) -> FanoutDataPath[object]:
+        key = datapath_key(path)
+        self._paths.setdefault(key, path)
+        if key not in self._fanouts:
+            self._fanouts[key] = FanoutDataPath()
+        return self._fanouts[key]
+
+    def _route_path(self, path: DataPath) -> None:
+        fanout = self._fanout(path)
+        for route in self._routes_for_path(path):
+            if not self._cluster.node_online(route.source_node):
+                continue
+            while route.source.pending():
+                payload = route.source.recv()
+                if payload is None:
+                    break
+
+                record = DataPathRecord(
+                    route.source.node,
+                    route.source.path,
+                    payload,
+                    self._cluster.elapsed_ns,
+                )
+                fanout.records.append(record)
+                for sink in route.sinks:
+                    sink.send(payload)
+
+    def _routes_for_path(self, path: DataPath) -> tuple[_DataPathRoute, ...]:
+        key = datapath_key(path)
+        if key in self._route_cache:
+            return self._route_cache[key]
+
+        links_by_source: dict[str, list[DataPathLink]] = {}
+        for link in self._links_for_path(path):
+            links_by_source.setdefault(link.source_node, []).append(link)
+
+        routes: list[_DataPathRoute] = []
+        for source_node, links in links_by_source.items():
+            source = self._source_for_link(links[0])
+            sinks = tuple(
+                sink
+                for link in links
+                for sink in self._sinks_for_link(link)
+            )
+            routes.append(_DataPathRoute(source_node, source, sinks))
+        self._route_cache[key] = tuple(routes)
+        return self._route_cache[key]
+
+    def _links_for_path(self, path: DataPath) -> tuple[DataPathLink, ...]:
+        key = datapath_key(path)
+        return tuple(link for link in self._links if datapath_key(link.path) == key)
+
+    def _source_for_link(self, link: DataPathLink) -> DataPathSource[object]:
+        node = self._cluster._rig_nodes[link.source_node]
+        for output in node.datapaths.outputs(link.path):
+            return DataPathSource(
+                node=link.source_node,
+                path=output.path,
+                pending=output.pending,
+                recv=output.recv,
+            )
+        raise KeyError(
+            f"node {link.source_node!r} has no output for datapath "
+            f"{link.path!r}"
+        )
+
+    def _sinks_for_link(self, link: DataPathLink) -> tuple[DataPathSink[object], ...]:
+        if link.sink_node is None:
+            return ()
+
+        node = self._cluster._rig_nodes[link.sink_node]
+        sinks: list[DataPathSink[object]] = []
+        for input_ in node.datapaths.inputs(link.path):
+            sinks.append(
+                DataPathSink(
+                    node=link.sink_node,
+                    path=input_.path,
+                    send=input_.send,
+                )
+            )
+        if not sinks:
+            raise KeyError(
+                f"node {link.sink_node!r} has no input for datapath "
+                f"{link.path!r}"
+            )
+        return tuple(sinks)
+
+
+class ClusterCanComms:
+    PATH = "can"
+
+    def __init__(self, cluster: ClusterRig, dataroutes: ClusterDataRoutes) -> None:
+        self._cluster = cluster
+        self._dataroutes = dataroutes
+
+    def connect_bus(
+        self,
+        bus: int | str | CanBusDescriptor,
+        *,
+        nodes: tuple[str, ...] | list[str] | None = None,
+    ) -> None:
+        node_names = tuple(self._cluster.nodes) if nodes is None else tuple(nodes)
+        for source_node in node_names:
+            source_bus = self._cluster.nodes[source_node].can.bus(bus)
+            path = self.path(source_bus)
+            if len(node_names) == 1:
+                self._dataroutes.connect(
+                    path,
+                    source_node=source_node,
+                )
+                continue
+            for sink_node in node_names:
+                if sink_node == source_node:
+                    continue
+                self._dataroutes.connect(
+                    path,
+                    source_node=source_node,
+                    sink_node=sink_node,
+                )
+
+    def connect_nodes(self, nodes: tuple[str, ...] | list[str]) -> None:
+        node_names = tuple(nodes)
+        for node_name in node_names:
+            if node_name not in self._cluster.nodes:
+                raise KeyError(f"CAN node {node_name!r} is not in this rig")
+
+        for source_node in node_names:
+            source = self._cluster.nodes[source_node]
+            for source_bus in source.can.buses:
+                path = self.path(source_bus)
+                if not self._node_has_datapath_output(source_node, path):
+                    continue
+                sink_buses = tuple(
+                    sink_node
+                    for sink_node in node_names
+                    if sink_node != source_node
+                    for sink_bus in self._cluster.nodes[sink_node].can.buses
+                    if sink_bus.name == source_bus.name
+                    and self._node_has_datapath_input(sink_node, path)
+                )
+                if not sink_buses:
+                    self._dataroutes.connect(
+                        path,
+                        source_node=source_node,
+                    )
+                    continue
+                for sink_node in sink_buses:
+                    self._dataroutes.connect(
+                        path,
+                        source_node=source_node,
+                        sink_node=sink_node,
+                    )
+
+    def _node_has_datapath_output(self, node: str, path: DataPath) -> bool:
+        return bool(self._cluster.nodes[node].datapaths.outputs(path))
+
+    def _node_has_datapath_input(self, node: str, path: DataPath) -> bool:
+        return bool(self._cluster.nodes[node].datapaths.inputs(path))
+
+    def connect_available_nodes(self) -> None:
+        self.connect_nodes(tuple(
+            node_name
+            for node_name, node in self._cluster.nodes.items()
+            if node.has_can
+        ))
+
+    @property
+    def events(self) -> tuple[RoutedCanEvent, ...]:
+        events = []
+        for path in self._dataroutes.paths:
+            if not self._is_can_path(path):
+                continue
+            bus_name = str(path.parts[1])
+            for record in self._dataroutes.records(path):
+                if isinstance(record.payload, CanEvent):
+                    events.append(RoutedCanEvent(record.source, CanBusDescriptor(record.payload.bus, bus_name), record.payload))
+        return tuple(events)
+
+    def route(self) -> None:
+        for path in self._dataroutes.paths:
+            if self._is_can_path(path):
+                self._dataroutes.route(path)
+
+    def reset(self) -> None:
+        self.clear()
+
+    def clear(self) -> None:
+        for path in self._dataroutes.paths:
+            if self._is_can_path(path):
+                self._dataroutes.clear(path)
+
+    @classmethod
+    def path(cls, bus: CanBusDescriptor | str) -> DataPath:
+        bus_name = bus.name if isinstance(bus, CanBusDescriptor) else str(bus)
+        return DataPath.can_bus(bus_name)
+
+    @classmethod
+    def _is_can_path(cls, path: DataPath) -> bool:
+        return len(path.parts) == 2 and path.parts[0] == cls.PATH
+
+    def latest_message(
+        self,
+        node: str,
+        message: str | CanMessageDescriptor,
+        *,
+        bus: int | str | CanBusDescriptor,
+    ) -> CanEvent | None:
+        node_rig = self._cluster.nodes[node]
+        bus_descriptor = node_rig.can.bus(bus)
+        message_id = (
+            node_rig.can.tx_message(message, bus=bus_descriptor).id
+            if isinstance(message, str)
+            else message.id
+        )
+
+        for routed in reversed(self.events):
+            if (
+                routed.node == node
+                and routed.bus.index == bus_descriptor.index
+                and routed.event.packet.id == message_id
+            ):
+                return routed.event
+        return None
+
+    def latest_bus_event(
+        self,
+        node: str,
+        bus: int | str | CanBusDescriptor,
+    ) -> CanEvent | None:
+        bus_descriptor = self._cluster.nodes[node].can.bus(bus)
+        for routed in reversed(self.events):
+            if routed.node == node and routed.bus.index == bus_descriptor.index:
+                return routed.event
+        return None
+
+
+class _TypedClusterComms(Generic[PayloadT]):
+    def __init__(self, dataroutes: ClusterDataRoutes, payload_type: type[PayloadT]) -> None:
+        self._dataroutes = dataroutes
+        self._payload_type = payload_type
+
+    def records(self, path: DataPath) -> tuple[DataPathRecord[PayloadT], ...]:
+        return tuple(
+            record
+            for record in self._dataroutes.records(path)
+            if isinstance(record.payload, self._payload_type)
+        )
+
+    def events(self, path: DataPath) -> tuple[PayloadT, ...]:
+        return tuple(record.payload for record in self.records(path))
+
+    def latest_event(
+        self,
+        path: DataPath,
+        *,
+        node: str | None = None,
+    ) -> PayloadT | None:
+        for record in reversed(self.records(path)):
+            if node is not None and record.source != node:
+                continue
+            return record.payload
+        return None
+
+
+class ClusterTimerComms(_TypedClusterComms[TimerChannelEvent]):
+    def __init__(self, dataroutes: ClusterDataRoutes) -> None:
+        super().__init__(dataroutes, TimerChannelEvent)
+
+
+class ClusterSpiComms(_TypedClusterComms[SpiTransaction]):
+    def __init__(self, dataroutes: ClusterDataRoutes) -> None:
+        super().__init__(dataroutes, SpiTransaction)
+
+
+class ClusterComms:
+    def __init__(self, cluster: ClusterRig, dataroutes: ClusterDataRoutes) -> None:
+        self._dataroutes = dataroutes
+        self.can = ClusterCanComms(cluster, dataroutes)
+        self.timer = ClusterTimerComms(dataroutes)
+        self.spi = ClusterSpiComms(dataroutes)
+
+    def route(self) -> None:
+        self._dataroutes.route()
+
+    def reset(self) -> None:
+        self._dataroutes.reset()
+
+    def connect_node_interfaces(self) -> None:
+        self.can.connect_available_nodes()
+        self._dataroutes.connect_available_paths()
+
+
+
+class ClusterRig:
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        hardware: str | None = None,
+        features: frozenset[str] | set[str] | tuple[str, ...] = frozenset(),
+        components: tuple[ComponentRig, ...] = (),
+        **nodes: ModelRig,
+    ) -> None:
+        if not nodes and not components:
+            raise ValueError("ClusterRig requires at least one node or component")
+        self.name = name or "cluster"
+        self.hardware = hardware
+        self.features = frozenset(features)
+        self.nodes = dict(nodes)
+        self._reject_duplicate_shared_libraries()
+        self.components = tuple(components)
+        self._component_nodes = {
+            f"__component_{index}": component
+            for index, component in enumerate(self.components)
+        }
+        self._rig_nodes = {
+            **self.nodes,
+            **self._component_nodes,
+        }
+        for node_name, node in self.nodes.items():
+            node._cluster_rig = self
+            node._cluster_node_name = node_name
+        for node_name, node in self._component_nodes.items():
+            node._cluster_rig = self
+            node._cluster_node_name = node_name
+        self._online_nodes = {name: True for name in self._rig_nodes}
+        self.elapsed_ns = 0
+        self.dataroutes = ClusterDataRoutes(self)
+        self.comm = ClusterComms(self, self.dataroutes)
+        self.comm.connect_node_interfaces()
+
+    def _reject_duplicate_shared_libraries(self) -> None:
+        nodes_by_library: dict[pathlib.Path, list[str]] = {}
+        for node_name, node in self.nodes.items():
+            library_path = getattr(node, "library_path", None)
+            if library_path is None:
+                continue
+            nodes_by_library.setdefault(pathlib.Path(library_path).resolve(), []).append(node_name)
+
+        duplicates = {
+            library_path: node_names
+            for library_path, node_names in nodes_by_library.items()
+            if len(node_names) > 1
+        }
+        if duplicates:
+            details = "; ".join(
+                f"{library_path}: {', '.join(node_names)}"
+                for library_path, node_names in sorted(duplicates.items())
+            )
+            raise ValueError(
+                "ClusterRig cannot instantiate the same Rust-backed controller shared object "
+                f"more than once because the current model ABI owns singleton runtime state: {details}"
+            )
+
+    def __getattr__(self, name: str) -> ModelRig:
+        try:
+            return self.nodes[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def reset(self) -> None:
+        for node in self._rig_nodes.values():
+            node.reset()
+        for name in self._rig_nodes:
+            self._online_nodes[name] = True
+        self.elapsed_ns = 0
+        self.comm.reset()
+
+    def has_feature(self, feature: str) -> bool:
+        return feature in self.features
+
+    def run_for(
+        self,
+        duration: int | float,
+        *,
+        unit: str = "ms",
+        step: int | float = 1,
+        step_unit: str | None = None,
+    ) -> None:
+        duration_ns = duration_to_ns(duration, unit=unit)
+        step_ns = duration_to_ns(step, unit=step_unit or unit)
+        if step_ns <= 0:
+            raise ValueError(f"step must be positive, got {step}")
+
+        if self._can_run_isolated_batch():
+            self._run_online_nodes(duration_ns)
+            self.elapsed_ns += duration_ns
+            self.comm.route()
+            return
+
+        remaining_ns = duration_ns
+        while remaining_ns:
+            max_delta_ns = min(step_ns, remaining_ns)
+            online_nodes = self._online_node_instances()
+            delta_ns = self._next_cluster_scheduler_step_ns(max_delta_ns, online_nodes)
+            for node in online_nodes:
+                node.run_for(delta_ns, unit="ns")
+            self.elapsed_ns += delta_ns
+            self.comm.route()
+            remaining_ns -= delta_ns
+
+    def run_until(
+        self,
+        predicate,
+        *,
+        timeout: int | float,
+        unit: str = "ms",
+        step: int | float = 1,
+        step_unit: str | None = None,
+        message: str | None = None,
+    ) -> int:
+        return run_until(
+            lambda delta_ns: self.run_for(delta_ns, unit="ns", step=delta_ns, step_unit="ns"),
+            predicate,
+            timeout_ns=duration_to_ns(timeout, unit=unit),
+            step_ns=duration_to_ns(step, unit=step_unit or unit),
+            message=message,
+        )
+
+    def set_node_online(self, name: str, online: bool) -> None:
+        if name not in self._rig_nodes:
+            raise KeyError(f"node {name!r} is not in this rig")
+        self._online_nodes[name] = online
+        if not online:
+            self._rig_nodes[name].reset()
+
+    def disable_node(self, name: str) -> None:
+        self.set_node_online(name, False)
+
+    def enable_node(self, name: str) -> None:
+        self.set_node_online(name, True)
+
+    def node_online(self, name: str) -> bool:
+        if name not in self._rig_nodes:
+            raise KeyError(f"node {name!r} is not in this rig")
+        return self._online_nodes[name]
+
+    def _online_node_instances(self) -> tuple[object, ...]:
+        return tuple(
+            node
+            for name, node in self._rig_nodes.items()
+            if self._online_nodes[name]
+        )
+
+    def _next_cluster_scheduler_step_ns(
+        self,
+        max_step_ns: int,
+        online_nodes: tuple[object, ...] | None = None,
+    ) -> int:
+        online_nodes = self._online_node_instances() if online_nodes is None else online_nodes
+        if not online_nodes:
+            return max_step_ns
+        return min(self._node_scheduler_step_ns(node, max_step_ns) for node in online_nodes)
+
+    def _can_run_isolated_batch(self) -> bool:
+        return len(self._online_node_instances()) == 1
+
+    def _run_online_nodes(self, duration_ns: int) -> None:
+        for node in self._online_node_instances():
+            node.run_for(duration_ns, unit="ns")
+
+    @staticmethod
+    def _node_scheduler_step_ns(node: object, max_step_ns: int) -> int:
+        next_scheduler_step = getattr(node, "next_scheduler_step", None)
+        if next_scheduler_step is None:
+            return max_step_ns
+        return int(next_scheduler_step(max_step_ns, unit="ns"))

--- a/sim/infra/rig/datapath.py
+++ b/sim/infra/rig/datapath.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, TypeVar
+
+
+PayloadT = TypeVar("PayloadT")
+
+
+@dataclass(frozen=True)
+class PeripheralBinding:
+    interface: str
+    channel: int | None = None
+    port: int | None = None
+    device: int | None = None
+
+
+@dataclass(frozen=True)
+class DataPath:
+    parts: tuple[object, ...]
+    peripheral_binding: PeripheralBinding | None = None
+
+    @classmethod
+    def component(cls, component: object, port: object) -> DataPath:
+        return cls((component, port))
+
+    @classmethod
+    def can_bus(cls, bus: object) -> DataPath:
+        return cls(("can", bus))
+
+    @classmethod
+    def peripheral(
+        cls,
+        *parts: object,
+        binding: PeripheralBinding,
+    ) -> DataPath:
+        return cls(parts, binding)
+
+
+def datapath_key(path: DataPath) -> str:
+    return "datapath:" + ":".join(_datapath_part_key(part) for part in path.parts)
+
+
+def _datapath_part_key(part: object) -> str:
+    if isinstance(part, Enum):
+        return f"{type(part).__module__}.{type(part).__qualname__}.{part.name}"
+    if isinstance(part, type):
+        return f"{part.__module__}.{part.__qualname__}"
+    return str(part)
+
+
+@dataclass(frozen=True)
+class DataPathRecord(Generic[PayloadT]):
+    source: str
+    path: DataPath
+    payload: PayloadT
+    timestamp_ns: int
+
+
+@dataclass(frozen=True)
+class DataPathLink:
+    path: DataPath
+    source_node: str
+    sink_node: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelDataPathInputConnector:
+    connect: Callable[[object, DataPath], None]
+
+
+@dataclass(frozen=True)
+class ComponentDataPathOutput:
+    path: Callable[[object], DataPath]
+
+    def bind_to(
+        self,
+        sink: ModelDataPathInputConnector,
+    ) -> ComponentDataPathBinding:
+        return ComponentDataPathBinding(self, sink)
+
+
+@dataclass(frozen=True)
+class ComponentDataPathBinding:
+    output: ComponentDataPathOutput
+    sink: ModelDataPathInputConnector
+
+    def bind(self, owner: object, component: object) -> None:
+        self.sink.connect(owner, self.output.path(component))
+
+
+@dataclass(frozen=True)
+class DataPathSource(Generic[PayloadT]):
+    node: str
+    path: DataPath
+    pending: Callable[[], int]
+    recv: Callable[[], PayloadT | None]
+
+
+@dataclass(frozen=True)
+class DataPathSink(Generic[PayloadT]):
+    node: str
+    path: DataPath
+    send: Callable[[PayloadT], bool]
+
+
+@dataclass(frozen=True)
+class ModelDataPathOutput(Generic[PayloadT]):
+    path: DataPath
+    pending: Callable[[], int]
+    recv: Callable[[], PayloadT | None]
+
+
+@dataclass(frozen=True)
+class ModelDataPathInput(Generic[PayloadT]):
+    path: DataPath
+    send: Callable[[PayloadT], bool]
+
+
+class FanoutDataPath(Generic[PayloadT]):
+    def __init__(self) -> None:
+        self.records: list[DataPathRecord[PayloadT]] = []
+
+    def clear(self) -> None:
+        self.records.clear()
+
+
+class ModelDataPaths:
+    def __init__(self) -> None:
+        self._outputs: list[ModelDataPathOutput[object]] = []
+        self._inputs: list[ModelDataPathInput[object]] = []
+
+    def add_output(
+        self,
+        path: DataPath,
+        *,
+        pending: Callable[[], int],
+        recv: Callable[[], object | None],
+    ) -> None:
+        self._outputs.append(ModelDataPathOutput(path, pending, recv))
+
+    def add_input(
+        self,
+        path: DataPath,
+        *,
+        send: Callable[[object], bool],
+    ) -> None:
+        self._inputs.append(ModelDataPathInput(path, send))
+
+    def outputs(self, path: DataPath | None = None) -> tuple[ModelDataPathOutput[object], ...]:
+        key = None if path is None else datapath_key(path)
+        return tuple(
+            output
+            for output in self._outputs
+            if key is None or datapath_key(output.path) == key
+        )
+
+    def inputs(self, path: DataPath | None = None) -> tuple[ModelDataPathInput[object], ...]:
+        key = None if path is None else datapath_key(path)
+        return tuple(
+            input_
+            for input_ in self._inputs
+            if key is None or datapath_key(input_.path) == key
+        )
+
+    @property
+    def paths(self) -> tuple[DataPath, ...]:
+        paths: dict[str, DataPath] = {}
+        for path in [output.path for output in self._outputs] + [input_.path for input_ in self._inputs]:
+            paths.setdefault(datapath_key(path), path)
+        return tuple(paths.values())

--- a/sim/infra/rig/datapath.py
+++ b/sim/infra/rig/datapath.py
@@ -149,7 +149,9 @@ class ModelDataPaths:
     ) -> None:
         self._inputs.append(ModelDataPathInput(path, send))
 
-    def outputs(self, path: DataPath | None = None) -> tuple[ModelDataPathOutput[object], ...]:
+    def outputs(
+        self, path: DataPath | None = None
+    ) -> tuple[ModelDataPathOutput[object], ...]:
         key = None if path is None else datapath_key(path)
         return tuple(
             output
@@ -157,7 +159,9 @@ class ModelDataPaths:
             if key is None or datapath_key(output.path) == key
         )
 
-    def inputs(self, path: DataPath | None = None) -> tuple[ModelDataPathInput[object], ...]:
+    def inputs(
+        self, path: DataPath | None = None
+    ) -> tuple[ModelDataPathInput[object], ...]:
         key = None if path is None else datapath_key(path)
         return tuple(
             input_
@@ -168,6 +172,8 @@ class ModelDataPaths:
     @property
     def paths(self) -> tuple[DataPath, ...]:
         paths: dict[str, DataPath] = {}
-        for path in [output.path for output in self._outputs] + [input_.path for input_ in self._inputs]:
+        for path in [output.path for output in self._outputs] + [
+            input_.path for input_ in self._inputs
+        ]:
             paths.setdefault(datapath_key(path), path)
         return tuple(paths.values())

--- a/sim/infra/rig/gen_python_enums.py
+++ b/sim/infra/rig/gen_python_enums.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from clang.cindex import Config, CursorKind, Index
+
+
+import re
+
+RUST_ENUM_RE = re.compile(r"pub\s+enum\s+(\w+)\s*\{(?P<body>.*?)\n\}", re.DOTALL)
+RUST_MEMBER_RE = re.compile(r"^\s*(\w+)(?:\s*=\s*(-?\d+))?,", re.MULTILINE)
+
+
+def camel_to_screaming(name: str) -> str:
+    words = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    words = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", words)
+    return words.upper()
+
+
+def python_member_name(
+    name: str, strip_prefix: str, strip_suffix: str, case: str
+) -> str:
+    if strip_prefix and name.startswith(strip_prefix):
+        name = name[len(strip_prefix) :]
+    if strip_suffix and name.endswith(strip_suffix):
+        name = name[: -len(strip_suffix)]
+    if case == "camel":
+        name = camel_to_screaming(name)
+    name = name.upper()
+    return f"_{name}" if name[:1].isdigit() else name
+
+
+def find_libclang() -> str | None:
+    for path in (
+        "/usr/lib/llvm-18/lib/libclang.so.1",
+        "/usr/lib/llvm-18/lib/libclang.so",
+        "/usr/lib/llvm-15/lib/libclang.so.1",
+        "/usr/lib/llvm-15/lib/libclang.so",
+    ):
+        if Path(path).exists():
+            return path
+    return None
+
+
+def parse_c_enums(
+    wrapper: Path, clang_args: list[str]
+) -> dict[str, list[tuple[str, int]]]:
+    libclang = find_libclang()
+    if libclang:
+        Config.set_library_file(libclang)
+
+    translation_unit = Index.create().parse(str(wrapper), args=clang_args)
+    errors = [
+        diag for diag in translation_unit.diagnostics if diag.severity >= diag.Error
+    ]
+    if errors:
+        message = "\n".join(str(diag) for diag in errors)
+        raise RuntimeError(f"libclang failed to parse {wrapper}:\n{message}")
+
+    enums: dict[str, list[tuple[str, int]]] = {}
+
+    def walk(cursor) -> None:
+        if cursor.kind == CursorKind.ENUM_DECL and cursor.spelling:
+            members = [
+                (child.spelling, child.enum_value)
+                for child in cursor.get_children()
+                if child.kind == CursorKind.ENUM_CONSTANT_DECL
+            ]
+            enums[cursor.spelling] = members
+        for child in cursor.get_children():
+            walk(child)
+
+    walk(translation_unit.cursor)
+    return enums
+
+
+def parse_rust_enum(source: str, enum_name: str) -> list[tuple[str, int]]:
+    for match in RUST_ENUM_RE.finditer(source):
+        if match.group(1) == enum_name:
+            members = []
+            next_value = 0
+            for name, value in RUST_MEMBER_RE.findall(match.group("body")):
+                if value:
+                    next_value = int(value)
+                members.append((name, next_value))
+                next_value += 1
+            return members
+    raise ValueError(f"Rust enum {enum_name!r} was not found")
+
+
+def enum_spec(spec: str) -> tuple[str, str, str, str, str]:
+    parts = spec.split(":")
+    if len(parts) != 5:
+        raise ValueError(
+            f"enum spec {spec!r} must be enum:python_enum:strip_prefix:strip_suffix:case"
+        )
+    return tuple(parts)  # type: ignore[return-value]
+
+
+def emit_enum(
+    members: list[tuple[str, int]],
+    python_enum: str,
+    strip_prefix: str,
+    strip_suffix: str,
+    case: str,
+) -> list[str]:
+    lines = [f"class {python_enum}(IntEnum):"]
+    for name, value in members:
+        member = python_member_name(name, strip_prefix, strip_suffix, case)
+        lines.append(f"    {member} = {value}")
+    if len(lines) == 1:
+        lines.append("    pass")
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--c-wrapper", required=True, type=Path)
+    parser.add_argument("--c-enum", action="append", default=[])
+    parser.add_argument("--rust-source", action="append", default=[])
+    parser.add_argument("--rust-enum", action="append", default=[])
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("clang_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    clang_args = args.clang_args
+    if clang_args and clang_args[0] == "--":
+        clang_args = clang_args[1:]
+
+    c_enums = parse_c_enums(args.c_wrapper, clang_args)
+    rust_sources = [Path(path).read_text() for path in args.rust_source]
+
+    output = [
+        "from __future__ import annotations",
+        "",
+        "from enum import IntEnum",
+        "",
+        "",
+    ]
+
+    for spec in args.c_enum:
+        c_enum, python_enum, strip_prefix, strip_suffix, case = enum_spec(spec)
+        if c_enum not in c_enums:
+            raise ValueError(f"C enum {c_enum!r} was not found")
+        output.extend(
+            emit_enum(c_enums[c_enum], python_enum, strip_prefix, strip_suffix, case)
+        )
+        output.extend(["", ""])
+
+    for spec in args.rust_enum:
+        rust_enum, python_enum, strip_prefix, strip_suffix, case = enum_spec(spec)
+        for source in rust_sources:
+            try:
+                members = parse_rust_enum(source, rust_enum)
+                break
+            except ValueError:
+                continue
+        else:
+            raise ValueError(f"Rust enum {rust_enum!r} was not found")
+        output.extend(emit_enum(members, python_enum, strip_prefix, strip_suffix, case))
+        output.extend(["", ""])
+
+    args.out.write_text("\n".join(output).rstrip() + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/infra/rig/gen_python_model.py
+++ b/sim/infra/rig/gen_python_model.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+RUST_EXTERN_RE = re.compile(
+    r"pub\s+extern\s+\"C\"\s+fn\s+(?P<name>[A-Za-z0-9_]+)\s*"
+    r"\((?P<args>[^)]*)\)\s*(?:->\s*(?P<ret>[A-Za-z0-9_]+))?"
+)
+
+RUST_TO_CTYPES = {
+    "bool": "ctypes.c_bool",
+    "f32": "ctypes.c_float",
+    "i32": "ctypes.c_int",
+    "u32": "ctypes.c_uint32",
+}
+
+BASE_MODEL_SUFFIXES = {
+    "new",
+    "run_for",
+}
+
+
+def property_name(symbol_suffix: str) -> str:
+    if symbol_suffix.startswith("get_"):
+        return symbol_suffix.removeprefix("get_")
+    return symbol_suffix
+
+
+def parse_model_getters(rust_source: Path, symbol_prefix: str) -> list[tuple[str, str]]:
+    getters = []
+    for match in RUST_EXTERN_RE.finditer(rust_source.read_text()):
+        symbol = match.group("name")
+        if not symbol.startswith(symbol_prefix + "_"):
+            continue
+        suffix = symbol.removeprefix(symbol_prefix + "_")
+        ret = match.group("ret")
+        if suffix in BASE_MODEL_SUFFIXES or not suffix.startswith("get_"):
+            continue
+        if match.group("args").strip():
+            continue
+        if ret not in RUST_TO_CTYPES:
+            continue
+        getters.append((suffix, ret))
+    return sorted(getters)
+
+
+def emit_model(
+    *,
+    class_name: str,
+    symbol_prefix: str,
+    buck_target: str,
+    env_var: str,
+    enum_env_var: str,
+    enum_target: str,
+    getters: list[tuple[str, str]],
+) -> str:
+    lines = [
+        "from __future__ import annotations",
+        "",
+        "from sim.infra.rig import NodeRig, load_generated_module",
+        "",
+        "",
+        "_enums = load_generated_module(",
+        f'    "{enum_env_var}",',
+        f'    "{enum_target}",',
+        f'    "{symbol_prefix}_generated_enums",',
+        ")",
+        "AnalogInput = _enums.AnalogInput",
+        "DigitalIo = _enums.DigitalIo",
+        "DigitalOutput = _enums.DigitalOutput",
+        "Fault = _enums.Fault",
+        "",
+        "",
+        f"class {class_name}(NodeRig):",
+        f'    buck_target = "{buck_target}"',
+        f'    env_var = "{env_var}"',
+        f'    symbol_prefix = "{symbol_prefix}"',
+        "",
+    ]
+
+    if getters:
+        lines.insert(2, "import ctypes")
+        lines.insert(3, "")
+
+    for suffix, _ret in getters:
+        prop = property_name(suffix)
+        lines += [
+            "    @property",
+            f"    def {prop}(self):",
+            f"        return self._{suffix}()",
+            "",
+        ]
+
+    lines += [
+        "    def _configure_abi(self) -> None:",
+        "        super()._configure_abi()",
+    ]
+    if getters:
+        for suffix, ret in getters:
+            lines += [
+                f"        self._{suffix} = self._bind_model_symbol(",
+                f'            "{suffix}",',
+                f"            restype={RUST_TO_CTYPES[ret]},",
+                "        )",
+            ]
+    else:
+        lines += ["        pass"]
+
+    lines += [
+        "",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rust-source", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--class-name", required=True)
+    parser.add_argument("--symbol-prefix", required=True)
+    parser.add_argument("--buck-target", required=True)
+    parser.add_argument("--env-var", required=True)
+    parser.add_argument("--enum-env-var", required=True)
+    parser.add_argument("--enum-target", required=True)
+    args = parser.parse_args()
+
+    args.out.write_text(
+        emit_model(
+            class_name=args.class_name,
+            symbol_prefix=args.symbol_prefix,
+            buck_target=args.buck_target,
+            env_var=args.env_var,
+            enum_env_var=args.enum_env_var,
+            enum_target=args.enum_target,
+            getters=parse_model_getters(args.rust_source, args.symbol_prefix),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/infra/rig/model.py
+++ b/sim/infra/rig/model.py
@@ -30,7 +30,9 @@ class ModelRig:
             else duration_to_ns(scheduler_period, unit=scheduler_unit)
         )
         if self._scheduler_period_ns is not None and self._scheduler_period_ns <= 0:
-            raise ValueError(f"scheduler period must be positive, got {scheduler_period}")
+            raise ValueError(
+                f"scheduler period must be positive, got {scheduler_period}"
+            )
 
     def reset(self) -> None:
         self.elapsed_ns = 0
@@ -76,7 +78,9 @@ class ModelRig:
 
     def set_online(self, online: bool) -> None:
         if self._cluster_rig is None or self._cluster_node_name is None:
-            raise RuntimeError(f"{type(self).__name__} is not attached to a cluster rig")
+            raise RuntimeError(
+                f"{type(self).__name__} is not attached to a cluster rig"
+            )
         self._cluster_rig.set_node_online(self._cluster_node_name, online)
 
     def is_online(self) -> bool:
@@ -87,7 +91,6 @@ class ModelRig:
 
 class ComponentRig(ModelRig):
     """Pure Python model that can run standalone or inside a cluster."""
-
 
 
 def extend_model_class(
@@ -107,4 +110,3 @@ def extend_model_class(
         },
     )
     return extended  # type: ignore[return-value]
-

--- a/sim/infra/rig/model.py
+++ b/sim/infra/rig/model.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+from .datapath import DataPath, ModelDataPaths
+from .time import duration_to_ns
+
+
+ModelClass = TypeVar("ModelClass", bound=type)
+
+
+class ModelRig:
+    """Schedulable model with datapaths that can participate in a cluster."""
+
+    has_can = False
+
+    def __init__(
+        self,
+        *,
+        scheduler_period: int | float | None = None,
+        scheduler_unit: str = "ms",
+    ) -> None:
+        self.datapaths = ModelDataPaths()
+        self._cluster_rig: ClusterRig | None = None
+        self._cluster_node_name: str | None = None
+        self.elapsed_ns = 0
+        self._scheduler_period_ns = (
+            None
+            if scheduler_period is None
+            else duration_to_ns(scheduler_period, unit=scheduler_unit)
+        )
+        if self._scheduler_period_ns is not None and self._scheduler_period_ns <= 0:
+            raise ValueError(f"scheduler period must be positive, got {scheduler_period}")
+
+    def reset(self) -> None:
+        self.elapsed_ns = 0
+
+    def run_for(self, duration: int | float, *, unit: str = "ms") -> None:
+        duration_ns = duration_to_ns(duration, unit=unit)
+        if self._scheduler_period_ns is None:
+            self.elapsed_ns += duration_ns
+            return
+
+        remaining_ns = duration_ns
+        while remaining_ns > 0:
+            step_ns = self.next_scheduler_step(remaining_ns, unit="ns")
+            self.elapsed_ns += step_ns
+            remaining_ns -= step_ns
+            if self.elapsed_ns % self._scheduler_period_ns == 0:
+                self._run_scheduled()
+
+    def next_scheduler_step(self, duration: int | float, *, unit: str = "ms") -> int:
+        duration_ns = duration_to_ns(duration, unit=unit)
+        if self._scheduler_period_ns is None:
+            return duration_ns
+        elapsed_in_period = self.elapsed_ns % self._scheduler_period_ns
+        remaining_period_ns = self._scheduler_period_ns - elapsed_in_period
+        return min(duration_ns, remaining_period_ns)
+
+    def _run_scheduled(self) -> None:
+        pass
+
+    def configure_datapath(self, path: DataPath) -> None:
+        raise ValueError(f"datapath {path!r} is not supported by {type(self).__name__}")
+
+    def configure_model_outputs_for(self, model: object) -> None:
+        datapaths = getattr(model, "datapaths", None)
+        if datapaths is None:
+            return
+        for input_ in datapaths.inputs():
+            if self.supports_datapath(input_.path):
+                self.configure_datapath(input_.path)
+
+    def supports_datapath(self, path: DataPath) -> bool:
+        return bool(self.datapaths.outputs(path))
+
+    def set_online(self, online: bool) -> None:
+        if self._cluster_rig is None or self._cluster_node_name is None:
+            raise RuntimeError(f"{type(self).__name__} is not attached to a cluster rig")
+        self._cluster_rig.set_node_online(self._cluster_node_name, online)
+
+    def is_online(self) -> bool:
+        if self._cluster_rig is None or self._cluster_node_name is None:
+            return True
+        return self._cluster_rig.node_online(self._cluster_node_name)
+
+
+class ComponentRig(ModelRig):
+    """Pure Python model that can run standalone or inside a cluster."""
+
+
+
+def extend_model_class(
+    model_class: ModelClass,
+    *mixins: type,
+    name: str | None = None,
+) -> ModelClass:
+    if not mixins:
+        return model_class
+
+    extended = type(
+        name or model_class.__name__,
+        (*mixins, model_class),
+        {
+            "__module__": model_class.__module__,
+            "__doc__": model_class.__doc__,
+        },
+    )
+    return extended  # type: ignore[return-value]
+

--- a/sim/infra/rig/node.py
+++ b/sim/infra/rig/node.py
@@ -1,0 +1,816 @@
+from __future__ import annotations
+
+import ctypes
+import os
+import pathlib
+from enum import IntEnum
+
+from .artifacts import buck_output, load_shared_library
+from .can import (
+    SIGNAL_KIND_NAMES,
+    CanBusDescriptor,
+    CanEnumNamespace,
+    CanEnumValueDescriptor,
+    CanEvent,
+    CanMessageDescriptor,
+    CanPacket,
+    CanSignalDescriptor,
+    _CanEnumValueDescriptorAbi,
+    _CanMessageDescriptorAbi,
+    _CanSignalDescriptorAbi,
+    python_enum_attr_member,
+    python_enum_class_name,
+    python_enum_member,
+)
+from .can_interface import CanInterface
+from .cluster import ClusterCanComms
+from .datapath import DataPath
+from .model import ModelRig
+from .peripherals import (
+    SpiInterface,
+    SpiPeripheralInterface,
+    SpiTransaction,
+    TimerCaptureEvent,
+    TimerChannelEvent,
+    TimerInterface,
+    TimerPeripheralInterface,
+)
+from .time import duration_to_ns
+
+
+RIG_MODEL_DATAPATH_TIMER_DUTY = 1
+RIG_MODEL_DATAPATH_TIMER_FREQUENCY = 2
+RIG_MODEL_DATAPATH_SPI_TRANSACTION = 3
+
+
+class _ModelDataPathDescriptorAbi(ctypes.Structure):
+    _fields_ = [
+        ("interface", ctypes.c_uint16),
+        ("port", ctypes.c_int32),
+        ("channel", ctypes.c_int32),
+        ("device", ctypes.c_int32),
+    ]
+
+
+class NodeRig(ModelRig):
+    """ctypes-backed fixture for a Buck-built simulated node."""
+
+    has_can = True
+    buck_target: str
+    env_var: str
+    symbol_prefix: str
+    timer = TimerInterface()
+    spi = SpiInterface()
+
+    def __init__(self, library_path: str | pathlib.Path | None = None) -> None:
+        super().__init__()
+        self._root = pathlib.Path(__file__).resolve().parents[3]
+        self.library_path = self._resolve_library_path(library_path)
+        self._lib = load_shared_library(self.library_path)
+        self._can_metadata: dict[str, tuple[object, ...]] | None = None
+        self.can = CanInterface(self) if self.has_can else None
+        self._timer_peripherals = TimerPeripheralInterface(self)
+        self._spi_peripherals = SpiPeripheralInterface(self)
+        self._configure_model_abi()
+        self._configure_abi()
+        self.reset()
+        self._configure_datapaths()
+
+    def reset(self) -> None:
+        super().reset()
+        self._new()
+
+    def run_for(self, duration: int | float, *, unit: str = "ms") -> None:
+        duration_ns = duration_to_ns(duration, unit=unit)
+        self.elapsed_ns += duration_ns
+        self._run_for(ctypes.c_uint64(duration_ns))
+
+    def next_scheduler_step(self, duration: int | float, *, unit: str = "ms") -> int:
+        duration_ns = duration_to_ns(duration, unit=unit)
+        return int(self._next_scheduler_step(ctypes.c_uint64(duration_ns)))
+
+    def set_analog_input(self, channel: int, voltage: float) -> None:
+        self._set_analog_input(ctypes.c_int(channel), ctypes.c_float(voltage))
+
+    def get_analog_input(self, channel: int) -> float:
+        return float(self._get_analog_input(ctypes.c_int(channel)))
+
+    def set_digital_io(self, channel: int, state: bool) -> None:
+        self._set_digital_io(ctypes.c_int(channel), ctypes.c_bool(state))
+
+    def get_digital_io(self, channel: int) -> bool:
+        return bool(self._get_digital_io(ctypes.c_int(channel)))
+
+    def get_fault(self, fault: int) -> bool:
+        return bool(self._get_fault(ctypes.c_int(fault)))
+
+    def _can_bus_count_value(self) -> int:
+        return int(self._can_bus_count())
+
+    @property
+    def _can_buses(self) -> tuple[CanBusDescriptor, ...]:
+        return self._load_can_metadata()["buses"]  # type: ignore[return-value]
+
+    @property
+    def _can_messages(self) -> tuple[CanMessageDescriptor, ...]:
+        return self._load_can_metadata()["messages"]  # type: ignore[return-value]
+
+    @property
+    def _can_tx_messages(self) -> tuple[CanMessageDescriptor, ...]:
+        return self._load_can_metadata()["tx_messages"]  # type: ignore[return-value]
+
+    @property
+    def _can_signals(self) -> tuple[CanSignalDescriptor, ...]:
+        return self._load_can_metadata()["signals"]  # type: ignore[return-value]
+
+    @property
+    def _can_tx_signals(self) -> tuple[CanSignalDescriptor, ...]:
+        return self._load_can_metadata()["tx_signals"]  # type: ignore[return-value]
+
+    @property
+    def _can_enum_values(self) -> tuple[CanEnumValueDescriptor, ...]:
+        return self._load_can_metadata()["enum_values"]  # type: ignore[return-value]
+
+    @property
+    def _can_enums(self) -> CanEnumNamespace:
+        return self._load_can_metadata()["enums"]  # type: ignore[return-value]
+
+    def _can_enum(self, enum_name: str) -> type[IntEnum]:
+        try:
+            return self._can_enums[enum_name]
+        except KeyError as exc:
+            raise KeyError(f"CAN enum {enum_name!r} was not found") from exc
+
+    def _can_signal_enum(self, signal_name: str) -> type[IntEnum]:
+        enum_name = self._signal_enum_names().get(signal_name)
+        if enum_name is None:
+            raise KeyError(f"CAN signal {signal_name!r} does not have generated enum metadata")
+        return self._can_enum(enum_name)
+
+    def _can_bus_descriptor(self, bus: int | str | CanBusDescriptor) -> CanBusDescriptor:
+        index = self._coerce_can_bus(bus)
+        return self._can_buses[index]
+
+    def _can_message_descriptor(
+        self,
+        name: str,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+        tx: bool = False,
+    ) -> CanMessageDescriptor:
+        messages = self._can_tx_messages if tx else self._can_messages
+        bus_index = None if bus is None else self._coerce_can_bus(bus)
+        for message in messages:
+            if message.name == name and (bus_index is None or message.bus == bus_index):
+                return message
+        direction = "TX" if tx else "RX"
+        bus_text = "" if bus is None else f" on bus {bus!r}"
+        raise KeyError(f"{direction} CAN message {name!r}{bus_text} was not found")
+
+    def _can_tx_message_descriptor(
+        self,
+        name: str,
+        *,
+        bus: int | str | CanBusDescriptor | None = None,
+    ) -> CanMessageDescriptor:
+        return self._can_message_descriptor(name, bus=bus, tx=True)
+
+    def _can_send_packet(
+        self,
+        bus: int | str | CanBusDescriptor,
+        frame_id: int,
+        payload: bytes | bytearray | list[int] | tuple[int, ...],
+    ) -> bool:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        packet = CanPacket.from_payload(frame_id, payload)
+        return bool(self._can_send(ctypes.c_uint8(bus_index), ctypes.byref(packet)))
+
+    def _can_recv_packet(self, bus: int | str | CanBusDescriptor) -> CanPacket | None:
+        event = self._can_recv_event(bus)
+        return None if event is None else event.packet
+
+    def _can_recv_event(self, bus: int | str | CanBusDescriptor) -> CanEvent | None:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        event = CanEvent()
+        if self._ffi_can_recv_event(ctypes.c_uint8(bus_index), ctypes.byref(event)):
+            return event
+        return None
+
+    def _can_recv_message(self, message: CanMessageDescriptor) -> CanEvent | None:
+        latest = None
+        while self._can_tx_count_value(message.bus):
+            event = self._can_recv_event(message.bus)
+            if event is not None and event.packet.id == message.id:
+                latest = event
+        return latest
+
+    def _can_rx_count_value(self, bus: int | str | CanBusDescriptor) -> int:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        return int(self._can_rx_count(ctypes.c_uint8(bus_index)))
+
+    def _can_tx_count_value(self, bus: int | str | CanBusDescriptor) -> int:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        return int(self._can_tx_count(ctypes.c_uint8(bus_index)))
+
+    def _can_decode_signal_raw(self, bus: int | str | CanBusDescriptor, packet: CanPacket, signal_name: str) -> float:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        value = ctypes.c_double()
+        ok = self._decode_can_signal(
+            ctypes.c_uint8(bus_index),
+            ctypes.byref(packet),
+            signal_name.encode(),
+            ctypes.byref(value),
+        )
+        if not ok:
+            raise ValueError(f"failed to decode CAN signal {signal_name!r} from packet id={packet.id}")
+        return float(value.value)
+
+    def _can_decode_message_raw(
+        self,
+        bus: int | str | CanBusDescriptor,
+        packet: CanPacket,
+        signal_names: list[str] | tuple[str, ...],
+    ) -> dict[str, float]:
+        return {
+            signal_name: self._can_decode_signal_raw(bus, packet, signal_name)
+            for signal_name in signal_names
+        }
+
+    def _can_encode_signal_raw(
+        self,
+        bus: int | str | CanBusDescriptor,
+        message_name: str,
+        signal_name: str,
+        value: float,
+    ) -> CanPacket:
+        packet = CanPacket()
+        self._encode_can_signal_into(bus, message_name, signal_name, value, packet)
+        return packet
+
+    def _can_encode_message_raw(self, bus: int | str | CanBusDescriptor, message_name: str, **signals: float) -> CanPacket:
+        packet = CanPacket()
+        for signal_name, value in signals.items():
+            self._encode_can_signal_into(bus, message_name, signal_name, value, packet)
+        return packet
+
+    def _encode_can_signal_into(
+        self,
+        bus: int | str | CanBusDescriptor,
+        message_name: str,
+        signal_name: str,
+        value: float,
+        packet: CanPacket,
+    ) -> None:
+        bus_index = self._coerce_can_bus(bus)
+        self._require_can_bus(bus_index)
+        ok = self._encode_can_signal(
+            ctypes.c_uint8(bus_index),
+            message_name.encode(),
+            signal_name.encode(),
+            ctypes.c_double(value),
+            ctypes.byref(packet),
+        )
+        if not ok:
+            raise ValueError(f"failed to encode CAN signal {signal_name!r} for {message_name!r}")
+
+    def _configure_abi(self) -> None:
+        if self.has_can:
+            self._bind_can_codec()
+            self._bind_can_codegen()
+
+    def _configure_datapaths(self) -> None:
+        for path in self._model_datapaths():
+            self.configure_datapath(path)
+
+        if self.has_can:
+            for bus in self.can.buses:
+                path = ClusterCanComms.path(bus)
+                self.datapaths.add_output(
+                    path,
+                    pending=lambda bus=bus: self.can.tx_count(bus),
+                    recv=lambda bus=bus: self.can.recv(bus),
+                )
+                self.datapaths.add_input(
+                    path,
+                    send=lambda event, bus=bus: self.can.send(
+                        bus,
+                        event.packet.id,
+                        event.packet.payload,
+                    ),
+                )
+
+    def configure_datapath(self, path: DataPath) -> None:
+        if self.datapaths.outputs(path) or self.datapaths.inputs(path):
+            return
+        peripheral = self._peripheral_model(path)
+        self.datapaths.add_output(
+            path,
+            pending=lambda path=path, peripheral=peripheral: peripheral.output_count(path),
+            recv=lambda path=path, peripheral=peripheral: peripheral.recv(path),
+        )
+        self.datapaths.add_input(
+            path,
+            send=lambda event, path=path, peripheral=peripheral: peripheral.send_payload(path, event),
+        )
+
+    def supports_datapath(self, path: DataPath) -> bool:
+        return self._peripheral_model_or_none(path) is not None
+
+    def _peripheral_model(self, path: DataPath):
+        peripheral = self._peripheral_model_or_none(path)
+        if peripheral is not None:
+            return peripheral
+        raise ValueError(f"datapath {path!r} is not backed by a known controller peripheral")
+
+    def _peripheral_model_or_none(self, path: DataPath):
+        try:
+            if self._timer_peripherals.supports(path):
+                return self._timer_peripherals
+            if self._spi_peripherals.supports(path):
+                return self._spi_peripherals
+        except ValueError:
+            return None
+        return None
+
+    def _model_datapaths(self) -> tuple[DataPath, ...]:
+        paths = []
+        for index in range(int(self._datapath_count())):
+            descriptor = _ModelDataPathDescriptorAbi()
+            if not self._datapath_descriptor(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+                continue
+            paths.append(self._datapath_from_descriptor(descriptor))
+        return tuple(paths)
+
+    def _datapath_from_descriptor(self, descriptor: _ModelDataPathDescriptorAbi) -> DataPath:
+        if descriptor.interface == RIG_MODEL_DATAPATH_TIMER_DUTY:
+            return self.timer.duty_events(descriptor.port, descriptor.channel)
+        if descriptor.interface == RIG_MODEL_DATAPATH_TIMER_FREQUENCY:
+            return self.timer.frequency_events(descriptor.port, descriptor.channel)
+        if descriptor.interface == RIG_MODEL_DATAPATH_SPI_TRANSACTION:
+            return self.spi.transactions(descriptor.device)
+        raise ValueError(f"unsupported Rust model datapath interface {descriptor.interface}")
+
+    def _library_from_env(self) -> pathlib.Path | None:
+        library_path = os.environ.get(self.env_var)
+        return pathlib.Path(library_path) if library_path else None
+
+    def _build_library(self) -> pathlib.Path:
+        return buck_output(self.buck_target, self._root)
+
+    def _resolve_library_path(self, library_path: str | pathlib.Path | None) -> pathlib.Path:
+        path = pathlib.Path(library_path) if library_path else self._library_from_env()
+        if path is None:
+            path = self._build_library()
+        return path.resolve()
+
+    def _configure_model_abi(self) -> None:
+        self._new = self._bind_symbol("rig_model_new")
+        self._run_for = self._bind_symbol("rig_model_run_for", [ctypes.c_uint64])
+        self._next_scheduler_step = self._bind_symbol(
+            "rig_model_next_scheduler_step",
+            [ctypes.c_uint64],
+            ctypes.c_uint64,
+        )
+        self._datapath_count = self._bind_symbol(
+            "rig_model_datapath_count",
+            restype=ctypes.c_uint32,
+        )
+        self._datapath_descriptor = self._bind_symbol(
+            "rig_model_datapath_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_ModelDataPathDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._set_analog_input = self._bind_symbol(
+            "rig_model_set_analog_input",
+            [ctypes.c_int, ctypes.c_float],
+        )
+        self._get_analog_input = self._bind_symbol(
+            "rig_model_get_analog_input",
+            [ctypes.c_int],
+            ctypes.c_float,
+        )
+        self._set_digital_io = self._bind_symbol(
+            "rig_model_set_digital_io",
+            [ctypes.c_int, ctypes.c_bool],
+        )
+        self._get_digital_io = self._bind_symbol(
+            "rig_model_get_digital_io",
+            [ctypes.c_int],
+            ctypes.c_bool,
+        )
+        self._get_fault = self._bind_symbol(
+            "rig_model_get_fault",
+            [ctypes.c_int],
+            ctypes.c_bool,
+        )
+        self._can_bus_count = self._bind_symbol(
+            "rig_model_can_bus_count",
+            restype=ctypes.c_uint8,
+        )
+        self._can_send = self._bind_symbol(
+            "rig_model_can_send",
+            [ctypes.c_uint8, ctypes.POINTER(CanPacket)],
+            ctypes.c_bool,
+        )
+        self._can_recv = self._bind_symbol(
+            "rig_model_can_recv",
+            [ctypes.c_uint8, ctypes.POINTER(CanPacket)],
+            ctypes.c_bool,
+        )
+        self._ffi_can_recv_event = self._bind_symbol(
+            "rig_model_can_recv_event",
+            [ctypes.c_uint8, ctypes.POINTER(CanEvent)],
+            ctypes.c_bool,
+        )
+        self._can_rx_count = self._bind_symbol(
+            "rig_model_can_rx_count",
+            [ctypes.c_uint8],
+            ctypes.c_uint32,
+        )
+        self._can_tx_count = self._bind_symbol(
+            "rig_model_can_tx_count",
+            [ctypes.c_uint8],
+            ctypes.c_uint32,
+        )
+        self._timer_send_duty = self._bind_symbol(
+            "rig_model_timer_send_duty",
+            [ctypes.POINTER(TimerChannelEvent)],
+            ctypes.c_bool,
+        )
+        self._timer_recv_duty = self._bind_symbol(
+            "rig_model_timer_recv_duty",
+            [ctypes.c_int, ctypes.c_int, ctypes.POINTER(TimerChannelEvent)],
+            ctypes.c_bool,
+        )
+        self._timer_duty_output_count = self._bind_symbol(
+            "rig_model_timer_duty_output_count",
+            [ctypes.c_int, ctypes.c_int],
+            ctypes.c_uint32,
+        )
+        self._timer_send_frequency = self._bind_symbol(
+            "rig_model_timer_send_frequency",
+            [ctypes.POINTER(TimerChannelEvent)],
+            ctypes.c_bool,
+        )
+        self._timer_recv_frequency = self._bind_symbol(
+            "rig_model_timer_recv_frequency",
+            [ctypes.c_int, ctypes.c_int, ctypes.POINTER(TimerChannelEvent)],
+            ctypes.c_bool,
+        )
+        self._timer_frequency_output_count = self._bind_symbol(
+            "rig_model_timer_frequency_output_count",
+            [ctypes.c_int, ctypes.c_int],
+            ctypes.c_uint32,
+        )
+        self._timer_send_capture = self._bind_symbol(
+            "rig_model_timer_send_capture",
+            [ctypes.POINTER(TimerCaptureEvent)],
+            ctypes.c_bool,
+        )
+        self._spi_send = self._bind_symbol(
+            "rig_model_spi_send",
+            [ctypes.POINTER(SpiTransaction)],
+            ctypes.c_bool,
+        )
+        self._spi_recv = self._bind_symbol(
+            "rig_model_spi_recv",
+            [ctypes.c_int, ctypes.POINTER(SpiTransaction)],
+            ctypes.c_bool,
+        )
+        self._spi_output_count = self._bind_symbol(
+            "rig_model_spi_output_count",
+            [ctypes.c_int],
+            ctypes.c_uint32,
+        )
+
+    def _require_can_bus(self, bus: int) -> None:
+        bus_count = self._can_bus_count_value()
+        if bus < 0 or bus >= bus_count:
+            raise ValueError(f"CAN bus {bus} out of range for model with {bus_count} buses")
+
+    def _coerce_can_bus(self, bus: int | str | CanBusDescriptor) -> int:
+        if isinstance(bus, CanBusDescriptor):
+            return bus.index
+        if isinstance(bus, str):
+            for descriptor in self._can_buses:
+                if descriptor.name.lower() == bus.lower():
+                    return descriptor.index
+            raise ValueError(f"CAN bus {bus!r} was not found")
+        return int(bus)
+
+    def _bind_model_symbol(
+        self,
+        suffix: str,
+        argtypes: list[object] | None = None,
+        restype: object | None = None,
+    ):
+        return self._bind_symbol(f"{self.symbol_prefix}_{suffix}", argtypes, restype)
+
+    def _bind_symbol(
+        self,
+        name: str,
+        argtypes: list[object] | None = None,
+        restype: object | None = None,
+    ):
+        symbol = getattr(self._lib, name)
+        symbol.argtypes = [] if argtypes is None else argtypes
+        symbol.restype = restype
+        return symbol
+
+    def _bind_can_codec(self) -> None:
+        decode_name = "rig_model_can_decode_signal"
+        encode_name = "rig_model_can_encode_signal"
+        self._decode_can_signal = self._bind_symbol(
+            decode_name,
+            [
+                ctypes.c_uint8,
+                ctypes.POINTER(CanPacket),
+                ctypes.c_char_p,
+                ctypes.POINTER(ctypes.c_double),
+            ],
+            ctypes.c_bool,
+        )
+        self._encode_can_signal = self._bind_symbol(
+            encode_name,
+            [
+                ctypes.c_uint8,
+                ctypes.c_char_p,
+                ctypes.c_char_p,
+                ctypes.c_double,
+                ctypes.POINTER(CanPacket),
+            ],
+            ctypes.c_bool,
+        )
+
+    def _bind_can_codegen(self) -> None:
+        prefix = "rig_model_can_codegen_"
+        self._can_codegen_bus_count = self._bind_symbol(prefix + "bus_count", restype=ctypes.c_uint8)
+        self._can_codegen_bus_name = self._bind_symbol(
+            prefix + "bus_name",
+            [ctypes.c_uint8, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_message_count = self._bind_symbol(prefix + "message_count", restype=ctypes.c_uint32)
+        self._can_codegen_message_descriptor = self._bind_symbol(
+            prefix + "message_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_CanMessageDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._can_codegen_message_name = self._bind_symbol(
+            prefix + "message_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_message_count = self._bind_symbol(prefix + "tx_message_count", restype=ctypes.c_uint32)
+        self._can_codegen_tx_message_descriptor = self._bind_symbol(
+            prefix + "tx_message_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_CanMessageDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_message_name = self._bind_symbol(
+            prefix + "tx_message_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_signal_count = self._bind_symbol(prefix + "signal_count", restype=ctypes.c_uint32)
+        self._can_codegen_signal_descriptor = self._bind_symbol(
+            prefix + "signal_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_CanSignalDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._can_codegen_signal_message_name = self._bind_symbol(
+            prefix + "signal_message_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_signal_name = self._bind_symbol(
+            prefix + "signal_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_signal_unit = self._bind_symbol(
+            prefix + "signal_unit",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_signal_enum_name = self._bind_symbol(
+            prefix + "signal_enum_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_signal_count = self._bind_symbol(prefix + "tx_signal_count", restype=ctypes.c_uint32)
+        self._can_codegen_tx_signal_descriptor = self._bind_symbol(
+            prefix + "tx_signal_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_CanSignalDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_signal_message_name = self._bind_symbol(
+            prefix + "tx_signal_message_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_signal_name = self._bind_symbol(
+            prefix + "tx_signal_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_signal_unit = self._bind_symbol(
+            prefix + "tx_signal_unit",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_tx_signal_enum_name = self._bind_symbol(
+            prefix + "tx_signal_enum_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_enum_value_count = self._bind_symbol(prefix + "enum_value_count", restype=ctypes.c_uint32)
+        self._can_codegen_enum_value_descriptor = self._bind_symbol(
+            prefix + "enum_value_descriptor",
+            [ctypes.c_uint32, ctypes.POINTER(_CanEnumValueDescriptorAbi)],
+            ctypes.c_bool,
+        )
+        self._can_codegen_enum_value_enum_name = self._bind_symbol(
+            prefix + "enum_value_enum_name",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+        self._can_codegen_enum_value_label = self._bind_symbol(
+            prefix + "enum_value_label",
+            [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
+            ctypes.c_bool,
+        )
+
+    def _load_can_metadata(self) -> dict[str, tuple[object, ...]]:
+        if self._can_metadata is not None:
+            return self._can_metadata
+
+        buses = tuple(
+            CanBusDescriptor(index, self._read_codegen_string(self._can_codegen_bus_name, index))
+            for index in range(int(self._can_codegen_bus_count()))
+        )
+        metadata = {
+            "buses": buses,
+            "messages": self._read_can_messages(
+                self._can_codegen_message_count,
+                self._can_codegen_message_descriptor,
+                self._can_codegen_message_name,
+                buses,
+            ),
+            "tx_messages": self._read_can_messages(
+                self._can_codegen_tx_message_count,
+                self._can_codegen_tx_message_descriptor,
+                self._can_codegen_tx_message_name,
+                buses,
+            ),
+            "signals": self._read_can_signals(
+                self._can_codegen_signal_count,
+                self._can_codegen_signal_descriptor,
+                self._can_codegen_signal_message_name,
+                self._can_codegen_signal_name,
+                self._can_codegen_signal_unit,
+                self._can_codegen_signal_enum_name,
+                buses,
+            ),
+            "tx_signals": self._read_can_signals(
+                self._can_codegen_tx_signal_count,
+                self._can_codegen_tx_signal_descriptor,
+                self._can_codegen_tx_signal_message_name,
+                self._can_codegen_tx_signal_name,
+                self._can_codegen_tx_signal_unit,
+                self._can_codegen_tx_signal_enum_name,
+                buses,
+            ),
+        }
+        enum_values = self._read_can_enum_values()
+        metadata["enum_values"] = enum_values
+        metadata["enums"] = self._build_can_enums(enum_values)
+        self._can_metadata = metadata
+        return metadata
+
+    def _read_can_messages(
+        self,
+        count_fn,
+        descriptor_fn,
+        name_fn,
+        buses: tuple[CanBusDescriptor, ...],
+    ) -> tuple[CanMessageDescriptor, ...]:
+        messages = []
+        for index in range(int(count_fn())):
+            descriptor = _CanMessageDescriptorAbi()
+            if not descriptor_fn(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+                raise RuntimeError(f"failed to read CAN message descriptor {index}")
+            messages.append(
+                CanMessageDescriptor(
+                    bus=int(descriptor.bus),
+                    bus_name=buses[int(descriptor.bus)].name,
+                    name=self._read_codegen_string(name_fn, index),
+                    id=int(descriptor.id),
+                    len=int(descriptor.len),
+                )
+            )
+        return tuple(messages)
+
+    def _read_can_signals(
+        self,
+        count_fn,
+        descriptor_fn,
+        message_name_fn,
+        signal_name_fn,
+        unit_fn,
+        enum_name_fn,
+        buses: tuple[CanBusDescriptor, ...],
+    ) -> tuple[CanSignalDescriptor, ...]:
+        signals = []
+        for index in range(int(count_fn())):
+            descriptor = _CanSignalDescriptorAbi()
+            if not descriptor_fn(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+                raise RuntimeError(f"failed to read CAN signal descriptor {index}")
+            unit = self._read_codegen_string(unit_fn, index)
+            enum_name = self._read_codegen_string(enum_name_fn, index)
+            signals.append(
+                CanSignalDescriptor(
+                    bus=int(descriptor.bus),
+                    bus_name=buses[int(descriptor.bus)].name,
+                    message_name=self._read_codegen_string(message_name_fn, index),
+                    message_id=int(descriptor.message_id),
+                    signal_name=self._read_codegen_string(signal_name_fn, index),
+                    unit=unit or None,
+                    kind=SIGNAL_KIND_NAMES.get(int(descriptor.kind), f"Unknown({int(descriptor.kind)})"),
+                    enum_name=enum_name or None,
+                )
+            )
+        return tuple(signals)
+
+    def _read_can_enum_values(self) -> tuple[CanEnumValueDescriptor, ...]:
+        enum_values = []
+        for index in range(int(self._can_codegen_enum_value_count())):
+            descriptor = _CanEnumValueDescriptorAbi()
+            if not self._can_codegen_enum_value_descriptor(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+                raise RuntimeError(f"failed to read CAN enum value descriptor {index}")
+            enum_values.append(
+                CanEnumValueDescriptor(
+                    enum_name=self._read_codegen_string(self._can_codegen_enum_value_enum_name, index),
+                    label=self._read_codegen_string(self._can_codegen_enum_value_label, index),
+                    raw=int(descriptor.raw),
+                )
+            )
+        return tuple(enum_values)
+
+    def _build_can_enums(
+        self,
+        enum_values: tuple[CanEnumValueDescriptor, ...],
+    ) -> CanEnumNamespace:
+        values_by_enum: dict[str, dict[str, int]] = {}
+        for enum_value in enum_values:
+            members = values_by_enum.setdefault(enum_value.enum_name, {})
+            members[python_enum_member(enum_value.label)] = enum_value.raw
+            members[python_enum_attr_member(enum_value.label)] = enum_value.raw
+        return CanEnumNamespace({
+            enum_name: IntEnum(python_enum_class_name(enum_name), values)
+            for enum_name, values in values_by_enum.items()
+        })
+
+    def _signal_enum_names(self) -> dict[str, str]:
+        names: dict[str, str] = {}
+        for signal in self._can_signals + self._can_tx_signals:
+            if signal.enum_name:
+                names[signal.signal_name] = signal.enum_name
+        return names
+
+    def _signals_for_message(self, message: CanMessageDescriptor) -> tuple[str, ...]:
+        signals = tuple(
+            signal.signal_name
+            for signal in self._can_tx_signals + self._can_signals
+            if signal.bus == message.bus
+            and signal.message_id == message.id
+            and signal.message_name == message.name
+        )
+        if not signals:
+            raise KeyError(f"CAN message {message.name!r} has no generated signal metadata")
+        return signals
+
+    def _coerce_decoded_can_value(self, signal_name: str, value: float) -> object:
+        enum_name = self._signal_enum_names().get(signal_name)
+        if enum_name:
+            enum_type = self._can_enum(enum_name)
+            return enum_type(int(value))
+        return bool(value) if self._signal_kind(signal_name) == "Boolean" else value
+
+    def _signal_kind(self, signal_name: str) -> str | None:
+        for signal in self._can_signals + self._can_tx_signals:
+            if signal.signal_name == signal_name:
+                return signal.kind
+        return None
+
+    def _read_codegen_string(self, symbol, index: int) -> str:
+        for size in (256, 1024, 4096):
+            buffer = ctypes.create_string_buffer(size)
+            if symbol(index, buffer, ctypes.c_size_t(size)):
+                return buffer.value.decode()
+        raise RuntimeError(f"failed to read generated CAN string {index}")

--- a/sim/infra/rig/node.py
+++ b/sim/infra/rig/node.py
@@ -144,10 +144,14 @@ class NodeRig(ModelRig):
     def _can_signal_enum(self, signal_name: str) -> type[IntEnum]:
         enum_name = self._signal_enum_names().get(signal_name)
         if enum_name is None:
-            raise KeyError(f"CAN signal {signal_name!r} does not have generated enum metadata")
+            raise KeyError(
+                f"CAN signal {signal_name!r} does not have generated enum metadata"
+            )
         return self._can_enum(enum_name)
 
-    def _can_bus_descriptor(self, bus: int | str | CanBusDescriptor) -> CanBusDescriptor:
+    def _can_bus_descriptor(
+        self, bus: int | str | CanBusDescriptor
+    ) -> CanBusDescriptor:
         index = self._coerce_can_bus(bus)
         return self._can_buses[index]
 
@@ -216,7 +220,9 @@ class NodeRig(ModelRig):
         self._require_can_bus(bus_index)
         return int(self._can_tx_count(ctypes.c_uint8(bus_index)))
 
-    def _can_decode_signal_raw(self, bus: int | str | CanBusDescriptor, packet: CanPacket, signal_name: str) -> float:
+    def _can_decode_signal_raw(
+        self, bus: int | str | CanBusDescriptor, packet: CanPacket, signal_name: str
+    ) -> float:
         bus_index = self._coerce_can_bus(bus)
         self._require_can_bus(bus_index)
         value = ctypes.c_double()
@@ -227,7 +233,9 @@ class NodeRig(ModelRig):
             ctypes.byref(value),
         )
         if not ok:
-            raise ValueError(f"failed to decode CAN signal {signal_name!r} from packet id={packet.id}")
+            raise ValueError(
+                f"failed to decode CAN signal {signal_name!r} from packet id={packet.id}"
+            )
         return float(value.value)
 
     def _can_decode_message_raw(
@@ -252,7 +260,9 @@ class NodeRig(ModelRig):
         self._encode_can_signal_into(bus, message_name, signal_name, value, packet)
         return packet
 
-    def _can_encode_message_raw(self, bus: int | str | CanBusDescriptor, message_name: str, **signals: float) -> CanPacket:
+    def _can_encode_message_raw(
+        self, bus: int | str | CanBusDescriptor, message_name: str, **signals: float
+    ) -> CanPacket:
         packet = CanPacket()
         for signal_name, value in signals.items():
             self._encode_can_signal_into(bus, message_name, signal_name, value, packet)
@@ -276,7 +286,9 @@ class NodeRig(ModelRig):
             ctypes.byref(packet),
         )
         if not ok:
-            raise ValueError(f"failed to encode CAN signal {signal_name!r} for {message_name!r}")
+            raise ValueError(
+                f"failed to encode CAN signal {signal_name!r} for {message_name!r}"
+            )
 
     def _configure_abi(self) -> None:
         if self.has_can:
@@ -310,12 +322,16 @@ class NodeRig(ModelRig):
         peripheral = self._peripheral_model(path)
         self.datapaths.add_output(
             path,
-            pending=lambda path=path, peripheral=peripheral: peripheral.output_count(path),
+            pending=lambda path=path, peripheral=peripheral: peripheral.output_count(
+                path
+            ),
             recv=lambda path=path, peripheral=peripheral: peripheral.recv(path),
         )
         self.datapaths.add_input(
             path,
-            send=lambda event, path=path, peripheral=peripheral: peripheral.send_payload(path, event),
+            send=lambda event,
+            path=path,
+            peripheral=peripheral: peripheral.send_payload(path, event),
         )
 
     def supports_datapath(self, path: DataPath) -> bool:
@@ -325,7 +341,9 @@ class NodeRig(ModelRig):
         peripheral = self._peripheral_model_or_none(path)
         if peripheral is not None:
             return peripheral
-        raise ValueError(f"datapath {path!r} is not backed by a known controller peripheral")
+        raise ValueError(
+            f"datapath {path!r} is not backed by a known controller peripheral"
+        )
 
     def _peripheral_model_or_none(self, path: DataPath):
         try:
@@ -341,19 +359,25 @@ class NodeRig(ModelRig):
         paths = []
         for index in range(int(self._datapath_count())):
             descriptor = _ModelDataPathDescriptorAbi()
-            if not self._datapath_descriptor(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+            if not self._datapath_descriptor(
+                ctypes.c_uint32(index), ctypes.byref(descriptor)
+            ):
                 continue
             paths.append(self._datapath_from_descriptor(descriptor))
         return tuple(paths)
 
-    def _datapath_from_descriptor(self, descriptor: _ModelDataPathDescriptorAbi) -> DataPath:
+    def _datapath_from_descriptor(
+        self, descriptor: _ModelDataPathDescriptorAbi
+    ) -> DataPath:
         if descriptor.interface == RIG_MODEL_DATAPATH_TIMER_DUTY:
             return self.timer.duty_events(descriptor.port, descriptor.channel)
         if descriptor.interface == RIG_MODEL_DATAPATH_TIMER_FREQUENCY:
             return self.timer.frequency_events(descriptor.port, descriptor.channel)
         if descriptor.interface == RIG_MODEL_DATAPATH_SPI_TRANSACTION:
             return self.spi.transactions(descriptor.device)
-        raise ValueError(f"unsupported Rust model datapath interface {descriptor.interface}")
+        raise ValueError(
+            f"unsupported Rust model datapath interface {descriptor.interface}"
+        )
 
     def _library_from_env(self) -> pathlib.Path | None:
         library_path = os.environ.get(self.env_var)
@@ -362,7 +386,9 @@ class NodeRig(ModelRig):
     def _build_library(self) -> pathlib.Path:
         return buck_output(self.buck_target, self._root)
 
-    def _resolve_library_path(self, library_path: str | pathlib.Path | None) -> pathlib.Path:
+    def _resolve_library_path(
+        self, library_path: str | pathlib.Path | None
+    ) -> pathlib.Path:
         path = pathlib.Path(library_path) if library_path else self._library_from_env()
         if path is None:
             path = self._build_library()
@@ -491,7 +517,9 @@ class NodeRig(ModelRig):
     def _require_can_bus(self, bus: int) -> None:
         bus_count = self._can_bus_count_value()
         if bus < 0 or bus >= bus_count:
-            raise ValueError(f"CAN bus {bus} out of range for model with {bus_count} buses")
+            raise ValueError(
+                f"CAN bus {bus} out of range for model with {bus_count} buses"
+            )
 
     def _coerce_can_bus(self, bus: int | str | CanBusDescriptor) -> int:
         if isinstance(bus, CanBusDescriptor):
@@ -549,13 +577,17 @@ class NodeRig(ModelRig):
 
     def _bind_can_codegen(self) -> None:
         prefix = "rig_model_can_codegen_"
-        self._can_codegen_bus_count = self._bind_symbol(prefix + "bus_count", restype=ctypes.c_uint8)
+        self._can_codegen_bus_count = self._bind_symbol(
+            prefix + "bus_count", restype=ctypes.c_uint8
+        )
         self._can_codegen_bus_name = self._bind_symbol(
             prefix + "bus_name",
             [ctypes.c_uint8, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
             ctypes.c_bool,
         )
-        self._can_codegen_message_count = self._bind_symbol(prefix + "message_count", restype=ctypes.c_uint32)
+        self._can_codegen_message_count = self._bind_symbol(
+            prefix + "message_count", restype=ctypes.c_uint32
+        )
         self._can_codegen_message_descriptor = self._bind_symbol(
             prefix + "message_descriptor",
             [ctypes.c_uint32, ctypes.POINTER(_CanMessageDescriptorAbi)],
@@ -566,7 +598,9 @@ class NodeRig(ModelRig):
             [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
             ctypes.c_bool,
         )
-        self._can_codegen_tx_message_count = self._bind_symbol(prefix + "tx_message_count", restype=ctypes.c_uint32)
+        self._can_codegen_tx_message_count = self._bind_symbol(
+            prefix + "tx_message_count", restype=ctypes.c_uint32
+        )
         self._can_codegen_tx_message_descriptor = self._bind_symbol(
             prefix + "tx_message_descriptor",
             [ctypes.c_uint32, ctypes.POINTER(_CanMessageDescriptorAbi)],
@@ -577,7 +611,9 @@ class NodeRig(ModelRig):
             [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
             ctypes.c_bool,
         )
-        self._can_codegen_signal_count = self._bind_symbol(prefix + "signal_count", restype=ctypes.c_uint32)
+        self._can_codegen_signal_count = self._bind_symbol(
+            prefix + "signal_count", restype=ctypes.c_uint32
+        )
         self._can_codegen_signal_descriptor = self._bind_symbol(
             prefix + "signal_descriptor",
             [ctypes.c_uint32, ctypes.POINTER(_CanSignalDescriptorAbi)],
@@ -603,7 +639,9 @@ class NodeRig(ModelRig):
             [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
             ctypes.c_bool,
         )
-        self._can_codegen_tx_signal_count = self._bind_symbol(prefix + "tx_signal_count", restype=ctypes.c_uint32)
+        self._can_codegen_tx_signal_count = self._bind_symbol(
+            prefix + "tx_signal_count", restype=ctypes.c_uint32
+        )
         self._can_codegen_tx_signal_descriptor = self._bind_symbol(
             prefix + "tx_signal_descriptor",
             [ctypes.c_uint32, ctypes.POINTER(_CanSignalDescriptorAbi)],
@@ -629,7 +667,9 @@ class NodeRig(ModelRig):
             [ctypes.c_uint32, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t],
             ctypes.c_bool,
         )
-        self._can_codegen_enum_value_count = self._bind_symbol(prefix + "enum_value_count", restype=ctypes.c_uint32)
+        self._can_codegen_enum_value_count = self._bind_symbol(
+            prefix + "enum_value_count", restype=ctypes.c_uint32
+        )
         self._can_codegen_enum_value_descriptor = self._bind_symbol(
             prefix + "enum_value_descriptor",
             [ctypes.c_uint32, ctypes.POINTER(_CanEnumValueDescriptorAbi)],
@@ -651,7 +691,9 @@ class NodeRig(ModelRig):
             return self._can_metadata
 
         buses = tuple(
-            CanBusDescriptor(index, self._read_codegen_string(self._can_codegen_bus_name, index))
+            CanBusDescriptor(
+                index, self._read_codegen_string(self._can_codegen_bus_name, index)
+            )
             for index in range(int(self._can_codegen_bus_count()))
         )
         metadata = {
@@ -741,7 +783,9 @@ class NodeRig(ModelRig):
                     message_id=int(descriptor.message_id),
                     signal_name=self._read_codegen_string(signal_name_fn, index),
                     unit=unit or None,
-                    kind=SIGNAL_KIND_NAMES.get(int(descriptor.kind), f"Unknown({int(descriptor.kind)})"),
+                    kind=SIGNAL_KIND_NAMES.get(
+                        int(descriptor.kind), f"Unknown({int(descriptor.kind)})"
+                    ),
                     enum_name=enum_name or None,
                 )
             )
@@ -751,12 +795,18 @@ class NodeRig(ModelRig):
         enum_values = []
         for index in range(int(self._can_codegen_enum_value_count())):
             descriptor = _CanEnumValueDescriptorAbi()
-            if not self._can_codegen_enum_value_descriptor(ctypes.c_uint32(index), ctypes.byref(descriptor)):
+            if not self._can_codegen_enum_value_descriptor(
+                ctypes.c_uint32(index), ctypes.byref(descriptor)
+            ):
                 raise RuntimeError(f"failed to read CAN enum value descriptor {index}")
             enum_values.append(
                 CanEnumValueDescriptor(
-                    enum_name=self._read_codegen_string(self._can_codegen_enum_value_enum_name, index),
-                    label=self._read_codegen_string(self._can_codegen_enum_value_label, index),
+                    enum_name=self._read_codegen_string(
+                        self._can_codegen_enum_value_enum_name, index
+                    ),
+                    label=self._read_codegen_string(
+                        self._can_codegen_enum_value_label, index
+                    ),
                     raw=int(descriptor.raw),
                 )
             )
@@ -771,10 +821,12 @@ class NodeRig(ModelRig):
             members = values_by_enum.setdefault(enum_value.enum_name, {})
             members[python_enum_member(enum_value.label)] = enum_value.raw
             members[python_enum_attr_member(enum_value.label)] = enum_value.raw
-        return CanEnumNamespace({
-            enum_name: IntEnum(python_enum_class_name(enum_name), values)
-            for enum_name, values in values_by_enum.items()
-        })
+        return CanEnumNamespace(
+            {
+                enum_name: IntEnum(python_enum_class_name(enum_name), values)
+                for enum_name, values in values_by_enum.items()
+            }
+        )
 
     def _signal_enum_names(self) -> dict[str, str]:
         names: dict[str, str] = {}
@@ -792,7 +844,9 @@ class NodeRig(ModelRig):
             and signal.message_name == message.name
         )
         if not signals:
-            raise KeyError(f"CAN message {message.name!r} has no generated signal metadata")
+            raise KeyError(
+                f"CAN message {message.name!r} has no generated signal metadata"
+            )
         return signals
 
     def _coerce_decoded_can_value(self, signal_name: str, value: float) -> object:

--- a/sim/infra/rig/peripherals.py
+++ b/sim/infra/rig/peripherals.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import ctypes
+from enum import IntEnum
+
+from .datapath import DataPath, PeripheralBinding
+
+
+class TimerChannelEvent(ctypes.Structure):
+    _fields_ = [
+        ("port", ctypes.c_int32),
+        ("channel", ctypes.c_int32),
+        ("value", ctypes.c_float),
+        ("timestamp_ns", ctypes.c_uint64),
+    ]
+
+
+class TimerCaptureEvent(ctypes.Structure):
+    _fields_ = [
+        ("channel", ctypes.c_int32),
+        ("value", ctypes.c_float),
+        ("timestamp_ns", ctypes.c_uint64),
+    ]
+
+
+class SpiTransaction(ctypes.Structure):
+    MAX_BYTES = 256
+    _fields_ = [
+        ("device", ctypes.c_int32),
+        ("tx_len", ctypes.c_uint16),
+        ("rx_len", ctypes.c_uint16),
+        ("tx_data", ctypes.c_uint8 * MAX_BYTES),
+        ("rx_data", ctypes.c_uint8 * MAX_BYTES),
+        ("timestamp_ns", ctypes.c_uint64),
+    ]
+
+    @classmethod
+    def from_payload(
+        cls,
+        device: int,
+        *,
+        tx_payload: bytes | bytearray | list[int] | tuple[int, ...] = (),
+        rx_payload: bytes | bytearray | list[int] | tuple[int, ...] = (),
+        timestamp_ns: int = 0,
+    ) -> SpiTransaction:
+        tx_bytes = bytes(tx_payload)
+        rx_bytes = bytes(rx_payload)
+        if len(tx_bytes) > cls.MAX_BYTES:
+            raise ValueError(f"SPI TX payload must be at most {cls.MAX_BYTES} bytes")
+        if len(rx_bytes) > cls.MAX_BYTES:
+            raise ValueError(f"SPI RX payload must be at most {cls.MAX_BYTES} bytes")
+
+        transaction = cls()
+        transaction.device = int(device)
+        transaction.tx_len = len(tx_bytes)
+        transaction.rx_len = len(rx_bytes)
+        transaction.timestamp_ns = int(timestamp_ns)
+        for index, value in enumerate(tx_bytes):
+            transaction.tx_data[index] = value
+        for index, value in enumerate(rx_bytes):
+            transaction.rx_data[index] = value
+        return transaction
+
+    @property
+    def tx_payload(self) -> bytes:
+        return bytes(self.tx_data[: self.tx_len])
+
+    @property
+    def rx_payload(self) -> bytes:
+        return bytes(self.rx_data[: self.rx_len])
+
+
+
+
+class TimerPeripheralInterface:
+    _TIMER_DUTY = "timer.duty"
+    _TIMER_FREQUENCY = "timer.frequency"
+
+    def __init__(self, model: NodeRig) -> None:
+        self._model = model
+
+    @classmethod
+    def timer_duty_events(cls, port: object, channel: object) -> DataPath:
+        return cls._timer_events(cls._TIMER_DUTY, "timer", "duty", port, channel)
+
+    @classmethod
+    def timer_frequency_events(cls, port: object, channel: object) -> DataPath:
+        return cls._timer_events(cls._TIMER_FREQUENCY, "timer", "frequency", port, channel)
+
+    @classmethod
+    def _timer_events(
+        cls,
+        interface: str,
+        peripheral: object,
+        event: object,
+        port: object,
+        channel: object,
+    ) -> DataPath:
+        return DataPath.peripheral(
+            peripheral,
+            event,
+            port,
+            channel,
+            binding=PeripheralBinding(
+                interface,
+                channel=int(channel),
+                port=int(port),
+            ),
+        )
+
+    @classmethod
+    def supports(cls, path: DataPath) -> bool:
+        binding = _peripheral_binding(path)
+        return binding.interface in (cls._TIMER_DUTY, cls._TIMER_FREQUENCY)
+
+    def send(
+        self,
+        path: DataPath,
+        *,
+        channel: int = 0,
+        value: float = 0.0,
+        timestamp_ns: int = 0,
+    ) -> bool:
+        binding = _peripheral_binding(path)
+        event = TimerChannelEvent()
+        event.port = int(binding.port if binding.port is not None else 0)
+        event.channel = int(binding.channel if binding.channel is not None else channel)
+        event.value = float(value)
+        event.timestamp_ns = int(timestamp_ns)
+        return self._send_event(binding, event)
+
+    def send_payload(self, path: DataPath, payload: object) -> bool:
+        if not isinstance(payload, TimerChannelEvent):
+            raise TypeError(f"timer datapaths require TimerChannelEvent payloads, got {type(payload).__name__}")
+        return self._send_event(_peripheral_binding(path), payload)
+
+    def recv(
+        self,
+        path: DataPath,
+    ) -> TimerChannelEvent | None:
+        binding = _peripheral_binding(path)
+        event = TimerChannelEvent()
+        recv = self._recv_symbol(binding)
+        if recv(
+            ctypes.c_int(binding.port if binding.port is not None else 0),
+            ctypes.c_int(binding.channel if binding.channel is not None else 0),
+            ctypes.byref(event),
+        ):
+            return event
+        return None
+
+    def output_count(
+        self,
+        path: DataPath,
+    ) -> int:
+        binding = _peripheral_binding(path)
+        count = self._count_symbol(binding)
+        return int(count(
+            ctypes.c_int(binding.port if binding.port is not None else 0),
+            ctypes.c_int(binding.channel if binding.channel is not None else 0),
+        ))
+
+    def _send_event(self, binding: PeripheralBinding, event: TimerChannelEvent) -> bool:
+        if binding.interface == self._TIMER_DUTY:
+            return bool(self._model._timer_send_duty(ctypes.byref(event)))
+        if binding.interface == self._TIMER_FREQUENCY:
+            return bool(self._model._timer_send_frequency(ctypes.byref(event)))
+        raise ValueError(f"unsupported timer interface {binding.interface!r}")
+
+    def _recv_symbol(self, binding: PeripheralBinding):
+        if binding.interface == self._TIMER_DUTY:
+            return self._model._timer_recv_duty
+        if binding.interface == self._TIMER_FREQUENCY:
+            return self._model._timer_recv_frequency
+        raise ValueError(f"unsupported timer interface {binding.interface!r}")
+
+    def _count_symbol(self, binding: PeripheralBinding):
+        if binding.interface == self._TIMER_DUTY:
+            return self._model._timer_duty_output_count
+        if binding.interface == self._TIMER_FREQUENCY:
+            return self._model._timer_frequency_output_count
+        raise ValueError(f"unsupported timer interface {binding.interface!r}")
+
+
+class SpiPeripheralInterface:
+    _SPI_TRANSACTION = "spi.transaction"
+
+    def __init__(self, model: NodeRig) -> None:
+        self._model = model
+
+    @classmethod
+    def transactions(cls, device: object) -> DataPath:
+        return DataPath.peripheral(
+            "spi",
+            "transactions",
+            device,
+            binding=PeripheralBinding(
+                cls._SPI_TRANSACTION,
+                device=int(device),
+            ),
+        )
+
+    @classmethod
+    def supports(cls, path: DataPath) -> bool:
+        return _peripheral_binding(path).interface == cls._SPI_TRANSACTION
+
+    def send_payload(self, path: DataPath, payload: object) -> bool:
+        _peripheral_binding(path)
+        if not isinstance(payload, SpiTransaction):
+            raise TypeError(f"SPI datapaths require SpiTransaction payloads, got {type(payload).__name__}")
+        return bool(self._model._spi_send(ctypes.byref(payload)))
+
+    def recv(self, path: DataPath) -> SpiTransaction | None:
+        binding = _peripheral_binding(path)
+        transaction = SpiTransaction()
+        if self._model._spi_recv(
+            ctypes.c_int(binding.device if binding.device is not None else 0),
+            ctypes.byref(transaction),
+        ):
+            return transaction
+        return None
+
+    def output_count(self, path: DataPath) -> int:
+        binding = _peripheral_binding(path)
+        return int(self._model._spi_output_count(
+            ctypes.c_int(binding.device if binding.device is not None else 0),
+        ))
+
+
+def _peripheral_binding(path: DataPath) -> PeripheralBinding:
+    if path.peripheral_binding is None:
+        raise ValueError(f"datapath {path!r} is not backed by a controller peripheral")
+    return path.peripheral_binding
+
+
+class TimerInterface:
+    def __init__(
+        self,
+        port_enum: type[IntEnum] | None = None,
+        channel_enum: type[IntEnum] | None = None,
+    ) -> None:
+        self._port_enum = port_enum
+        self._channel_enum = channel_enum
+
+    def duty_events(self, port: object, channel: object) -> DataPath:
+        port, channel = self._coerce(port, channel)
+        return TimerPeripheralInterface.timer_duty_events(port, channel)
+
+    def frequency_events(self, port: object, channel: object) -> DataPath:
+        port, channel = self._coerce(port, channel)
+        return TimerPeripheralInterface.timer_frequency_events(port, channel)
+
+    def _coerce(self, port: object, channel: object) -> tuple[IntEnum | int, IntEnum | int]:
+        return (
+            self._coerce_enum(self._port_enum, port, "timer port"),
+            self._coerce_enum(self._channel_enum, channel, "timer channel"),
+        )
+
+    @staticmethod
+    def _coerce_enum(enum_type: type[IntEnum] | None, value: object, label: str) -> IntEnum | int:
+        if enum_type is None:
+            return int(value)  # type: ignore[arg-type]
+        if isinstance(value, enum_type):
+            return value
+        try:
+            return enum_type(value)
+        except ValueError as exc:
+            raise ValueError(f"{value!r} is not a valid {label} for {enum_type.__name__}") from exc
+
+
+class SpiInterface:
+    def __init__(self, device_enum: type[IntEnum] | None = None) -> None:
+        self._device_enum = device_enum
+
+    def transactions(self, device: object) -> DataPath:
+        device = self._coerce_device(device)
+        return SpiPeripheralInterface.transactions(device)
+
+    def _coerce_device(self, device: object) -> IntEnum | int:
+        if self._device_enum is None:
+            return int(device)  # type: ignore[arg-type]
+        if isinstance(device, self._device_enum):
+            return device
+        try:
+            return self._device_enum(device)
+        except ValueError as exc:
+            raise ValueError(f"{device!r} is not a valid SPI device for {self._device_enum.__name__}") from exc
+

--- a/sim/infra/rig/peripherals.py
+++ b/sim/infra/rig/peripherals.py
@@ -70,8 +70,6 @@ class SpiTransaction(ctypes.Structure):
         return bytes(self.rx_data[: self.rx_len])
 
 
-
-
 class TimerPeripheralInterface:
     _TIMER_DUTY = "timer.duty"
     _TIMER_FREQUENCY = "timer.frequency"
@@ -85,7 +83,9 @@ class TimerPeripheralInterface:
 
     @classmethod
     def timer_frequency_events(cls, port: object, channel: object) -> DataPath:
-        return cls._timer_events(cls._TIMER_FREQUENCY, "timer", "frequency", port, channel)
+        return cls._timer_events(
+            cls._TIMER_FREQUENCY, "timer", "frequency", port, channel
+        )
 
     @classmethod
     def _timer_events(
@@ -131,7 +131,9 @@ class TimerPeripheralInterface:
 
     def send_payload(self, path: DataPath, payload: object) -> bool:
         if not isinstance(payload, TimerChannelEvent):
-            raise TypeError(f"timer datapaths require TimerChannelEvent payloads, got {type(payload).__name__}")
+            raise TypeError(
+                f"timer datapaths require TimerChannelEvent payloads, got {type(payload).__name__}"
+            )
         return self._send_event(_peripheral_binding(path), payload)
 
     def recv(
@@ -155,10 +157,12 @@ class TimerPeripheralInterface:
     ) -> int:
         binding = _peripheral_binding(path)
         count = self._count_symbol(binding)
-        return int(count(
-            ctypes.c_int(binding.port if binding.port is not None else 0),
-            ctypes.c_int(binding.channel if binding.channel is not None else 0),
-        ))
+        return int(
+            count(
+                ctypes.c_int(binding.port if binding.port is not None else 0),
+                ctypes.c_int(binding.channel if binding.channel is not None else 0),
+            )
+        )
 
     def _send_event(self, binding: PeripheralBinding, event: TimerChannelEvent) -> bool:
         if binding.interface == self._TIMER_DUTY:
@@ -207,7 +211,9 @@ class SpiPeripheralInterface:
     def send_payload(self, path: DataPath, payload: object) -> bool:
         _peripheral_binding(path)
         if not isinstance(payload, SpiTransaction):
-            raise TypeError(f"SPI datapaths require SpiTransaction payloads, got {type(payload).__name__}")
+            raise TypeError(
+                f"SPI datapaths require SpiTransaction payloads, got {type(payload).__name__}"
+            )
         return bool(self._model._spi_send(ctypes.byref(payload)))
 
     def recv(self, path: DataPath) -> SpiTransaction | None:
@@ -222,9 +228,11 @@ class SpiPeripheralInterface:
 
     def output_count(self, path: DataPath) -> int:
         binding = _peripheral_binding(path)
-        return int(self._model._spi_output_count(
-            ctypes.c_int(binding.device if binding.device is not None else 0),
-        ))
+        return int(
+            self._model._spi_output_count(
+                ctypes.c_int(binding.device if binding.device is not None else 0),
+            )
+        )
 
 
 def _peripheral_binding(path: DataPath) -> PeripheralBinding:
@@ -250,14 +258,18 @@ class TimerInterface:
         port, channel = self._coerce(port, channel)
         return TimerPeripheralInterface.timer_frequency_events(port, channel)
 
-    def _coerce(self, port: object, channel: object) -> tuple[IntEnum | int, IntEnum | int]:
+    def _coerce(
+        self, port: object, channel: object
+    ) -> tuple[IntEnum | int, IntEnum | int]:
         return (
             self._coerce_enum(self._port_enum, port, "timer port"),
             self._coerce_enum(self._channel_enum, channel, "timer channel"),
         )
 
     @staticmethod
-    def _coerce_enum(enum_type: type[IntEnum] | None, value: object, label: str) -> IntEnum | int:
+    def _coerce_enum(
+        enum_type: type[IntEnum] | None, value: object, label: str
+    ) -> IntEnum | int:
         if enum_type is None:
             return int(value)  # type: ignore[arg-type]
         if isinstance(value, enum_type):
@@ -265,7 +277,9 @@ class TimerInterface:
         try:
             return enum_type(value)
         except ValueError as exc:
-            raise ValueError(f"{value!r} is not a valid {label} for {enum_type.__name__}") from exc
+            raise ValueError(
+                f"{value!r} is not a valid {label} for {enum_type.__name__}"
+            ) from exc
 
 
 class SpiInterface:
@@ -284,5 +298,6 @@ class SpiInterface:
         try:
             return self._device_enum(device)
         except ValueError as exc:
-            raise ValueError(f"{device!r} is not a valid SPI device for {self._device_enum.__name__}") from exc
-
+            raise ValueError(
+                f"{device!r} is not a valid SPI device for {self._device_enum.__name__}"
+            ) from exc

--- a/sim/infra/rig/pytest.py
+++ b/sim/infra/rig/pytest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from .catalog import ClusterCatalog
+from .cluster import ClusterRig
+
+
+def cluster_rig_fixture(catalog: ClusterCatalog):
+    cases = catalog.pytest_cases()
+
+    @pytest.fixture(
+        params=cases,
+        ids=lambda cluster: cluster.name,
+    )
+    def fixture(request) -> ClusterRig:
+        rig = request.param.rig()
+        yield rig
+        rig.reset()
+
+    return fixture

--- a/sim/infra/rig/time.py
+++ b/sim/infra/rig/time.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+
+class RunUntilTimeout(AssertionError):
+    pass
+
+
+def duration_to_ns(duration: int | float, *, unit: str = "ms") -> int:
+    scale_by_unit = {
+        "ns": 1,
+        "us": 1_000,
+        "ms": 1_000_000,
+        "s": 1_000_000_000,
+    }
+    if duration < 0:
+        raise ValueError(f"duration must be non-negative, got {duration}")
+    try:
+        scale = scale_by_unit[unit]
+    except KeyError as exc:
+        raise ValueError(
+            f"time unit {unit!r} was not found; expected one of {', '.join(scale_by_unit)}"
+        ) from exc
+    return int(duration * scale)
+
+
+def run_until(
+    run_for,
+    predicate,
+    *,
+    timeout_ns: int,
+    step_ns: int = 1_000_000,
+    message: str | None = None,
+) -> int:
+    if timeout_ns < 0:
+        raise ValueError(f"timeout must be non-negative, got {timeout_ns} ns")
+    if step_ns <= 0:
+        raise ValueError(f"step must be positive, got {step_ns} ns")
+
+    elapsed_ns = 0
+    if predicate():
+        return elapsed_ns
+
+    while elapsed_ns < timeout_ns:
+        delta_ns = min(step_ns, timeout_ns - elapsed_ns)
+        run_for(delta_ns)
+        elapsed_ns += delta_ns
+        if predicate():
+            return elapsed_ns
+
+    detail = "" if message is None else f": {message}"
+    raise RunUntilTimeout(
+        f"condition did not become true within {timeout_ns} ns{detail}"
+    )

--- a/sim/models/BUCK
+++ b/sim/models/BUCK
@@ -1,0 +1,10 @@
+load("//sim/infra:defs.bzl", "rig_model_python")
+
+rig_model_python(
+    srcs = [
+        "platforms.py",
+        "//sim/models/components:python",
+        "//sim/models/components/dc_load:python",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/BUCK
+++ b/sim/models/controllers/BUCK
@@ -1,0 +1,10 @@
+load("//sim/infra:defs.bzl", "rig_model_python")
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "fixtures.py",
+        "variants.py",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/__init__.py
+++ b/sim/models/controllers/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/sim/models/controllers/fixtures.py
+++ b/sim/models/controllers/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import CONTROLLER_CLUSTERS
+
+controller_cluster = cluster_rig_fixture(CONTROLLER_CLUSTERS)

--- a/sim/models/controllers/variants.py
+++ b/sim/models/controllers/variants.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog
+from sim.models.controllers.vcfront.variants import VCFRONT_CLUSTERS
+from sim.models.controllers.vcpdu.variants import VCPDU_CLUSTERS
+from sim.models.controllers.vcrear.variants import VCREAR_CLUSTERS
+
+CONTROLLER_CLUSTERS = ClusterCatalog(
+    *(VCFRONT_CLUSTERS.clusters + VCPDU_CLUSTERS.clusters + VCREAR_CLUSTERS.clusters),
+)

--- a/sim/models/controllers/vcfront/BUCK
+++ b/sim/models/controllers/vcfront/BUCK
@@ -1,0 +1,176 @@
+load("//components/vc/front:platforms.bzl", "VCFRONT_PLATFORM_VARIANTS")
+load("//sim/infra:defs.bzl", "rig_bindgen", "rig_embedded_rust_model", "rig_embedded_rust_model_platform_aliases", "rig_feature_consts", "rig_model_c_support", "rig_model_python", "rig_platforms_from_variants", "rig_python_enums", "rig_python_model", "rig_runtime_srcs")
+
+VCFRONT_SIM_PLATFORMS = rig_platforms_from_variants(VCFRONT_PLATFORM_VARIANTS)
+
+rig_python_model(
+    name = "vcfront-py",
+    out = "vcfront.py",
+    rust_source = ":rust-wrapper-src",
+    class_name = "VcfrontModel",
+    symbol_prefix = "vcfront_sim",
+    buck_target = "//sim/models/controllers/vcfront:sil-so",
+    env_var = "VCFRONT_SIM_LIB",
+    enum_env_var = "VCFRONT_ENUMS_PY",
+    enum_target = "//sim/models/controllers/vcfront:enums-py",
+    visibility = ["PUBLIC"],
+)
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "extensions.py",
+        "fixtures.py",
+        "variants.py",
+        ":vcfront-py",
+        ":enums-py",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_model_c_support(
+    srcs = rig_runtime_srcs(["core", "faults", "io", "peripherals", "time"]) + [
+    ],
+    headers = {
+        "runtime_state.h": "//sim/infra/runtime:c/src/runtime_state.h",
+    },
+    deps = [
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/front:sil-features",
+        "//components/vc/front:sil-host-headers",
+        "//components/vc/front:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+)
+
+rig_feature_consts(
+    name = "features-rs",
+    out = "features.rs",
+    deps = [
+        "//components/vc/front:sil-features",
+    ],
+    allowlist_vars = [
+        "APP_COMPONENT_ID",
+        "APP_VARIANT_ID",
+        "NVM_BLOCK_SIZE",
+        "NVM_FLASH_BACKED",
+        "NVM_LIB_ENABLED",
+    ],
+)
+
+rig_bindgen(
+    name = "bindings-rs",
+    out = "bindings.rs",
+    include_headers = [
+        "Module.h",
+        "HW_gpio_componentSpecific.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD.h",
+        "drv_outputAD_componentSpecific.h",
+        "YamcanShared.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/front:sil-features",
+        "//components/vc/front:sil-host-headers",
+        "//components/vc/front:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    allowlist_types = [
+        "drv_inputAD_channelAnalog_E",
+        "drv_outputAD_channelDigital_E",
+        "HW_GPIO_pinmux_E",
+        "CAN_data_T",
+        "YamcanShared",
+    ],
+    allowlist_functions = [
+        "Module_Init",
+        "Module_1kHz_TSK",
+        "Module_100Hz_TSK",
+        "Module_10Hz_TSK",
+        "Module_1Hz_TSK",
+        "drv_outputAD_toggleDigitalState",
+        "YAMCAN_shared_init_static",
+    ],
+    allowlist_vars = [
+        "g_yamcan",
+    ],
+    bindgen_flags = [
+        "--no-layout-tests",
+        "--default-enum-style rust",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+    ],
+)
+
+rig_python_enums(
+    name = "enums-py",
+    out = "enums.py",
+    include_headers = [
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD_componentSpecific.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/front:sil-features",
+        "//components/vc/front:sil-host-headers",
+        "//components/vc/front:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    c_enums = [
+        "drv_inputAD_channelAnalog_E:AnalogInput:DRV_INPUTAD_ANALOG_::upper",
+        "HW_GPIO_pinmux_E:DigitalIo:HW_GPIO_::upper",
+        "drv_outputAD_channelDigital_E:DigitalOutput:DRV_OUTPUTAD_DIGITAL_::upper",
+        "HW_TIM_port_E:TimerPort:HW_TIM_PORT_::upper",
+        "HW_TIM_channel_E:TimerChannel:HW_TIM_CHANNEL_::upper",
+    ],
+    rust_sources = [
+        "//components/vc/front:sil-yamcan[rust_faults_generated.rs]",
+    ],
+    rust_enums = [
+        "FmFault:Fault:Vcfront:Fault:camel",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model(
+    name = "sil-so",
+    crate = "vcfront_sim",
+    out = "libvcfront_sim.so",
+    link_deps = [
+        "//components/vc/front:sil-application",
+        ":model-c-support",
+        "//components/vc/front:sil-yamcan-c",
+    ],
+    rust_env = {
+        "VCFRONT_BINDINGS_RS": ":bindings-rs",
+        "VCFRONT_FEATURES_RS": ":features-rs",
+        "VCFRONT_YAMCAN_DECODE_RS": "//components/vc/front:sil-yamcan[rust_decode_generated.rs]",
+        "VCFRONT_YAMCAN_MODEL_RS": "//components/vc/front:sil-yamcan[rust_model_generated.rs]",
+        "VCFRONT_YAMCAN_RS": "//components/vc/front:sil-yamcan[yamcan.rs]",
+    },
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model_platform_aliases(
+    name = "sil-so",
+    actual = ":sil-so",
+    platforms = VCFRONT_SIM_PLATFORMS,
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/vcfront/__init__.py
+++ b/sim/models/controllers/vcfront/__init__.py
@@ -1,0 +1,43 @@
+from sim.infra.rig import TimerInterface, extend_model_class, load_generated_module
+
+from .extensions import VcfrontPytestHelpers
+
+_model = load_generated_module(
+    "VCFRONT_MODEL_PY",
+    "//sim/models/controllers/vcfront:vcfront-py",
+    "vcfront_generated_model",
+)
+_enums = load_generated_module(
+    "VCFRONT_ENUMS_PY",
+    "//sim/models/controllers/vcfront:enums-py",
+    "vcfront_generated_enums",
+)
+
+AnalogInput = _enums.AnalogInput
+DigitalIo = _enums.DigitalIo
+DigitalOutput = _enums.DigitalOutput
+Fault = _enums.Fault
+TimerChannel = _enums.TimerChannel
+TimerPort = _enums.TimerPort
+VcfrontPytestHelpers.AnalogInput = AnalogInput
+
+
+class VcfrontModel(extend_model_class(_model.VcfrontModel, VcfrontPytestHelpers)):
+    timer = TimerInterface(TimerPort, TimerChannel)
+
+
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from .variants import VCFRONT_CLUSTERS
+
+__all__ = [
+    "AnalogInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "Fault",
+    "TimerChannel",
+    "TimerPort",
+    "VCFRONT_CLUSTERS",
+    "VcfrontModel",
+    "PLATFORM_VARIANTS",
+]

--- a/sim/models/controllers/vcfront/extensions.py
+++ b/sim/models/controllers/vcfront/extensions.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+
+class VcfrontPytestHelpers:
+    AnalogInput = None
+    _APPS1_POINTS = (
+        (0, 0.720),
+        (5, 0.802),
+        (10, 0.882),
+        (15, 0.945),
+        (20, 1.007),
+        (25, 1.059),
+        (30, 1.112),
+        (35, 1.163),
+        (40, 1.209),
+        (45, 1.261),
+        (50, 1.309),
+        (55, 1.351),
+        (60, 1.390),
+        (65, 1.429),
+        (70, 1.469),
+        (75, 1.509),
+        (80, 1.543),
+        (85, 1.576),
+        (90, 1.600),
+        (95, 1.620),
+        (100, 1.628),
+    )
+    _APPS2_POINTS = (
+        (0, 1.475),
+        (5, 1.523),
+        (10, 1.555),
+        (15, 1.584),
+        (20, 1.613),
+        (25, 1.640),
+        (30, 1.666),
+        (35, 1.690),
+        (40, 1.716),
+        (45, 1.738),
+        (50, 1.762),
+        (55, 1.786),
+        (60, 1.809),
+        (65, 1.831),
+        (70, 1.853),
+        (75, 1.875),
+        (80, 1.895),
+        (85, 1.914),
+        (90, 1.928),
+        (95, 1.942),
+        (100, 1.950),
+    )
+    _BRAKE_POINTS = (
+        (0, 0.3),
+        (100, 2.7),
+    )
+
+    def set_brake_position(self, position_percent: float) -> None:
+        if self.AnalogInput is None:
+            raise RuntimeError("VcfrontPytestHelpers.AnalogInput was not configured")
+        self.set_analog_input(
+            self.AnalogInput.BR_PR,
+            self._voltage_for_position(position_percent, self._BRAKE_POINTS),
+        )
+
+    def set_accelerator_position(self, position_percent: float) -> None:
+        self.set_apps1_position(position_percent)
+        self.set_apps2_position(position_percent)
+
+    def set_apps1_position(self, position_percent: float) -> None:
+        if self.AnalogInput is None:
+            raise RuntimeError("VcfrontPytestHelpers.AnalogInput was not configured")
+        self.set_analog_input(
+            self.AnalogInput.APPS_P1,
+            self._voltage_for_position(position_percent, self._APPS1_POINTS),
+        )
+
+    def set_apps2_position(self, position_percent: float) -> None:
+        if self.AnalogInput is None:
+            raise RuntimeError("VcfrontPytestHelpers.AnalogInput was not configured")
+        self.set_analog_input(
+            self.AnalogInput.APPS_P2,
+            self._voltage_for_position(position_percent, self._APPS2_POINTS),
+        )
+
+    def _voltage_for_position(
+        self, position_percent: float, points: tuple[tuple[float, float], ...]
+    ) -> float:
+        if position_percent < 0 or position_percent > 100:
+            raise ValueError(
+                f"pedal position percent must be in [0, 100], got {position_percent}"
+            )
+
+        for index, (left_position, left_voltage) in enumerate(points[:-1]):
+            right_position, right_voltage = points[index + 1]
+            if position_percent <= right_position:
+                span = right_position - left_position
+                if span == 0:
+                    return right_voltage
+                ratio = (position_percent - left_position) / span
+                return left_voltage + ((right_voltage - left_voltage) * ratio)
+
+        return points[-1][1]

--- a/sim/models/controllers/vcfront/fixtures.py
+++ b/sim/models/controllers/vcfront/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import VCFRONT_CLUSTERS
+
+vcfront_cluster = cluster_rig_fixture(VCFRONT_CLUSTERS)

--- a/sim/models/controllers/vcfront/src/lib.rs
+++ b/sim/models/controllers/vcfront/src/lib.rs
@@ -1,0 +1,115 @@
+mod rig_runtime {
+    include!(env!("RIG_RUNTIME_RS"));
+}
+
+mod bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCFRONT_BINDINGS_RS"));
+}
+
+mod features {
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCFRONT_FEATURES_RS"));
+}
+
+mod yamcan {
+    include!(env!("VCFRONT_YAMCAN_RS"));
+}
+
+pub use yamcan::SignalMeasurement;
+
+mod rust_model_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCFRONT_YAMCAN_MODEL_RS"));
+}
+
+mod rust_decode_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCFRONT_YAMCAN_DECODE_RS"));
+}
+
+use bindings::drv_inputAD_channelAnalog_E::{
+    DRV_INPUTAD_ANALOG_APPS_P1, DRV_INPUTAD_ANALOG_APPS_P2, DRV_INPUTAD_ANALOG_BR_PR,
+};
+use bindings::drv_outputAD_channelDigital_E::DRV_OUTPUTAD_DIGITAL_LED;
+use rig_runtime::nvm::ControllerNvm;
+use rig_runtime::{AppDesc, ModuleDesc, NodeModel, NodeTarget, RTController};
+use std::sync::Mutex;
+
+const VCFRONT_APP_START: u32 = 0x0800_2000;
+const VCFRONT_APP_END: u32 = 0x0802_0000;
+const VCFRONT_APP_CRC_LOCATION: u32 = 0x0801_FFF0;
+
+rig_rt_controller_nvm_storage!(ControllerNvm<
+    { features::NVM_BLOCK_SIZE as usize },
+    { features::NVM_LIB_ENABLED },
+    { features::NVM_FLASH_BACKED },
+>);
+
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static appDesc: AppDesc = AppDesc::new(
+    VCFRONT_APP_START,
+    VCFRONT_APP_END,
+    VCFRONT_APP_CRC_LOCATION,
+    features::APP_COMPONENT_ID as u16,
+    features::APP_VARIANT_ID as u16,
+);
+
+unsafe extern "C" fn vcfront_sys_1hz() {
+    unsafe { bindings::drv_outputAD_toggleDigitalState(DRV_OUTPUTAD_DIGITAL_LED) };
+}
+
+#[unsafe(no_mangle)]
+pub static sys_desc: ModuleDesc = ModuleDesc::new(None, None, None, None, Some(vcfront_sys_1hz));
+
+struct Vcfront {
+    nvm: ControllerNvm<
+        { features::NVM_BLOCK_SIZE as usize },
+        { features::NVM_LIB_ENABLED },
+        { features::NVM_FLASH_BACKED },
+    >,
+}
+
+impl Vcfront {
+    const fn new() -> Self {
+        Self {
+            nvm: ControllerNvm::<
+                { features::NVM_BLOCK_SIZE as usize },
+                { features::NVM_LIB_ENABLED },
+                { features::NVM_FLASH_BACKED },
+            >::new(),
+        }
+    }
+}
+
+impl NodeTarget for Vcfront {
+    unsafe fn reset_node(&mut self, controller: &mut RTController) {
+        self.nvm.reset();
+        rig_runtime::can::configure_network(VCFRONT_CAN_NETWORK);
+        unsafe { bindings::YAMCAN_shared_init_static() };
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_BR_PR as i32, 0.3);
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_APPS_P1 as i32, 0.720);
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_APPS_P2 as i32, 1.475);
+    }
+}
+
+static VCFRONT: Mutex<NodeModel<Vcfront>> = Mutex::new(NodeModel::new(
+    RTController::new_embedded_module(),
+    Vcfront::new(),
+));
+
+rig_model_abi!(VCFRONT);
+
+rig_yamcan_network!(
+    VCFRONT_CAN_NETWORK,
+    rust_model_generated,
+    rust_decode_generated,
+    yamcan
+);

--- a/sim/models/controllers/vcfront/variants.py
+++ b/sim/models/controllers/vcfront/variants.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec, NodeSpec
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from . import VcfrontModel
+
+
+def vcfront_node(hardware: str | None = None) -> NodeSpec:
+    return NodeSpec("vcfront", VcfrontModel, hardware=hardware)
+
+
+def vcfront_cluster_spec(hardware: str | None = None) -> ClusterSpec:
+    prefix = f"{hardware}-" if hardware is not None else ""
+    return ClusterSpec(
+        name=f"{prefix}vcfront-cluster",
+        hardware=hardware,
+        nodes=(vcfront_node(hardware),),
+    )
+
+
+VCFRONT_CLUSTERS = ClusterCatalog(
+    *(vcfront_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/platforms.py
+++ b/sim/models/platforms.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+
+_PLATFORM_ENV = "SIM_PLATFORM_VARIANTS"
+
+
+def _load_platform_variants() -> tuple[str, ...]:
+    raw = os.environ.get(_PLATFORM_ENV)
+    if raw is None:
+        raise RuntimeError(
+            f"{_PLATFORM_ENV} is not configured; Buck tests must provide the platform catalog"
+        )
+
+    platforms = tuple(
+        platform.strip() for platform in raw.split(",") if platform.strip()
+    )
+    if not platforms:
+        raise RuntimeError(f"{_PLATFORM_ENV} did not declare any platforms")
+    if len(set(platforms)) != len(platforms):
+        raise RuntimeError(f"{_PLATFORM_ENV} contains duplicate platforms: {raw}")
+    return platforms
+
+
+PLATFORM_VARIANTS = _load_platform_variants()

--- a/sim/tests/test_rig_infra.py
+++ b/sim/tests/test_rig_infra.py
@@ -1,0 +1,276 @@
+from sim.infra.rig import (
+    CanBusDescriptor,
+    ClusterCanComms,
+    ClusterRig,
+    ComponentRig,
+    DataPath,
+    ModelRig,
+)
+
+
+class FakeNode(ModelRig):
+    has_can = False
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_count = 0
+        self.reset_count = 0
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+    def run_for(self, duration: int | float, *, unit: str = "ms") -> None:
+        self.run_count += duration
+
+
+class FakeCan:
+    def __init__(self, buses: tuple[CanBusDescriptor, ...]) -> None:
+        self.buses = buses
+
+
+class ScheduledComponent(ComponentRig):
+    def __init__(self) -> None:
+        super().__init__(scheduler_period=250, scheduler_unit="us")
+        self.scheduled_times_ns = []
+
+    def reset(self) -> None:
+        super().reset()
+        self.scheduled_times_ns.clear()
+
+    def _run_scheduled(self) -> None:
+        self.scheduled_times_ns.append(self.elapsed_ns)
+
+
+class TickModel(ModelRig):
+    def __init__(self) -> None:
+        super().__init__(scheduler_period=1)
+        self.ticks = 0
+
+    def reset(self) -> None:
+        super().reset()
+        self.ticks = 0
+
+    def _run_scheduled(self) -> None:
+        self.ticks += 1
+
+
+class BatchObservedModel(TickModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_durations_ns = []
+
+    def run_for(self, duration: int | float, *, unit: str = "ms") -> None:
+        super().run_for(duration, unit=unit)
+        self.run_durations_ns.append(int(duration))
+
+
+class PythonOwner(ModelRig):
+    def __init__(self, path: DataPath) -> None:
+        super().__init__()
+        self.path = path
+        self.pending_payloads = []
+
+    def supports_datapath(self, path: DataPath) -> bool:
+        return path == self.path
+
+    def configure_datapath(self, path: DataPath) -> None:
+        if self.datapaths.outputs(path):
+            return
+        self.datapaths.add_output(
+            path,
+            pending=lambda: len(self.pending_payloads),
+            recv=lambda: self.pending_payloads.pop(0) if self.pending_payloads else None,
+        )
+
+
+class PythonConsumer(ComponentRig):
+    def __init__(self, path: DataPath) -> None:
+        super().__init__()
+        self.received_payloads = []
+        self.datapaths.add_input(
+            path,
+            send=lambda payload: not self.received_payloads.append(payload),
+        )
+
+
+class SharedObjectBackedFakeNode(ModelRig):
+    def __init__(self, library_path) -> None:
+        super().__init__()
+        self.library_path = library_path
+
+
+def test_custom_datapath_routes_between_cluster_nodes():
+    source = FakeNode()
+    sink = FakeNode()
+    same_node_sink = []
+    received_payloads = []
+    pending_payloads = [
+        {"sample": 1, "value": 12.5},
+        {"sample": 2, "value": 37.0},
+    ]
+    debug_path = DataPath(("sensor-debug", "primary"))
+
+    source.datapaths.add_output(
+        debug_path,
+        pending=lambda: len(pending_payloads),
+        recv=lambda: pending_payloads.pop(0) if pending_payloads else None,
+    )
+    source.datapaths.add_input(
+        debug_path,
+        send=lambda payload: not same_node_sink.append(payload),
+    )
+    sink.datapaths.add_input(
+        debug_path,
+        send=lambda payload: not received_payloads.append(payload),
+    )
+
+    cluster = ClusterRig(source=source, sink=sink)
+    cluster.run_for(1)
+
+    assert received_payloads == [
+        {"sample": 1, "value": 12.5},
+        {"sample": 2, "value": 37.0},
+    ]
+    assert same_node_sink == []
+    records = cluster.dataroutes.records(debug_path)
+    assert [record.source for record in records] == ["source", "source"]
+    assert [record.path for record in records] == [debug_path, debug_path]
+    assert [record.timestamp_ns for record in records] == [1_000_000, 1_000_000]
+
+
+def test_custom_datapath_routes_explicitly_between_paths():
+    source = FakeNode()
+    sink = FakeNode()
+    received_payloads = []
+    pending_payloads = ["packet"]
+    ethernet_tx = DataPath(("ethernet", "eth0", "tx"))
+
+    source.datapaths.add_output(
+        ethernet_tx,
+        pending=lambda: len(pending_payloads),
+        recv=lambda: pending_payloads.pop(0) if pending_payloads else None,
+    )
+    cluster = ClusterRig(source=source, sink=sink)
+    sink.datapaths.add_input(
+        ethernet_tx,
+        send=lambda payload: not received_payloads.append(payload),
+    )
+    cluster.dataroutes.connect_available_paths()
+    cluster.run_for(1)
+
+    assert received_payloads == ["packet"]
+
+
+def test_can_node_connections_use_generated_common_bus_names_only():
+    source = FakeNode()
+    sink = FakeNode()
+    veh = CanBusDescriptor(0, "veh")
+    nose = CanBusDescriptor(1, "nose")
+    source.can = FakeCan((veh, nose))
+    sink.can = FakeCan((CanBusDescriptor(0, "veh"),))
+    source_payloads = {
+        veh: ["veh-packet"],
+        nose: ["nose-packet"],
+    }
+    received_payloads = []
+
+    for bus in source.can.buses:
+        source.datapaths.add_output(
+            ClusterCanComms.path(bus),
+            pending=lambda bus=bus: len(source_payloads[bus]),
+            recv=lambda bus=bus: source_payloads[bus].pop(0) if source_payloads[bus] else None,
+        )
+    for bus in sink.can.buses:
+        sink.datapaths.add_input(
+            ClusterCanComms.path(bus),
+            send=lambda payload, bus=bus: not received_payloads.append((bus.name, payload)),
+        )
+
+    cluster = ClusterRig(source=source, sink=sink)
+    cluster.run_for(1)
+
+    assert received_payloads == [("veh", "veh-packet")]
+    assert [record.path for record in cluster.dataroutes.records(ClusterCanComms.path("veh"))] == [ClusterCanComms.path("veh")]
+    assert [record.path for record in cluster.dataroutes.records(ClusterCanComms.path("nose"))] == [ClusterCanComms.path("nose")]
+
+
+def test_component_scheduler_participates_in_cluster_temporal_order():
+    controller = FakeNode()
+    component = ScheduledComponent()
+
+    cluster = ClusterRig(controller=controller, component=component)
+    cluster.run_for(1)
+
+    assert component.scheduled_times_ns == [250_000, 500_000, 750_000, 1_000_000]
+    assert cluster.elapsed_ns == 1_000_000
+
+
+def test_component_scheduler_runs_all_due_periods_when_used_standalone():
+    component = ScheduledComponent()
+
+    component.run_for(1)
+
+    assert component.scheduled_times_ns == [250_000, 500_000, 750_000, 1_000_000]
+    assert component.elapsed_ns == 1_000_000
+
+
+def test_model_rig_set_online_resets_and_gates_scheduler_ticks():
+    model = TickModel()
+    cluster = ClusterRig(model=model)
+
+    assert model.is_online()
+    cluster.run_for(3)
+    assert model.ticks == 3
+
+    model.set_online(False)
+    assert not model.is_online()
+    assert model.ticks == 0
+
+    cluster.run_for(3)
+    assert model.ticks == 0
+
+    model.set_online(True)
+    assert model.is_online()
+    cluster.run_for(2)
+    assert model.ticks == 2
+
+
+def test_single_model_cluster_batches_scheduler_work_into_one_model_run():
+    model = BatchObservedModel()
+    cluster = ClusterRig(model=model)
+
+    cluster.run_for(5)
+
+    assert model.ticks == 5
+    assert model.run_durations_ns == [5_000_000]
+
+
+def test_cluster_rejects_duplicate_rust_backed_shared_object_instances(tmp_path):
+    shared_object = tmp_path / "libcontroller.so"
+    shared_object.touch()
+
+    first = SharedObjectBackedFakeNode(shared_object)
+    second = SharedObjectBackedFakeNode(shared_object)
+
+    try:
+        ClusterRig(first=first, second=second)
+    except ValueError as exc:
+        assert "same Rust-backed controller shared object" in str(exc)
+        assert "first" in str(exc)
+        assert "second" in str(exc)
+    else:
+        raise AssertionError("expected duplicate shared-object controller instances to fail")
+
+
+def test_python_model_owner_configures_outputs_for_component_inputs():
+    path = DataPath(("python", "stream"))
+    owner = PythonOwner(path)
+    component = PythonConsumer(path)
+
+    owner.configure_model_outputs_for(component)
+    owner.pending_payloads.append("payload")
+    cluster = ClusterRig(owner=owner, component=component)
+    cluster.dataroutes.connect_available_paths()
+    cluster.run_for(1)
+
+    assert component.received_payloads == ["payload"]

--- a/sim/tests/test_rig_infra.py
+++ b/sim/tests/test_rig_infra.py
@@ -79,7 +79,9 @@ class PythonOwner(ModelRig):
         self.datapaths.add_output(
             path,
             pending=lambda: len(self.pending_payloads),
-            recv=lambda: self.pending_payloads.pop(0) if self.pending_payloads else None,
+            recv=lambda: self.pending_payloads.pop(0)
+            if self.pending_payloads
+            else None,
         )
 
 
@@ -178,20 +180,30 @@ def test_can_node_connections_use_generated_common_bus_names_only():
         source.datapaths.add_output(
             ClusterCanComms.path(bus),
             pending=lambda bus=bus: len(source_payloads[bus]),
-            recv=lambda bus=bus: source_payloads[bus].pop(0) if source_payloads[bus] else None,
+            recv=lambda bus=bus: source_payloads[bus].pop(0)
+            if source_payloads[bus]
+            else None,
         )
     for bus in sink.can.buses:
         sink.datapaths.add_input(
             ClusterCanComms.path(bus),
-            send=lambda payload, bus=bus: not received_payloads.append((bus.name, payload)),
+            send=lambda payload, bus=bus: not received_payloads.append(
+                (bus.name, payload)
+            ),
         )
 
     cluster = ClusterRig(source=source, sink=sink)
     cluster.run_for(1)
 
     assert received_payloads == [("veh", "veh-packet")]
-    assert [record.path for record in cluster.dataroutes.records(ClusterCanComms.path("veh"))] == [ClusterCanComms.path("veh")]
-    assert [record.path for record in cluster.dataroutes.records(ClusterCanComms.path("nose"))] == [ClusterCanComms.path("nose")]
+    assert [
+        record.path
+        for record in cluster.dataroutes.records(ClusterCanComms.path("veh"))
+    ] == [ClusterCanComms.path("veh")]
+    assert [
+        record.path
+        for record in cluster.dataroutes.records(ClusterCanComms.path("nose"))
+    ] == [ClusterCanComms.path("nose")]
 
 
 def test_component_scheduler_participates_in_cluster_temporal_order():
@@ -259,7 +271,9 @@ def test_cluster_rejects_duplicate_rust_backed_shared_object_instances(tmp_path)
         assert "first" in str(exc)
         assert "second" in str(exc)
     else:
-        raise AssertionError("expected duplicate shared-object controller instances to fail")
+        raise AssertionError(
+            "expected duplicate shared-object controller instances to fail"
+        )
 
 
 def test_python_model_owner_configures_outputs_for_component_inputs():

--- a/sim/tests/test_vcfront.py
+++ b/sim/tests/test_vcfront.py
@@ -1,0 +1,231 @@
+import pytest
+
+from sim.models.controllers.vcfront import (
+    AnalogInput,
+    Fault,
+)
+from sim.models.controllers.vcfront.fixtures import vcfront_cluster
+
+
+@pytest.mark.parametrize(
+    "brake_pressure_voltage",
+    [
+        pytest.param(0.10, id="shorted-brake-pressure-sensor"),
+        pytest.param(3.00, id="open-brake-pressure-sensor"),
+    ],
+)
+def test_brake_pedal_faults(vcfront_cluster, brake_pressure_voltage):
+    vcfront = vcfront_cluster.vcfront
+    message = vcfront.can.tx_message("VCFRONT_pedalPosition", bus="veh")
+    vcfront.set_analog_input(AnalogInput.BR_PR, brake_pressure_voltage)
+    vcfront_cluster.run_for(20)
+
+    faulted = vcfront.get_fault(Fault.BRAKE_SENSOR)
+    assert faulted, (
+        "expected brake sensor fault for "
+        f"brake_pressure_voltage={brake_pressure_voltage:.3f}"
+    )
+    signals = vcfront.can.latest(message)
+    assert (
+        signals is not None
+    ), f"expected CAN TX message {message.name} on {message.bus_name}"
+    assert signals.VCFRONT_brakePosition == 0
+
+
+@pytest.mark.parametrize(
+    "channel,fault,voltage",
+    [
+        pytest.param(
+            AnalogInput.APPS_P1, Fault.APPS1_SENSOR, 0.30, id="shorted-apps1-sensor"
+        ),
+        pytest.param(
+            AnalogInput.APPS_P1, Fault.APPS1_SENSOR, 2.60, id="open-apps1-sensor"
+        ),
+        pytest.param(
+            AnalogInput.APPS_P2, Fault.APPS2_SENSOR, 0.40, id="shorted-apps2-sensor"
+        ),
+        pytest.param(
+            AnalogInput.APPS_P2, Fault.APPS2_SENSOR, 2.60, id="open-apps2-sensor"
+        ),
+    ],
+)
+def test_apps_pedal_faults(vcfront_cluster, channel, fault, voltage):
+    vcfront = vcfront_cluster.vcfront
+    message = vcfront.can.tx_message("VCFRONT_pedalPosition", bus="veh")
+    vcfront.set_analog_input(channel, voltage)
+    vcfront_cluster.run_for(20)
+
+    faulted = vcfront.get_fault(fault)
+    assert faulted, f"expected {fault.name} for {channel.name} voltage={voltage:.3f}"
+    signals = vcfront.can.latest(message)
+    assert (
+        signals is not None
+    ), f"expected CAN TX message {message.name} on {message.bus_name}"
+    assert signals.VCFRONT_acceleratorPosition == 0
+    if channel == AnalogInput.APPS_P1:
+        assert signals.VCFRONT_apps1 == 0
+    else:
+        assert signals.VCFRONT_apps2 == 0
+
+
+@pytest.mark.parametrize(
+    "accelerator_position,brake_position",
+    [
+        pytest.param(0, 0, id="pedals-released"),
+        pytest.param(50, 50, id="pedals-half"),
+        pytest.param(100, 100, id="pedals-full"),
+    ],
+)
+def test_pedal_position_sensors_report_on_can(
+    vcfront_cluster, accelerator_position, brake_position
+):
+    vcfront = vcfront_cluster.vcfront
+    vcfront.set_accelerator_position(accelerator_position)
+    vcfront.set_brake_position(brake_position)
+    vcfront_cluster.run_for(20)
+
+    signals = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert signals is not None
+    assert signals.VCFRONT_apps1 == accelerator_position
+    assert signals.VCFRONT_apps2 == accelerator_position
+    assert signals.VCFRONT_acceleratorPosition == accelerator_position
+    assert signals.VCFRONT_brakePosition == brake_position
+
+
+@pytest.mark.parametrize(
+    "vehicle_state,torque_command_enabled",
+    [
+        pytest.param("INIT", False, id="init"),
+        pytest.param("ON_GLV", False, id="on-glv"),
+        pytest.param("ON_HV", False, id="on-hv"),
+        pytest.param("TS_RUN", True, id="ts-run"),
+        pytest.param("SLEEP", False, id="sleep"),
+    ],
+)
+def test_torque_request_requires_ts_run_but_driver_input_follows_pedal(
+    vcfront_cluster,
+    vehicle_state,
+    torque_command_enabled,
+):
+    vcfront = vcfront_cluster.vcfront
+    VehicleState = vcfront.can.enums.VehicleState
+    state = getattr(VehicleState, vehicle_state)
+    vehicle_state_message = vcfront.can.message("VCPDU_vehicleState", bus="veh")
+
+    vcfront.set_brake_position(0)
+    vcfront.set_accelerator_position(0)
+    vcfront_cluster.run_for(30)
+
+    assert vcfront.can.send(vehicle_state_message, VCPDU_vehicleState=state)
+
+    vcfront.set_accelerator_position(50)
+    vcfront_cluster.run_for(100)
+
+    torque = vcfront.can.latest("VCFRONT_torqueManager", bus="veh")
+    debug = vcfront.can.latest("VCFRONT_tractionControlDebug", bus="veh")
+    assert torque is not None
+    assert debug is not None
+    assert debug.VCFRONT_torqueDriverInput > 0
+
+    if torque_command_enabled:
+        assert torque.VCFRONT_torqueRequest > 0
+    else:
+        assert torque.VCFRONT_torqueRequest == 0
+
+
+@pytest.mark.parametrize(
+    "apps1_position,apps2_position",
+    [
+        pytest.param(80, 0, id="apps1-high-apps2-low"),
+        pytest.param(0, 80, id="apps1-low-apps2-high"),
+    ],
+)
+def test_apps_disagreement_reports_error_and_recovers(
+    vcfront_cluster, apps1_position, apps2_position
+):
+    vcfront = vcfront_cluster.vcfront
+    AppsState = vcfront.can.enums.AppsState
+
+    vcfront.set_accelerator_position(50)
+    vcfront.set_brake_position(0)
+    vcfront_cluster.run_for(60)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 50
+
+    vcfront.set_apps1_position(apps1_position)
+    vcfront.set_apps2_position(apps2_position)
+    vcfront_cluster.run_for(50)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.DISAGREEMENT
+    assert status.VCFRONT_acceleratorPosition == 0
+
+    vcfront.set_accelerator_position(50)
+    vcfront_cluster.run_for(30)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 50
+
+
+def test_bppc_fault_latches_until_accelerator_is_released(vcfront_cluster):
+    vcfront = vcfront_cluster.vcfront
+    AppsState = vcfront.can.enums.AppsState
+    BppcState = vcfront.can.enums.BppcState
+
+    vcfront.set_accelerator_position(0)
+    vcfront.set_brake_position(0)
+    vcfront_cluster.run_for(20)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 0
+    assert status.VCFRONT_bppcState == BppcState.OK
+
+    vcfront.set_accelerator_position(50)
+    vcfront_cluster.run_for(40)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 50
+    assert status.VCFRONT_bppcState == BppcState.OK
+
+    vcfront.set_brake_position(50)
+    vcfront_cluster.run_for(30)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 50
+    assert status.VCFRONT_brakePosition == 50
+    assert status.VCFRONT_bppcState == BppcState.FAULT
+
+    vcfront.set_brake_position(0)
+    vcfront_cluster.run_for(20)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_bppcState == BppcState.FAULT_LATCHED
+
+    vcfront_cluster.run_for(10)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_bppcState == BppcState.ERROR
+    assert status.VCFRONT_acceleratorPosition == 50
+
+    vcfront.set_accelerator_position(0)
+    vcfront_cluster.run_for(30)
+
+    status = vcfront.can.latest("VCFRONT_pedalPosition", bus="veh")
+    assert status is not None
+    assert status.VCFRONT_acceleratorState == AppsState.OK
+    assert status.VCFRONT_acceleratorPosition == 0
+    assert status.VCFRONT_bppcState == BppcState.OK


### PR DESCRIPTION
### Reason for Change

Build the first controller-level simulations around vcfront and vcrear so the rig runtime can exercise real embedded applications through generated CAN/runtime interfaces.

### Changes

1. Add vcfront and vcrear controller model structure.
2. Add Python rig infrastructure and controller-level test coverage for brake, APP, BPPC, torque gating, CAN TX/RX, and brake-light behavior.
3. Apply formatting fixes required by the stack CI.

### Test Plan

- Local: `buckle test sim/tests/...` from the top stack branch
- CI: Formatting
- CI: Build All Firmware, including `sim-tests` once introduced by #650

### Stack

Depends on #646. Follow-ups: #650, #651, #652.
