### PR TITLE
Vehicle Sim

### DIFF
--- a/components/vc/pdu/BUCK
+++ b/components/vc/pdu/BUCK
@@ -5,8 +5,9 @@ load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
 load("//drive-stack/ota-agent/defs.bzl", "ota_agent")
 load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
-load("//tools/yamcan/defs.bzl", "generate_code")
+load("//tools/yamcan/defs.bzl", "generate_c_library", "generate_code", "generate_resources")
 load("//tools/hextools/defs.bzl", "inject_crc")
+load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load(
     "//components/vehicle_platform:defs.bzl",
     "add_platform_deploy_targets",
@@ -15,15 +16,13 @@ load(
     "platform_selected_targets",
 )
 load("//components/vehicle_platform:platforms.bzl", "PLATFORMS", "platform_output_name")
+load("//components/vc/pdu:platforms.bzl", "VCPDU_PLATFORM_VARIANTS")
 
 TOOLCHAIN = "@toolchains//:gcc-14.2.rel1-arm-none-eabi"
 APP_START_ADDR = 0x08002000
 APP_NAME = "vcpdu"
 
-platform_variants = [
-    (PLATFORMS.CFR25, 0),
-    (PLATFORMS.CFR26, 0),
-]
+platform_variants = VCPDU_PLATFORM_VARIANTS
 
 compiler_flags = [
     "-std=c11",
@@ -161,6 +160,140 @@ generate_code(
         "//components/shared/code:headers",
         "//components/shared/code/RTOS:headers",
     ],
+)
+
+generate_resources(
+    name = "sil-yamcan",
+    network_dep = "//network:network",
+    node = APP_NAME,
+    rust_wrapper = True,
+    visibility = ["//sim/models/controllers/vcpdu/..."],
+)
+
+generate_feature_tree(
+    name = "sil-features",
+    variant_id = 0,
+    srcs = {
+        "variants.yaml": "variants.yaml",
+        "STM32F105_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F105_FeatureSels.yaml",
+        "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",
+        "APP_V1_FeatureSels.yaml": "//components/shared:FeatureSels/APP_V1_FeatureSels.yaml",
+        "Application_FeatureDefs.yaml": "//components/shared:FeatureDefs/Application_FeatureDefs.yaml",
+        "SharedApp_FeatureDefs.yaml": "//components/shared/code:SharedApp_FeatureDefs.yaml",
+        "NVM_FeatureDefs.yaml": "//components/shared:FeatureDefs/NVM_FeatureDefs.yaml",
+        "hw_FeatureDefs.yaml": "//components/shared/code:HW/hw_FeatureDefs.yaml",
+        "FeatureDefs.yaml": "FeatureDefs.yaml",
+        "FeatureSels.yaml": "FeatureSels.yaml",
+    },
+    feature_overrides = {
+        "app_variant_id": 0,
+    },
+    visibility = ["//sim/models/controllers/vcpdu/..."],
+    vcpdu_variant_id = "0U",
+)
+
+prebuilt_cxx_library(
+    name = "sil-host-headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = remap_headers(["include/HW/", "include/"]),
+    visibility = ["//sim/models/controllers/vcpdu/..."],
+)
+
+generate_c_library(
+    name = "sil-yamcan-c",
+    codegen_target = ":sil-yamcan",
+    compiler_flags = [
+        "-fshort-enums",
+    ],
+    library_deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "sil-application",
+    srcs = [
+        "//components/shared/code:DRV/drv_asm330.c",
+        "//components/shared/code:DRV/drv_hsd.c",
+        "//components/shared/code:DRV/drv_inputAD.c",
+        "//components/shared/code:DRV/drv_io.c",
+        "//components/shared/code:DRV/drv_mux.c",
+        "//components/shared/code:DRV/drv_outputAD.c",
+        "//components/shared/code:DRV/drv_timer.c",
+        "//components/shared/code:DRV/drv_tps20xx.c",
+        "//components/shared/code:DRV/drv_tps2hb16ab.c",
+        "//components/shared/code:DRV/drv_vn9008.c",
+        "//components/shared/code:app/CAN/CANIO-rx.c",
+        "//components/shared/code:app/CAN/CANIO-tx.c",
+        "//components/shared/code:app/app_faultManager.c",
+        "//components/shared/code:app/app_vehicleSpeed.c",
+        "//components/shared/code:app/app_vehicleState.c",
+        "//components/shared/code:libs/LIB_app.c",
+        "//components/shared/code:libs/Utility.c",
+        "//components/shared/code:libs/lib_interpolation.c",
+        "//components/shared/code:libs/lib_madgwick.c",
+        "//components/shared/code:libs/lib_nvm.c",
+        "//components/shared/code:libs/lib_simpleFilter.c",
+        "//components/shared/code/RTOS:Module.c",
+        "//embedded/libs:isotp-src[isotp.c]",
+        "//embedded/libs/uds:lib_udsServer.c",
+        "//embedded/libs:libcrc.c",
+        "src/CANIO_componentSpecific.c",
+        "src/cooling.c",
+        "src/crashSensor.c",
+        "src/imu.c",
+        "src/lib_nvm_componentSpecific.c",
+        "src/Module_componentSpecific.c",
+        "src/powerManager.c",
+        "src/uds_componentSpecific.c",
+        "src/wheelSpeed_componentSpecific.c",
+        "src/HW/drv_inputAD_componentSpecific.c",
+        "src/HW/drv_outputAD_componentSpecific.c",
+        "src/HW/drv_tps20xx_componentSpecific.c",
+        "src/HW/drv_tps2hb16ab_componentSpecific.c",
+        "src/HW/drv_vn9008_componentSpecific.c",
+    ],
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-Wno-missing-braces",
+        "-fshort-enums",
+    ],
+    header_namespace = "",
+    headers = {
+        "asm330lhb_reg.h": "//embedded/libs:asm330lhb[asm330lhb_reg.h]",
+        "isotp.h": "//embedded/libs:isotp-src[include/isotp.h]",
+        "isotp_config.h": "//embedded/libs:isotp-src[include/isotp_config.h]",
+        "isotp_defines.h": "//embedded/libs:isotp-src[include/isotp_defines.h]",
+        "isotp_user.h": "//embedded/libs:isotp-src[include/isotp_user.h]",
+        "lib_uds.h": "//embedded/libs/uds:lib_uds.h",
+        "libcrc.h": "//embedded/libs:libcrc.h",
+    },
+    deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        ":sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["//sim/models/controllers/vcpdu/..."],
 )
 
 cxx_library(

--- a/components/vc/pdu/platforms.bzl
+++ b/components/vc/pdu/platforms.bzl
@@ -1,0 +1,6 @@
+load("//components/vehicle_platform:platforms.bzl", "PLATFORMS")
+
+VCPDU_PLATFORM_VARIANTS = [
+    (PLATFORMS.CFR25, 0),
+    (PLATFORMS.CFR26, 0),
+]

--- a/components/vc/rear/BUCK
+++ b/components/vc/rear/BUCK
@@ -4,9 +4,10 @@ load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
 load("//drive-stack/defs.bzl", "deployable_target")
 load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
-load("//tools/yamcan/defs.bzl", "generate_code")
+load("//tools/yamcan/defs.bzl", "generate_c_library", "generate_code", "generate_resources")
 load("//tools/hextools/defs.bzl", "inject_crc")
 load("//drive-stack/ota-agent/defs.bzl", "ota_agent")
+load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load(
     "//components/vehicle_platform:defs.bzl",
     "add_platform_deploy_targets",
@@ -15,15 +16,13 @@ load(
     "platform_selected_targets",
 )
 load("//components/vehicle_platform:platforms.bzl", "PLATFORMS", "platform_output_name")
+load("//components/vc/rear:platforms.bzl", "VCREAR_PLATFORM_VARIANTS")
 
 TOOLCHAIN = "@toolchains//:gcc-14.2.rel1-arm-none-eabi"
 APP_START_ADDR = 0x08002000
 APP_NAME = "vcrear"
 
-platform_variants = [
-    (PLATFORMS.CFR25, 0),
-    (PLATFORMS.CFR26, 0),
-]
+platform_variants = VCREAR_PLATFORM_VARIANTS
 
 compiler_flags = [
     "-std=c11",
@@ -149,6 +148,17 @@ prebuilt_cxx_library(
     exported_deps = platform_selected_targets(platform_variants),
 )
 
+prebuilt_cxx_library(
+    name = "sil-host-headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = {
+        "shockpot.h": "//components/vc/shared:app/shockpot.h",
+        "brakeTemp.h": "//components/vc/shared:app/brakeTemp.h",
+    } | remap_headers(["include/HW/", "include/"]),
+    visibility = ["//sim/models/controllers/vcrear/..."],
+)
+
 compiler_flags += ["-include", "BuildDefines.h"]
 
 generate_code(
@@ -165,6 +175,118 @@ generate_code(
         "//components/shared/code/RTOS:headers",
         "//components/vc/shared:headers",
     ],
+)
+
+generate_resources(
+    name = "sil-yamcan",
+    network_dep = "//network:network",
+    node = APP_NAME,
+    rust_wrapper = True,
+    visibility = ["//sim/models/controllers/vcrear/..."],
+)
+
+generate_feature_tree(
+    name = "sil-features",
+    variant_id = 0,
+    srcs = {
+        "variants.yaml": "variants.yaml",
+        "STM32F105_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F105_FeatureSels.yaml",
+        "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",
+        "APP_V1_FeatureSels.yaml": "//components/shared:FeatureSels/APP_V1_FeatureSels.yaml",
+        "Application_FeatureDefs.yaml": "//components/shared:FeatureDefs/Application_FeatureDefs.yaml",
+        "SharedApp_FeatureDefs.yaml": "//components/shared/code:SharedApp_FeatureDefs.yaml",
+        "VC_FeatureSels.yaml": "//components/vc/shared/features:VC_FeatureSels.yaml",
+        "VC_FeatureDefs.yaml": "//components/vc/shared/features:VC_FeatureDefs.yaml",
+        "NVM_FeatureDefs.yaml": "//components/shared:FeatureDefs/NVM_FeatureDefs.yaml",
+        "FeatureDefs.yaml": "FeatureDefs.yaml",
+        "FeatureSels.yaml": "FeatureSels.yaml",
+    },
+    feature_overrides = {
+        "app_variant_id": 0,
+    },
+    visibility = ["//sim/models/controllers/vcrear/..."],
+    vcrear_variant_id = "0U",
+)
+
+generate_c_library(
+    name = "sil-yamcan-c",
+    codegen_target = ":sil-yamcan",
+    library_deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "sil-application",
+    srcs =
+        glob(["src/*.c"], exclude = ["src/SystemManager.c"]) + [
+            "//components/shared/code:DRV/drv_hsd.c",
+            "//components/shared/code:DRV/drv_inputAD.c",
+            "//components/shared/code:DRV/drv_io.c",
+            "//components/shared/code:DRV/drv_mux.c",
+            "//components/shared/code:DRV/drv_outputAD.c",
+            "//components/shared/code:DRV/drv_tempSensors.c",
+            "//components/shared/code:DRV/drv_timer.c",
+            "//components/shared/code:DRV/drv_tps20xx.c",
+            "//components/shared/code:app/CAN/CANIO-rx.c",
+            "//components/shared/code:app/CAN/CANIO-tx.c",
+            "//components/shared/code:app/app_faultManager.c",
+            "//components/shared/code:app/app_vehicleSpeed.c",
+            "//components/shared/code:app/app_vehicleState.c",
+            "//components/shared/code:libs/LIB_app.c",
+            "//components/shared/code:libs/lib_interpolation.c",
+            "//components/shared/code:libs/lib_rateLimit.c",
+            "//components/shared/code:libs/lib_simpleFilter.c",
+            "//components/shared/code:libs/lib_thermistors.c",
+            "//components/shared/code:libs/lib_utility.c",
+            "//components/shared/code/RTOS:Module.c",
+            "src/HW/drv_inputAD_componentSpecific.c",
+            "src/HW/drv_outputAD_componentSpecific.c",
+            "src/HW/drv_tempSensors_componentSpecific.c",
+            "src/HW/drv_tps20xx_componentSpecific.c",
+            "//components/vc/shared:app/brakeTemp.c",
+            "//components/vc/shared:app/shockpot.c",
+            "//embedded/libs:isotp-src[isotp.c]",
+            "//embedded/libs/uds:lib_udsServer.c",
+        ],
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+    ],
+    header_namespace = "",
+    headers = {
+        "lib_atomic.h": "//embedded/libs:lib_atomic.h",
+        "isotp.h": "//embedded/libs:isotp-src[include/isotp.h]",
+        "isotp_config.h": "//embedded/libs:isotp-src[include/isotp_config.h]",
+        "isotp_defines.h": "//embedded/libs:isotp-src[include/isotp_defines.h]",
+        "isotp_user.h": "//embedded/libs:isotp-src[include/isotp_user.h]",
+        "lib_uds.h": "//embedded/libs/uds:lib_uds.h",
+    },
+    deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        ":sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["//sim/models/controllers/vcrear/..."],
 )
 
 cxx_library(

--- a/components/vc/rear/platforms.bzl
+++ b/components/vc/rear/platforms.bzl
@@ -1,0 +1,6 @@
+load("//components/vehicle_platform:platforms.bzl", "PLATFORMS")
+
+VCREAR_PLATFORM_VARIANTS = [
+    (PLATFORMS.CFR25, 0),
+    (PLATFORMS.CFR26, 0),
+]

--- a/sim/models/components/BUCK
+++ b/sim/models/components/BUCK
@@ -1,0 +1,8 @@
+load("//sim/infra:defs.bzl", "rig_model_python")
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/components/__init__.py
+++ b/sim/models/components/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/sim/models/components/dc_load/BUCK
+++ b/sim/models/components/dc_load/BUCK
@@ -1,0 +1,9 @@
+load("//sim/infra:defs.bzl", "rig_model_python")
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "model.py",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/components/dc_load/__init__.py
+++ b/sim/models/components/dc_load/__init__.py
@@ -1,0 +1,6 @@
+from .model import DcLoadModel, DcLoadSpec
+
+__all__ = [
+    "DcLoadModel",
+    "DcLoadSpec",
+]

--- a/sim/models/components/dc_load/model.py
+++ b/sim/models/components/dc_load/model.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from sim.infra.rig import (
+    ComponentDataPathBinding,
+    ComponentDataPathOutput,
+    ComponentSpec,
+    ComponentRig,
+    DataPath,
+    TimerChannelEvent,
+)
+
+
+class DcLoadPort(Enum):
+    CURRENT_OUTPUT = auto()
+
+
+@dataclass(frozen=True)
+class DcLoadSpec:
+    resistance_ohms: float | None = None
+    inductance_henrys: float | None = None
+    capacitance_farads: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.resistance_ohms is not None and self.resistance_ohms <= 0.0:
+            raise ValueError(f"resistance must be positive, got {self.resistance_ohms}")
+        if self.inductance_henrys is not None and self.inductance_henrys <= 0.0:
+            raise ValueError(
+                f"inductance must be positive, got {self.inductance_henrys}"
+            )
+        if self.capacitance_farads is not None and self.capacitance_farads <= 0.0:
+            raise ValueError(
+                f"capacitance must be positive, got {self.capacitance_farads}"
+            )
+        if (
+            self.resistance_ohms is None
+            and self.inductance_henrys is None
+            and self.capacitance_farads is None
+        ):
+            raise ValueError("DC load spec must include at least one L/R/C component")
+
+
+class DcLoadModel(ComponentRig):
+    current_output = ComponentDataPathOutput(
+        lambda component: component.current_output_channel,
+    )
+
+    @classmethod
+    def spec(
+        cls,
+        *,
+        voltage_input_channel: DataPath,
+        load_spec: DcLoadSpec,
+        bindings: tuple[ComponentDataPathBinding, ...] = (),
+    ) -> ComponentSpec:
+        return ComponentSpec(
+            cls,
+            parameters={
+                "voltage_input_channel": voltage_input_channel,
+                "load_spec": load_spec,
+            },
+            bindings=bindings,
+        )
+
+    def __init__(
+        self,
+        *,
+        voltage_input_channel: DataPath,
+        current_output_channel: DataPath | None = None,
+        load_spec: DcLoadSpec,
+    ) -> None:
+        super().__init__(
+            scheduler_period=1,
+            scheduler_unit="ms",
+        )
+        self.voltage_input_channel = voltage_input_channel
+        self.current_output_channel = current_output_channel or DataPath.component(
+            self,
+            DcLoadPort.CURRENT_OUTPUT,
+        )
+        self.load_spec = load_spec
+        self.input_voltage = 0.0
+        self.output_current = 0.0
+        self._inductor_current = 0.0
+        self._previous_voltage = 0.0
+        self._last_update_ns = 0
+        self._pending_current = False
+        self.datapaths.add_input(
+            self.voltage_input_channel,
+            send=self._set_voltage_from_timer,
+        )
+        self.datapaths.add_output(
+            self.current_output_channel,
+            pending=lambda: 1 if self._pending_current else 0,
+            recv=self._recv_current,
+        )
+
+    def reset(self) -> None:
+        super().reset()
+        self.input_voltage = 0.0
+        self.output_current = 0.0
+        self._inductor_current = 0.0
+        self._previous_voltage = 0.0
+        self._last_update_ns = 0
+        self._pending_current = False
+
+    def _run_scheduled(self) -> None:
+        elapsed_since_update_ns = self.elapsed_ns - self._last_update_ns
+        dt_seconds = elapsed_since_update_ns / 1_000_000_000.0
+        if dt_seconds <= 0.0:
+            return
+
+        self.output_current = self._current_for_step(dt_seconds)
+        self._previous_voltage = self.input_voltage
+        self._last_update_ns = self.elapsed_ns
+        self._pending_current = True
+
+    def _current_for_step(self, dt_seconds: float) -> float:
+        current = 0.0
+        if self.load_spec.resistance_ohms is not None:
+            current += self.input_voltage / self.load_spec.resistance_ohms
+        if self.load_spec.inductance_henrys is not None:
+            self._inductor_current += (
+                self.input_voltage / self.load_spec.inductance_henrys
+            ) * dt_seconds
+            current += self._inductor_current
+        if self.load_spec.capacitance_farads is not None:
+            current += self.load_spec.capacitance_farads * (
+                (self.input_voltage - self._previous_voltage) / dt_seconds
+            )
+        return current
+
+    def _set_voltage_from_timer(self, event: TimerChannelEvent) -> bool:
+        self.input_voltage = max(0.0, float(event.value))
+        return True
+
+    def _recv_current(self) -> float | None:
+        if not self._pending_current:
+            return None
+        self._pending_current = False
+        return self.output_current

--- a/sim/models/controllers/vcpdu/BUCK
+++ b/sim/models/controllers/vcpdu/BUCK
@@ -1,0 +1,202 @@
+load("//components/vc/pdu:platforms.bzl", "VCPDU_PLATFORM_VARIANTS")
+load("//sim/infra:defs.bzl", "rig_bindgen", "rig_embedded_rust_model", "rig_embedded_rust_model_platform_aliases", "rig_feature_consts", "rig_model_c_support", "rig_model_python", "rig_platforms_from_variants", "rig_python_enums", "rig_python_model", "rig_runtime_srcs")
+
+VCPDU_SIM_PLATFORMS = rig_platforms_from_variants(VCPDU_PLATFORM_VARIANTS)
+
+rig_python_model(
+    name = "vcpdu-py",
+    out = "vcpdu.py",
+    rust_source = ":rust-wrapper-src",
+    class_name = "VcpduModel",
+    symbol_prefix = "vcpdu_sim",
+    buck_target = "//sim/models/controllers/vcpdu:sil-so",
+    env_var = "VCPDU_SIM_LIB",
+    enum_env_var = "VCPDU_ENUMS_PY",
+    enum_target = "//sim/models/controllers/vcpdu:enums-py",
+    visibility = ["PUBLIC"],
+)
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "extensions.py",
+        "fixtures.py",
+        "variants.py",
+        ":vcpdu-py",
+        ":enums-py",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_model_c_support(
+    srcs = rig_runtime_srcs(["core", "faults", "io", "peripherals", "spi", "time"]),
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-fshort-enums",
+    ],
+    headers = {
+        "runtime_state.h": "//sim/infra/runtime:c/src/runtime_state.h",
+    },
+    deps = [
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/pdu:sil-features",
+        "//components/vc/pdu:sil-host-headers",
+        "//components/vc/pdu:sil-yamcan-c",
+        "//sim/infra/runtime:headers",
+    ],
+)
+
+rig_feature_consts(
+    name = "features-rs",
+    out = "features.rs",
+    deps = [
+        "//components/vc/pdu:sil-features",
+    ],
+    allowlist_vars = [
+        "APP_COMPONENT_ID",
+        "APP_VARIANT_ID",
+        "NVM_BLOCK_SIZE",
+        "NVM_FLASH_BACKED",
+        "NVM_LIB_ENABLED",
+    ],
+)
+
+rig_bindgen(
+    name = "bindings-rs",
+    out = "bindings.rs",
+    include_headers = [
+        "Module.h",
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD.h",
+        "drv_outputAD_componentSpecific.h",
+        "drv_vn9008.h",
+        "drv_vn9008_componentSpecific.h",
+        "YamcanShared.h",
+        "app_vehicleState.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/pdu:sil-features",
+        "//components/vc/pdu:sil-host-headers",
+        "//components/vc/pdu:sil-yamcan-c",
+        "//sim/infra/runtime:headers",
+    ],
+    allowlist_types = [
+        "drv_inputAD_channelAnalog_E",
+        "drv_outputAD_channelDigital_E",
+        "drv_vn9008_channelConfig_S",
+        "drv_vn9008_E",
+        "HW_GPIO_pinmux_E",
+        "HW_TIM_channel_E",
+        "HW_TIM_port_E",
+        "CAN_data_T",
+        "YamcanShared",
+    ],
+    allowlist_functions = [
+        "Module_Init",
+        "Module_1kHz_TSK",
+        "Module_100Hz_TSK",
+        "Module_10Hz_TSK",
+        "Module_1Hz_TSK",
+        "drv_outputAD_toggleDigitalState",
+        "app_vehicleState_allowSleep",
+        "YAMCAN_shared_init_static",
+    ],
+    allowlist_vars = [
+        "g_yamcan",
+        "drv_vn9008_channels",
+    ],
+    bindgen_flags = [
+        "--no-layout-tests",
+        "--default-enum-style rust",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+)
+
+rig_python_enums(
+    name = "enums-py",
+    out = "enums.py",
+    include_headers = [
+        "HW_gpio_componentSpecific.h",
+        "HW_spi.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD_componentSpecific.h",
+        "drv_vn9008_componentSpecific.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/pdu:sil-features",
+        "//components/vc/pdu:sil-host-headers",
+        "//components/vc/pdu:sil-yamcan-c",
+        "//sim/infra/runtime:headers",
+    ],
+    c_enums = [
+        "drv_inputAD_channelAnalog_E:AnalogInput:DRV_INPUTAD_ANALOG_::upper",
+        "HW_GPIO_pinmux_E:DigitalIo:HW_GPIO_::upper",
+        "drv_outputAD_channelDigital_E:DigitalOutput:DRV_OUTPUTAD_::upper",
+        "drv_vn9008_E:Vn9008Channel:DRV_VN9008_CHANNEL_::upper",
+        "HW_spi_device_E:SpiDevice:HW_SPI_DEV_::upper",
+        "HW_TIM_port_E:TimerPort:HW_TIM_PORT_::upper",
+        "HW_TIM_channel_E:TimerChannel:HW_TIM_CHANNEL_::upper",
+    ],
+    rust_sources = [
+        "//components/vc/pdu:sil-yamcan[rust_faults_generated.rs]",
+    ],
+    rust_enums = [
+        "FmFault:Fault:Vcpdu:Fault:camel",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model(
+    name = "sil-so",
+    crate = "vcpdu_sim",
+    out = "libvcpdu_sim.so",
+    link_deps = [
+        "//components/vc/pdu:sil-application",
+        ":model-c-support",
+        "//components/vc/pdu:sil-yamcan-c",
+        "//components/vc/pdu:sil-application",
+    ],
+    rust_env = {
+        "VCPDU_BINDINGS_RS": ":bindings-rs",
+        "VCPDU_FEATURES_RS": ":features-rs",
+        "VCPDU_YAMCAN_DECODE_RS": "//components/vc/pdu:sil-yamcan[rust_decode_generated.rs]",
+        "VCPDU_YAMCAN_MODEL_RS": "//components/vc/pdu:sil-yamcan[rust_model_generated.rs]",
+        "VCPDU_YAMCAN_RS": "//components/vc/pdu:sil-yamcan[yamcan.rs]",
+    },
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model_platform_aliases(
+    name = "sil-so",
+    actual = ":sil-so",
+    platforms = VCPDU_SIM_PLATFORMS,
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/vcpdu/__init__.py
+++ b/sim/models/controllers/vcpdu/__init__.py
@@ -1,0 +1,48 @@
+from sim.infra.rig import SpiInterface, TimerInterface, extend_model_class, load_generated_module
+
+from .extensions import VcpduModelExtensions
+
+_model = load_generated_module(
+    "VCPDU_MODEL_PY",
+    "//sim/models/controllers/vcpdu:vcpdu-py",
+    "vcpdu_generated_model",
+)
+_enums = load_generated_module(
+    "VCPDU_ENUMS_PY",
+    "//sim/models/controllers/vcpdu:enums-py",
+    "vcpdu_generated_enums",
+)
+
+AnalogInput = _enums.AnalogInput
+DigitalIo = _enums.DigitalIo
+DigitalOutput = _enums.DigitalOutput
+Fault = _enums.Fault
+SpiDevice = _enums.SpiDevice
+TimerChannel = _enums.TimerChannel
+TimerPort = _enums.TimerPort
+Vn9008Channel = _enums.Vn9008Channel
+VcpduModelExtensions.AnalogInput = AnalogInput
+VcpduModelExtensions.Vn9008Channel = Vn9008Channel
+
+
+class VcpduModel(extend_model_class(_model.VcpduModel, VcpduModelExtensions)):
+    timer = TimerInterface(TimerPort, TimerChannel)
+    spi = SpiInterface(SpiDevice)
+
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from .variants import VCPDU_CLUSTERS
+
+__all__ = [
+    "AnalogInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "Fault",
+    "SpiDevice",
+    "TimerChannel",
+    "TimerPort",
+    "Vn9008Channel",
+    "PLATFORM_VARIANTS",
+    "VCPDU_CLUSTERS",
+    "VcpduModel",
+]

--- a/sim/models/controllers/vcpdu/__init__.py
+++ b/sim/models/controllers/vcpdu/__init__.py
@@ -1,4 +1,9 @@
-from sim.infra.rig import SpiInterface, TimerInterface, extend_model_class, load_generated_module
+from sim.infra.rig import (
+    SpiInterface,
+    TimerInterface,
+    extend_model_class,
+    load_generated_module,
+)
 
 from .extensions import VcpduModelExtensions
 
@@ -28,6 +33,7 @@ VcpduModelExtensions.Vn9008Channel = Vn9008Channel
 class VcpduModel(extend_model_class(_model.VcpduModel, VcpduModelExtensions)):
     timer = TimerInterface(TimerPort, TimerChannel)
     spi = SpiInterface(SpiDevice)
+
 
 from sim.models.platforms import PLATFORM_VARIANTS
 

--- a/sim/models/controllers/vcpdu/extensions.py
+++ b/sim/models/controllers/vcpdu/extensions.py
@@ -12,7 +12,9 @@ class VcpduModelExtensions:
     def _configure_abi(self) -> None:
         super()._configure_abi()
         if self.AnalogInput is None or self.Vn9008Channel is None:
-            raise RuntimeError("VcpduModelExtensions generated enums were not configured")
+            raise RuntimeError(
+                "VcpduModelExtensions generated enums were not configured"
+            )
         self._get_vn9008_cs_amps_per_volt = self._bind_model_symbol(
             "get_vn9008_cs_amps_per_volt",
             [ctypes.c_int],
@@ -83,8 +85,12 @@ class VcpduModelExtensions:
         value = self.can.latest_signal("VCPDU_hsdCurrent1", signal_name, bus="veh")
         return None if value is None else float(value)
 
-    def set_vn9008_current_feedback(self, hsd_channel, analog_channel, current_amps: float) -> bool:
-        amps_per_volt = float(self._get_vn9008_cs_amps_per_volt(ctypes.c_int(int(hsd_channel))))
+    def set_vn9008_current_feedback(
+        self, hsd_channel, analog_channel, current_amps: float
+    ) -> bool:
+        amps_per_volt = float(
+            self._get_vn9008_cs_amps_per_volt(ctypes.c_int(int(hsd_channel)))
+        )
         if amps_per_volt <= 0.0:
             return False
         self.set_analog_input(analog_channel, float(current_amps) / amps_per_volt)
@@ -96,7 +102,8 @@ class VcpduModelExtensions:
         signals = {
             signal.signal_name: DigitalStatus.OFF
             for signal in self.can.rx_signals
-            if signal.message_name == message.name and signal.enum_name == "digitalStatus"
+            if signal.message_name == message.name
+            and signal.enum_name == "digitalStatus"
         }
         signals[signal_name] = DigitalStatus.ON if requested else DigitalStatus.OFF
         return self.can.send(message, **signals)
@@ -109,7 +116,9 @@ class VcpduModelExtensions:
         raise ValueError(f"unsupported VCPDU HSD channel {hsd_channel!r}")
 
     @classmethod
-    def vn9008_current_feedback(cls, *, hsd_channel, analog_input) -> ModelDataPathInputConnector:
+    def vn9008_current_feedback(
+        cls, *, hsd_channel, analog_input
+    ) -> ModelDataPathInputConnector:
         def connect(node, path) -> None:
             node.datapaths.add_input(
                 path,

--- a/sim/models/controllers/vcpdu/extensions.py
+++ b/sim/models/controllers/vcpdu/extensions.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import ctypes
+
+from sim.infra.rig import ModelDataPathInputConnector
+
+
+class VcpduModelExtensions:
+    AnalogInput = None
+    Vn9008Channel = None
+
+    def _configure_abi(self) -> None:
+        super()._configure_abi()
+        if self.AnalogInput is None or self.Vn9008Channel is None:
+            raise RuntimeError("VcpduModelExtensions generated enums were not configured")
+        self._get_vn9008_cs_amps_per_volt = self._bind_model_symbol(
+            "get_vn9008_cs_amps_per_volt",
+            [ctypes.c_int],
+            ctypes.c_float,
+        )
+        self._allow_sleep = self._bind_model_symbol("allow_sleep")
+
+    def latest_vehicle_state(self):
+        return self.can.latest_signal(
+            "VCPDU_vehicleState",
+            "VCPDU_vehicleState",
+            bus="veh",
+        )
+
+    def record_latest_vehicle_state(self, observed: list) -> object | None:
+        state = self.latest_vehicle_state()
+        if state is not None and (not observed or observed[-1] != state):
+            observed.append(state)
+        return state
+
+    def allow_sleep(self) -> None:
+        self._allow_sleep()
+
+    def waking_sleepable_controllers(self) -> tuple[str, ...]:
+        controllers = []
+        for signal in self.can.rx_signals:
+            if not signal.signal_name.endswith("_sleepable"):
+                continue
+            controller = signal.signal_name.removesuffix("_sleepable").lower()
+            if controller not in controllers:
+                controllers.append(controller)
+        return tuple(controllers)
+
+    def send_waking_controller_sleepable(self, controller: str, state) -> bool:
+        prefix = controller.upper()
+        message = self.can.message(f"{prefix}_sleep", bus="veh")
+        return self.can.send(message, **{f"{prefix}_sleepable": state})
+
+    def send_all_waking_controllers_sleepable(self, state) -> bool:
+        return all(
+            self.send_waking_controller_sleepable(controller, state)
+            for controller in self.waking_sleepable_controllers()
+        )
+
+    def request_test_hsd(self, hsd_channel, requested: bool) -> bool:
+        signal_name = self._hsd_signal_name(
+            hsd_channel,
+            pump="SWS_requestTestPump",
+            fan="SWS_requestTestFan",
+        )
+        return self._send_driver_request(signal_name, requested)
+
+    def latest_hsd_duty_cycle(self, hsd_channel) -> float | None:
+        signal_name = self._hsd_signal_name(
+            hsd_channel,
+            pump="VCPDU_pumpDutyCycle",
+            fan="VCPDU_fanDutyCycle",
+        )
+        value = self.can.latest_signal("VCPDU_hsdDuty", signal_name, bus="veh")
+        return None if value is None else float(value)
+
+    def latest_hsd_current(self, hsd_channel) -> float | None:
+        signal_name = self._hsd_signal_name(
+            hsd_channel,
+            pump="VCPDU_pumpCurrent",
+            fan="VCPDU_fanCurrent",
+        )
+        value = self.can.latest_signal("VCPDU_hsdCurrent1", signal_name, bus="veh")
+        return None if value is None else float(value)
+
+    def set_vn9008_current_feedback(self, hsd_channel, analog_channel, current_amps: float) -> bool:
+        amps_per_volt = float(self._get_vn9008_cs_amps_per_volt(ctypes.c_int(int(hsd_channel))))
+        if amps_per_volt <= 0.0:
+            return False
+        self.set_analog_input(analog_channel, float(current_amps) / amps_per_volt)
+        return True
+
+    def _send_driver_request(self, signal_name: str, requested: bool) -> bool:
+        DigitalStatus = self.can.enums.DigitalStatus
+        message = self.can.message("SWS_driverRequest", bus="veh")
+        signals = {
+            signal.signal_name: DigitalStatus.OFF
+            for signal in self.can.rx_signals
+            if signal.message_name == message.name and signal.enum_name == "digitalStatus"
+        }
+        signals[signal_name] = DigitalStatus.ON if requested else DigitalStatus.OFF
+        return self.can.send(message, **signals)
+
+    def _hsd_signal_name(self, hsd_channel, *, pump: str, fan: str) -> str:
+        if int(hsd_channel) == int(self.Vn9008Channel.PUMP):
+            return pump
+        if int(hsd_channel) == int(self.Vn9008Channel.FAN):
+            return fan
+        raise ValueError(f"unsupported VCPDU HSD channel {hsd_channel!r}")
+
+    @classmethod
+    def vn9008_current_feedback(cls, *, hsd_channel, analog_input) -> ModelDataPathInputConnector:
+        def connect(node, path) -> None:
+            node.datapaths.add_input(
+                path,
+                send=lambda current: node.set_vn9008_current_feedback(
+                    hsd_channel,
+                    analog_input,
+                    current,
+                ),
+            )
+
+        return ModelDataPathInputConnector(connect)

--- a/sim/models/controllers/vcpdu/fixtures.py
+++ b/sim/models/controllers/vcpdu/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import VCPDU_CLUSTERS
+
+vcpdu_cluster = cluster_rig_fixture(VCPDU_CLUSTERS)

--- a/sim/models/controllers/vcpdu/src/lib.rs
+++ b/sim/models/controllers/vcpdu/src/lib.rs
@@ -1,0 +1,127 @@
+mod rig_runtime {
+    include!(env!("RIG_RUNTIME_RS"));
+}
+
+mod bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCPDU_BINDINGS_RS"));
+}
+
+mod features {
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCPDU_FEATURES_RS"));
+}
+
+mod yamcan {
+    include!(env!("VCPDU_YAMCAN_RS"));
+}
+
+pub use yamcan::SignalMeasurement;
+
+mod rust_model_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCPDU_YAMCAN_MODEL_RS"));
+}
+
+mod rust_decode_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCPDU_YAMCAN_DECODE_RS"));
+}
+
+use bindings::drv_inputAD_channelAnalog_E::{
+    DRV_INPUTAD_ANALOG_5V_VOLTAGE, DRV_INPUTAD_ANALOG_UVL_BATT,
+};
+use bindings::drv_outputAD_channelDigital_E::DRV_OUTPUTAD_DIGITAL_LED;
+use rig_runtime::nvm::ControllerNvm;
+use rig_runtime::{AppDesc, ModuleDesc, NodeModel, NodeTarget, RTController};
+use std::sync::Mutex;
+
+const VCPDU_APP_START: u32 = 0x0800_2000;
+const VCPDU_APP_END: u32 = 0x0802_0000;
+const VCPDU_APP_CRC_LOCATION: u32 = 0x0801_FFF0;
+
+rig_rt_controller_nvm_storage!(ControllerNvm<
+    { features::NVM_BLOCK_SIZE as usize },
+    { features::NVM_LIB_ENABLED },
+    { features::NVM_FLASH_BACKED },
+>);
+
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static appDesc: AppDesc = AppDesc::new(
+    VCPDU_APP_START,
+    VCPDU_APP_END,
+    VCPDU_APP_CRC_LOCATION,
+    features::APP_COMPONENT_ID as u16,
+    features::APP_VARIANT_ID as u16,
+);
+
+unsafe extern "C" fn vcpdu_sys_1hz() {
+    unsafe { bindings::drv_outputAD_toggleDigitalState(DRV_OUTPUTAD_DIGITAL_LED) };
+}
+
+#[unsafe(no_mangle)]
+pub static sys_desc: ModuleDesc = ModuleDesc::new(None, None, None, None, Some(vcpdu_sys_1hz));
+
+struct Vcpdu {
+    nvm: ControllerNvm<
+        { features::NVM_BLOCK_SIZE as usize },
+        { features::NVM_LIB_ENABLED },
+        { features::NVM_FLASH_BACKED },
+    >,
+}
+
+impl Vcpdu {
+    const fn new() -> Self {
+        Self {
+            nvm: ControllerNvm::<
+                { features::NVM_BLOCK_SIZE as usize },
+                { features::NVM_LIB_ENABLED },
+                { features::NVM_FLASH_BACKED },
+            >::new(),
+        }
+    }
+}
+
+impl NodeTarget for Vcpdu {
+    unsafe fn reset_node(&mut self, controller: &mut RTController) {
+        self.nvm.reset();
+        rig_runtime::can::configure_network(VCPDU_CAN_NETWORK);
+        unsafe { bindings::YAMCAN_shared_init_static() };
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_UVL_BATT as i32, 1.8);
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_5V_VOLTAGE as i32, 1.4);
+    }
+}
+
+static VCPDU: Mutex<NodeModel<Vcpdu>> = Mutex::new(NodeModel::new(
+    RTController::new_embedded_module(),
+    Vcpdu::new(),
+));
+
+rig_model_abi!(VCPDU);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vcpdu_sim_get_vn9008_cs_amps_per_volt(channel: i32) -> f32 {
+    if channel < 0 || channel >= bindings::drv_vn9008_E::DRV_VN9008_CHANNEL_COUNT as i32 {
+        return 0.0;
+    }
+    unsafe { bindings::drv_vn9008_channels[channel as usize].cs_amp_per_volt }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vcpdu_sim_allow_sleep() {
+    unsafe { bindings::app_vehicleState_allowSleep() };
+}
+
+rig_yamcan_network!(
+    VCPDU_CAN_NETWORK,
+    rust_model_generated,
+    rust_decode_generated,
+    yamcan
+);

--- a/sim/models/controllers/vcpdu/variants.py
+++ b/sim/models/controllers/vcpdu/variants.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec, NodeSpec
+from sim.models.components.dc_load import DcLoadModel, DcLoadSpec
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from . import AnalogInput, TimerChannel, TimerPort, VcpduModel, Vn9008Channel
+
+
+def vcpdu_node(hardware: str | None = None) -> NodeSpec:
+    pump_voltage = VcpduModel.timer.duty_events(TimerPort.PWM, TimerChannel._1)
+    fan_voltage = VcpduModel.timer.duty_events(TimerPort.HP, TimerChannel._2)
+    components = (
+        DcLoadModel.spec(
+            voltage_input_channel=pump_voltage,
+            load_spec=DcLoadSpec(resistance_ohms=2.0),
+            bindings=(
+                DcLoadModel.current_output.bind_to(
+                    VcpduModel.vn9008_current_feedback(
+                        hsd_channel=Vn9008Channel.PUMP,
+                        analog_input=AnalogInput.DEMUX2_PUMP,
+                    ),
+                ),
+            ),
+        ),
+        DcLoadModel.spec(
+            voltage_input_channel=fan_voltage,
+            load_spec=DcLoadSpec(resistance_ohms=1.0),
+            bindings=(
+                DcLoadModel.current_output.bind_to(
+                    VcpduModel.vn9008_current_feedback(
+                        hsd_channel=Vn9008Channel.FAN,
+                        analog_input=AnalogInput.DEMUX2_FAN,
+                    ),
+                ),
+            ),
+        ),
+    )
+    return NodeSpec(
+        "vcpdu",
+        VcpduModel,
+        hardware=hardware,
+        components=components,
+    )
+
+
+def vcpdu_cluster_spec(hardware: str | None = None) -> ClusterSpec:
+    prefix = f"{hardware}-" if hardware is not None else ""
+    return ClusterSpec(
+        name=f"{prefix}vcpdu-cluster",
+        hardware=hardware,
+        nodes=(vcpdu_node(hardware),),
+    )
+
+
+VCPDU_CLUSTERS = ClusterCatalog(
+    *(vcpdu_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/controllers/vcrear/BUCK
+++ b/sim/models/controllers/vcrear/BUCK
@@ -1,0 +1,175 @@
+load("//components/vc/rear:platforms.bzl", "VCREAR_PLATFORM_VARIANTS")
+load("//sim/infra:defs.bzl", "rig_bindgen", "rig_embedded_rust_model", "rig_embedded_rust_model_platform_aliases", "rig_feature_consts", "rig_model_c_support", "rig_model_python", "rig_platforms_from_variants", "rig_python_enums", "rig_python_model", "rig_runtime_srcs")
+
+VCREAR_SIM_PLATFORMS = rig_platforms_from_variants(VCREAR_PLATFORM_VARIANTS)
+
+rig_python_model(
+    name = "vcrear-py",
+    out = "vcrear.py",
+    rust_source = ":rust-wrapper-src",
+    class_name = "VcrearModel",
+    symbol_prefix = "vcrear_sim",
+    buck_target = "//sim/models/controllers/vcrear:sil-so",
+    env_var = "VCREAR_SIM_LIB",
+    enum_env_var = "VCREAR_ENUMS_PY",
+    enum_target = "//sim/models/controllers/vcrear:enums-py",
+    visibility = ["PUBLIC"],
+)
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "extensions.py",
+        "fixtures.py",
+        "variants.py",
+        ":vcrear-py",
+        ":enums-py",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_model_c_support(
+    srcs = rig_runtime_srcs(["core", "faults", "io", "peripherals", "time"]),
+    headers = {
+        "runtime_state.h": "//sim/infra/runtime:c/src/runtime_state.h",
+    },
+    deps = [
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/rear:sil-features",
+        "//components/vc/rear:sil-host-headers",
+        "//components/vc/rear:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+)
+
+rig_feature_consts(
+    name = "features-rs",
+    out = "features.rs",
+    deps = [
+        "//components/vc/rear:sil-features",
+    ],
+    allowlist_vars = [
+        "APP_COMPONENT_ID",
+        "APP_VARIANT_ID",
+        "NVM_BLOCK_SIZE",
+        "NVM_FLASH_BACKED",
+        "NVM_LIB_ENABLED",
+    ],
+)
+
+rig_bindgen(
+    name = "bindings-rs",
+    out = "bindings.rs",
+    include_headers = [
+        "Module.h",
+        "HW_gpio_componentSpecific.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD.h",
+        "drv_outputAD_componentSpecific.h",
+        "YamcanShared.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/rear:sil-features",
+        "//components/vc/rear:sil-host-headers",
+        "//components/vc/rear:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    allowlist_types = [
+        "drv_inputAD_channelAnalog_E",
+        "drv_outputAD_channelDigital_E",
+        "HW_GPIO_pinmux_E",
+        "CAN_data_T",
+        "YamcanShared",
+    ],
+    allowlist_functions = [
+        "Module_Init",
+        "Module_1kHz_TSK",
+        "Module_100Hz_TSK",
+        "Module_10Hz_TSK",
+        "Module_1Hz_TSK",
+        "drv_outputAD_toggleDigitalState",
+        "YAMCAN_shared_init_static",
+    ],
+    allowlist_vars = [
+        "g_yamcan",
+    ],
+    bindgen_flags = [
+        "--no-layout-tests",
+        "--default-enum-style rust",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+    ],
+)
+
+rig_python_enums(
+    name = "enums-py",
+    out = "enums.py",
+    include_headers = [
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD_componentSpecific.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/rear:sil-features",
+        "//components/vc/rear:sil-host-headers",
+        "//components/vc/rear:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    c_enums = [
+        "drv_inputAD_channelAnalog_E:AnalogInput:DRV_INPUTAD_ANALOG_::upper",
+        "HW_GPIO_pinmux_E:DigitalIo:HW_GPIO_::upper",
+        "drv_outputAD_channelDigital_E:DigitalOutput:DRV_OUTPUTAD_DIGITAL_::upper",
+        "HW_TIM_port_E:TimerPort:HW_TIM_PORT_::upper",
+        "HW_TIM_channel_E:TimerChannel:HW_TIM_CHANNEL_::upper",
+    ],
+    rust_sources = [
+        "//components/vc/rear:sil-yamcan[rust_faults_generated.rs]",
+    ],
+    rust_enums = [
+        "FmFault:Fault:Vcrear:Fault:camel",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model(
+    name = "sil-so",
+    crate = "vcrear_sim",
+    out = "libvcrear_sim.so",
+    link_deps = [
+        "//components/vc/rear:sil-application",
+        ":model-c-support",
+        "//components/vc/rear:sil-yamcan-c",
+    ],
+    rust_env = {
+        "VCREAR_BINDINGS_RS": ":bindings-rs",
+        "VCREAR_FEATURES_RS": ":features-rs",
+        "VCREAR_YAMCAN_DECODE_RS": "//components/vc/rear:sil-yamcan[rust_decode_generated.rs]",
+        "VCREAR_YAMCAN_MODEL_RS": "//components/vc/rear:sil-yamcan[rust_model_generated.rs]",
+        "VCREAR_YAMCAN_RS": "//components/vc/rear:sil-yamcan[yamcan.rs]",
+    },
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model_platform_aliases(
+    name = "sil-so",
+    actual = ":sil-so",
+    platforms = VCREAR_SIM_PLATFORMS,
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/vcrear/__init__.py
+++ b/sim/models/controllers/vcrear/__init__.py
@@ -1,0 +1,42 @@
+from sim.infra.rig import TimerInterface, extend_model_class, load_generated_module
+
+from .extensions import VcrearPytestHelpers
+
+_model = load_generated_module(
+    "VCREAR_MODEL_PY",
+    "//sim/models/controllers/vcrear:vcrear-py",
+    "vcrear_generated_model",
+)
+_enums = load_generated_module(
+    "VCREAR_ENUMS_PY",
+    "//sim/models/controllers/vcrear:enums-py",
+    "vcrear_generated_enums",
+)
+
+AnalogInput = _enums.AnalogInput
+DigitalIo = _enums.DigitalIo
+DigitalOutput = _enums.DigitalOutput
+Fault = _enums.Fault
+TimerChannel = _enums.TimerChannel
+TimerPort = _enums.TimerPort
+
+
+class VcrearModel(extend_model_class(_model.VcrearModel, VcrearPytestHelpers)):
+    timer = TimerInterface(TimerPort, TimerChannel)
+
+
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from .variants import VCREAR_CLUSTERS
+
+__all__ = [
+    "AnalogInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "Fault",
+    "TimerChannel",
+    "TimerPort",
+    "VCREAR_CLUSTERS",
+    "VcrearModel",
+    "PLATFORM_VARIANTS",
+]

--- a/sim/models/controllers/vcrear/extensions.py
+++ b/sim/models/controllers/vcrear/extensions.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class VcrearPytestHelpers:
+    pass

--- a/sim/models/controllers/vcrear/fixtures.py
+++ b/sim/models/controllers/vcrear/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import VCREAR_CLUSTERS
+
+vcrear_cluster = cluster_rig_fixture(VCREAR_CLUSTERS)

--- a/sim/models/controllers/vcrear/src/lib.rs
+++ b/sim/models/controllers/vcrear/src/lib.rs
@@ -1,0 +1,109 @@
+mod rig_runtime {
+    include!(env!("RIG_RUNTIME_RS"));
+}
+
+mod bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCREAR_BINDINGS_RS"));
+}
+
+mod features {
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCREAR_FEATURES_RS"));
+}
+
+mod yamcan {
+    include!(env!("VCREAR_YAMCAN_RS"));
+}
+
+pub use yamcan::SignalMeasurement;
+
+mod rust_model_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCREAR_YAMCAN_MODEL_RS"));
+}
+
+mod rust_decode_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("VCREAR_YAMCAN_DECODE_RS"));
+}
+
+use bindings::drv_outputAD_channelDigital_E::DRV_OUTPUTAD_DIGITAL_LED;
+use rig_runtime::nvm::ControllerNvm;
+use rig_runtime::{AppDesc, ModuleDesc, NodeModel, NodeTarget, RTController};
+use std::sync::Mutex;
+
+const VCREAR_APP_START: u32 = 0x0800_2000;
+const VCREAR_APP_END: u32 = 0x0802_0000;
+const VCREAR_APP_CRC_LOCATION: u32 = 0x0801_FFF0;
+
+rig_rt_controller_nvm_storage!(ControllerNvm<
+    { features::NVM_BLOCK_SIZE as usize },
+    { features::NVM_LIB_ENABLED },
+    { features::NVM_FLASH_BACKED },
+>);
+
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static appDesc: AppDesc = AppDesc::new(
+    VCREAR_APP_START,
+    VCREAR_APP_END,
+    VCREAR_APP_CRC_LOCATION,
+    features::APP_COMPONENT_ID as u16,
+    features::APP_VARIANT_ID as u16,
+);
+
+unsafe extern "C" fn vcrear_sys_1hz() {
+    unsafe { bindings::drv_outputAD_toggleDigitalState(DRV_OUTPUTAD_DIGITAL_LED) };
+}
+
+#[unsafe(no_mangle)]
+pub static sys_desc: ModuleDesc = ModuleDesc::new(None, None, None, None, Some(vcrear_sys_1hz));
+
+struct Vcrear {
+    nvm: ControllerNvm<
+        { features::NVM_BLOCK_SIZE as usize },
+        { features::NVM_LIB_ENABLED },
+        { features::NVM_FLASH_BACKED },
+    >,
+}
+
+impl Vcrear {
+    const fn new() -> Self {
+        Self {
+            nvm: ControllerNvm::<
+                { features::NVM_BLOCK_SIZE as usize },
+                { features::NVM_LIB_ENABLED },
+                { features::NVM_FLASH_BACKED },
+            >::new(),
+        }
+    }
+}
+
+impl NodeTarget for Vcrear {
+    unsafe fn reset_node(&mut self, _controller: &mut RTController) {
+        self.nvm.reset();
+        rig_runtime::can::configure_network(VCREAR_CAN_NETWORK);
+        unsafe { bindings::YAMCAN_shared_init_static() };
+    }
+}
+
+static VCREAR: Mutex<NodeModel<Vcrear>> = Mutex::new(NodeModel::new(
+    RTController::new_embedded_module(),
+    Vcrear::new(),
+));
+
+rig_model_abi!(VCREAR);
+
+rig_yamcan_network!(
+    VCREAR_CAN_NETWORK,
+    rust_model_generated,
+    rust_decode_generated,
+    yamcan
+);

--- a/sim/models/controllers/vcrear/variants.py
+++ b/sim/models/controllers/vcrear/variants.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec, NodeSpec
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from . import VcrearModel
+
+
+def vcrear_node(hardware: str | None = None) -> NodeSpec:
+    return NodeSpec("vcrear", VcrearModel, hardware=hardware)
+
+
+def vcrear_cluster_spec(hardware: str | None = None) -> ClusterSpec:
+    prefix = f"{hardware}-" if hardware is not None else ""
+    return ClusterSpec(
+        name=f"{prefix}vcrear-cluster",
+        hardware=hardware,
+        nodes=(vcrear_node(hardware),),
+    )
+
+
+VCREAR_CLUSTERS = ClusterCatalog(
+    *(vcrear_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/vehicle/BUCK
+++ b/sim/models/vehicle/BUCK
@@ -1,0 +1,10 @@
+load("//sim/infra:defs.bzl", "rig_model_python")
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "fixtures.py",
+        "variants.py",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/vehicle/__init__.py
+++ b/sim/models/vehicle/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from .variants import VEHICLE_CLUSTERS, vehicle_cluster_spec
+
+__all__ = [
+    "PLATFORM_VARIANTS",
+    "VEHICLE_CLUSTERS",
+    "vehicle_cluster_spec",
+]

--- a/sim/models/vehicle/fixtures.py
+++ b/sim/models/vehicle/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import VEHICLE_CLUSTERS
+
+vehicle_cluster = cluster_rig_fixture(VEHICLE_CLUSTERS)

--- a/sim/models/vehicle/variants.py
+++ b/sim/models/vehicle/variants.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec
+from sim.models.controllers.vcfront.variants import vcfront_node
+from sim.models.controllers.vcrear.variants import vcrear_node
+from sim.models.platforms import PLATFORM_VARIANTS
+
+
+def vehicle_cluster_spec(hardware: str) -> ClusterSpec:
+    return ClusterSpec(
+        name=f"{hardware}-vc-cluster",
+        hardware=hardware,
+        nodes=(
+            vcfront_node(hardware),
+            vcrear_node(hardware),
+        ),
+    )
+
+
+VEHICLE_CLUSTERS = ClusterCatalog(
+    *(vehicle_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/vehicle/variants.py
+++ b/sim/models/vehicle/variants.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sim.infra.rig import ClusterCatalog, ClusterSpec
 from sim.models.controllers.vcfront.variants import vcfront_node
+from sim.models.controllers.vcpdu.variants import vcpdu_node
 from sim.models.controllers.vcrear.variants import vcrear_node
 from sim.models.platforms import PLATFORM_VARIANTS
 
@@ -12,6 +13,7 @@ def vehicle_cluster_spec(hardware: str) -> ClusterSpec:
         hardware=hardware,
         nodes=(
             vcfront_node(hardware),
+            vcpdu_node(hardware),
             vcrear_node(hardware),
         ),
     )

--- a/sim/tests/BUCK
+++ b/sim/tests/BUCK
@@ -117,29 +117,19 @@ rig_pytest(
 )
 
 rig_pytest(
-    name = "vehicle_cluster",
-    test_file = "sim/tests/test_vehicle.py",
+    name = "vcrear_cluster",
+    test_file = "sim/tests/test_vcrear.py",
     env = {
-        "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
-        "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
-        "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
         "VCREAR_ENUMS_PY": "$(location {}:enums-py)".format(VCREAR_MODEL),
         "VCREAR_MODEL_PY": "$(location {}:vcrear-py)".format(VCREAR_MODEL),
         "VCREAR_SIM_LIB": "$(location {}:sil-so)".format(VCREAR_MODEL),
     } |
     rig_platform_variants_env(ALL_PLATFORMS) |
-    rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCREAR", VCREAR_MODEL, ALL_PLATFORMS),
     resources = [
-        "{}:enums-py".format(VCFRONT_MODEL),
-        "{}:vcfront-py".format(VCFRONT_MODEL),
-        "{}:sil-so".format(VCFRONT_MODEL),
-        "//sim/models/vehicle:python",
         "{}:enums-py".format(VCREAR_MODEL),
         "{}:vcrear-py".format(VCREAR_MODEL),
         "{}:sil-so".format(VCREAR_MODEL),
-    ] +
-    rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS) +
-    rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),
+    ] + rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),
     visibility = ["PUBLIC"],
 )

--- a/sim/tests/BUCK
+++ b/sim/tests/BUCK
@@ -1,0 +1,145 @@
+load("//components/vehicle_platform:platforms.bzl", "ALL_PLATFORMS")
+load("//sim/infra:defs.bzl", "rig_platform_sim_lib_env", "rig_platform_sim_lib_resources", "rig_platform_variants_env", "rig_pytest")
+
+VCFRONT_MODEL = "//sim/models/controllers/vcfront"
+VCPDU_MODEL = "//sim/models/controllers/vcpdu"
+VCREAR_MODEL = "//sim/models/controllers/vcrear"
+
+rig_pytest(
+    name = "rig_infra",
+    test_file = "sim/tests/test_rig_infra.py",
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "runtime_infra",
+    test_file = "sim/tests/test_runtime_infra.py",
+    env = {
+        "VCPDU_ENUMS_PY": "$(location {}:enums-py)".format(VCPDU_MODEL),
+        "VCPDU_MODEL_PY": "$(location {}:vcpdu-py)".format(VCPDU_MODEL),
+        "VCPDU_SIM_LIB": "$(location {}:sil-so)".format(VCPDU_MODEL),
+    } |
+    rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCPDU", VCPDU_MODEL, ALL_PLATFORMS),
+    resources = [
+        "{}:enums-py".format(VCPDU_MODEL),
+        "{}:vcpdu-py".format(VCPDU_MODEL),
+        "{}:sil-so".format(VCPDU_MODEL),
+        "//sim/models/components:python",
+        "//sim/models/components/dc_load:python",
+    ] + rig_platform_sim_lib_resources(VCPDU_MODEL, ALL_PLATFORMS),
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "dc_load",
+    test_file = "sim/tests/test_dc_load.py",
+    resources = [
+        "//sim/models/components:python",
+        "//sim/models/components/dc_load:python",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "component",
+    test_file = "sim/tests/test_component.py",
+    env = {
+        "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
+        "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
+        "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
+        "VCPDU_ENUMS_PY": "$(location {}:enums-py)".format(VCPDU_MODEL),
+        "VCPDU_MODEL_PY": "$(location {}:vcpdu-py)".format(VCPDU_MODEL),
+        "VCPDU_SIM_LIB": "$(location {}:sil-so)".format(VCPDU_MODEL),
+        "VCREAR_ENUMS_PY": "$(location {}:enums-py)".format(VCREAR_MODEL),
+        "VCREAR_MODEL_PY": "$(location {}:vcrear-py)".format(VCREAR_MODEL),
+        "VCREAR_SIM_LIB": "$(location {}:sil-so)".format(VCREAR_MODEL),
+    } |
+    rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCPDU", VCPDU_MODEL, ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCREAR", VCREAR_MODEL, ALL_PLATFORMS),
+    resources = [
+        "{}:enums-py".format(VCFRONT_MODEL),
+        "{}:vcfront-py".format(VCFRONT_MODEL),
+        "{}:sil-so".format(VCFRONT_MODEL),
+        "{}:enums-py".format(VCPDU_MODEL),
+        "{}:vcpdu-py".format(VCPDU_MODEL),
+        "{}:sil-so".format(VCPDU_MODEL),
+        "{}:enums-py".format(VCREAR_MODEL),
+        "{}:vcrear-py".format(VCREAR_MODEL),
+        "{}:sil-so".format(VCREAR_MODEL),
+        "//sim/models/components:python",
+        "//sim/models/components/dc_load:python",
+    ] +
+    rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS) +
+    rig_platform_sim_lib_resources(VCPDU_MODEL, ALL_PLATFORMS) +
+    rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "vcfront_cluster",
+    test_file = "sim/tests/test_vcfront.py",
+    env = {
+        "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
+        "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
+        "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
+    } |
+    rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS),
+    resources = [
+        "{}:enums-py".format(VCFRONT_MODEL),
+        "{}:vcfront-py".format(VCFRONT_MODEL),
+        "{}:sil-so".format(VCFRONT_MODEL),
+    ] + rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS),
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "vcpdu_cluster",
+    test_file = "sim/tests/test_vcpdu.py",
+    env = {
+        "VCPDU_ENUMS_PY": "$(location {}:enums-py)".format(VCPDU_MODEL),
+        "VCPDU_MODEL_PY": "$(location {}:vcpdu-py)".format(VCPDU_MODEL),
+        "VCPDU_SIM_LIB": "$(location {}:sil-so)".format(VCPDU_MODEL),
+    } |
+    rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCPDU", VCPDU_MODEL, ALL_PLATFORMS),
+    resources = [
+        "{}:enums-py".format(VCPDU_MODEL),
+        "{}:vcpdu-py".format(VCPDU_MODEL),
+        "{}:sil-so".format(VCPDU_MODEL),
+        "//sim/models/components:python",
+        "//sim/models/components/dc_load:python",
+    ] + rig_platform_sim_lib_resources(VCPDU_MODEL, ALL_PLATFORMS),
+    visibility = ["PUBLIC"],
+)
+
+rig_pytest(
+    name = "vehicle_cluster",
+    test_file = "sim/tests/test_vehicle.py",
+    env = {
+        "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
+        "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
+        "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
+        "VCREAR_ENUMS_PY": "$(location {}:enums-py)".format(VCREAR_MODEL),
+        "VCREAR_MODEL_PY": "$(location {}:vcrear-py)".format(VCREAR_MODEL),
+        "VCREAR_SIM_LIB": "$(location {}:sil-so)".format(VCREAR_MODEL),
+    } |
+    rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("VCREAR", VCREAR_MODEL, ALL_PLATFORMS),
+    resources = [
+        "{}:enums-py".format(VCFRONT_MODEL),
+        "{}:vcfront-py".format(VCFRONT_MODEL),
+        "{}:sil-so".format(VCFRONT_MODEL),
+        "//sim/models/vehicle:python",
+        "{}:enums-py".format(VCREAR_MODEL),
+        "{}:vcrear-py".format(VCREAR_MODEL),
+        "{}:sil-so".format(VCREAR_MODEL),
+    ] +
+    rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS) +
+    rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),
+    visibility = ["PUBLIC"],
+)

--- a/sim/tests/test_component.py
+++ b/sim/tests/test_component.py
@@ -1,0 +1,99 @@
+from sim.models.controllers.vcfront.fixtures import vcfront_cluster
+from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
+from sim.models.controllers.vcrear.fixtures import vcrear_cluster
+
+
+def controller_node(component_cluster):
+    controllers = tuple(
+        (name, node) for name, node in component_cluster.nodes.items() if node.has_can
+    )
+    assert len(controllers) == 1
+    return controllers[0]
+
+
+def heartbeat_message_name(node_name):
+    return f"{node_name.upper()}_rtosTaskInfo"
+
+
+def check_can_tx_streams_emit_controller_heartbeat(component_cluster):
+    node_name, controller = controller_node(component_cluster)
+    message_name = heartbeat_message_name(node_name)
+    assert controller.can.bus_count == len(controller.can.buses)
+
+    component_cluster.run_for(1100)
+
+    message = controller.can.tx_message(message_name)
+    event = component_cluster.comm.can.latest_message(
+        node_name,
+        message,
+        bus=message.bus,
+    )
+    assert event is not None, f"expected {message.name} on {message.bus_name}"
+    assert event.bus == message.bus
+    assert event.timestamp_ns > 0
+    assert event.packet.id == message.id
+    assert event.packet.len == message.len
+    assert len(event.packet.payload) == event.packet.len
+
+
+def check_can_tx_streams_emit_packets_on_every_bus(component_cluster):
+    node_name, controller = controller_node(component_cluster)
+    assert controller.can.bus_count == len(controller.can.buses)
+
+    component_cluster.run_for(1100)
+
+    for bus in controller.can.buses:
+        event = component_cluster.comm.can.latest_bus_event(node_name, bus)
+        assert event is not None, f"expected {node_name} to transmit on {bus.name}"
+        assert event.bus == bus.index
+        assert event.timestamp_ns > 0
+        assert len(event.packet.payload) == event.packet.len
+
+
+def check_can_rx_stream_consumes_injected_packet(component_cluster):
+    node_name, controller = controller_node(component_cluster)
+
+    for bus in controller.can.buses:
+        assert controller.can.send(
+            bus, 0x7FF, bytes(8)
+        ), f"expected {node_name} to accept an injected CAN packet on {bus.name}"
+        component_cluster.run_for(1)
+        assert (
+            controller.can.rx_count(bus) == 0
+        ), f"expected {node_name} to consume injected CAN packets on {bus.name}"
+
+
+def test_vcfront_can_tx_streams_emit_controller_heartbeat(vcfront_cluster):
+    check_can_tx_streams_emit_controller_heartbeat(vcfront_cluster)
+
+
+def test_vcfront_can_tx_streams_emit_packets_on_every_bus(vcfront_cluster):
+    check_can_tx_streams_emit_packets_on_every_bus(vcfront_cluster)
+
+
+def test_vcfront_can_rx_stream_consumes_injected_packet(vcfront_cluster):
+    check_can_rx_stream_consumes_injected_packet(vcfront_cluster)
+
+
+def test_vcpdu_can_tx_streams_emit_controller_heartbeat(vcpdu_cluster):
+    check_can_tx_streams_emit_controller_heartbeat(vcpdu_cluster)
+
+
+def test_vcpdu_can_tx_streams_emit_packets_on_every_bus(vcpdu_cluster):
+    check_can_tx_streams_emit_packets_on_every_bus(vcpdu_cluster)
+
+
+def test_vcpdu_can_rx_stream_consumes_injected_packet(vcpdu_cluster):
+    check_can_rx_stream_consumes_injected_packet(vcpdu_cluster)
+
+
+def test_vcrear_can_tx_streams_emit_controller_heartbeat(vcrear_cluster):
+    check_can_tx_streams_emit_controller_heartbeat(vcrear_cluster)
+
+
+def test_vcrear_can_tx_streams_emit_packets_on_every_bus(vcrear_cluster):
+    check_can_tx_streams_emit_packets_on_every_bus(vcrear_cluster)
+
+
+def test_vcrear_can_rx_stream_consumes_injected_packet(vcrear_cluster):
+    check_can_rx_stream_consumes_injected_packet(vcrear_cluster)

--- a/sim/tests/test_dc_load.py
+++ b/sim/tests/test_dc_load.py
@@ -1,0 +1,40 @@
+import pytest
+
+from sim.infra.rig import DataPath, TimerChannelEvent
+from sim.models.components.dc_load import DcLoadModel, DcLoadSpec
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"resistance_ohms": 0.0},
+        {"inductance_henrys": 0.0},
+        {"capacitance_farads": 0.0},
+    ],
+)
+def test_dc_load_spec_rejects_invalid_or_empty_components(kwargs):
+    with pytest.raises(ValueError):
+        DcLoadSpec(**kwargs)
+
+
+def test_dc_load_lrc_spec_updates_current_every_scheduler_step():
+    load = DcLoadModel(
+        voltage_input_channel=DataPath.component(object(), "voltage"),
+        load_spec=DcLoadSpec(
+            resistance_ohms=2.0,
+            inductance_henrys=4.0,
+            capacitance_farads=0.001,
+        ),
+    )
+    event = TimerChannelEvent()
+    event.value = 8.0
+
+    assert load._set_voltage_from_timer(event)
+    load.run_for(1)
+
+    assert load.output_current == pytest.approx(12.002)
+
+    load.run_for(1)
+
+    assert load.output_current == pytest.approx(4.004)

--- a/sim/tests/test_runtime_infra.py
+++ b/sim/tests/test_runtime_infra.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sim.infra.rig import DataPath
+from sim.models.components.dc_load import DcLoadModel
+from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
+
+
+def dc_loads(cluster):
+    return tuple(
+        component
+        for component in cluster.components
+        if isinstance(component, DcLoadModel)
+    )
+
+
+def test_runtime_timer_streams_are_timestamped_after_scheduler_runs(vcpdu_cluster):
+    vcpdu_cluster.run_for(20)
+
+    for load in dc_loads(vcpdu_cluster):
+        timer_stream = load.voltage_input_channel
+        assert isinstance(timer_stream, DataPath)
+        event = vcpdu_cluster.comm.timer.latest_event(
+            timer_stream,
+            node="vcpdu",
+        )
+        assert event is not None
+        assert event.timestamp_ns > 0
+        assert vcpdu_cluster.comm.timer.records(timer_stream)[-1].path == timer_stream
+
+
+def test_dc_loads_auto_bind_voltage_and_current_paths(
+    vcpdu_cluster,
+):
+    vcpdu_cluster.run_for(20)
+
+    for load in dc_loads(vcpdu_cluster):
+        assert vcpdu_cluster.vcpdu.datapaths.inputs(load.current_output_channel)
+        current_records = vcpdu_cluster.dataroutes.records(load.current_output_channel)
+        assert current_records
+        assert current_records[-1].payload == pytest.approx(load.output_current)
+        assert load.output_current == pytest.approx(
+            load.input_voltage / load.load_spec.resistance_ohms
+        )

--- a/sim/tests/test_vcpdu.py
+++ b/sim/tests/test_vcpdu.py
@@ -9,7 +9,10 @@ def test_vcpdu_boots_and_cycles_to_glv_on(vcpdu_cluster):
     observed = []
 
     def record_state():
-        return vcpdu_cluster.vcpdu.record_latest_vehicle_state(observed) == VehicleState.ON_GLV
+        return (
+            vcpdu_cluster.vcpdu.record_latest_vehicle_state(observed)
+            == VehicleState.ON_GLV
+        )
 
     vcpdu_cluster.run_until(
         record_state,
@@ -75,7 +78,9 @@ def test_vcpdu_sleeps_then_wakes_from_waking_controller_sleepable_states(
             VehicleState.INIT,
             VehicleState.ON_GLV,
         ]
-        assert vcpdu.send_waking_controller_sleepable(controller, SleepFollowerState.OK_TO_SLEEP)
+        assert vcpdu.send_waking_controller_sleepable(
+            controller, SleepFollowerState.OK_TO_SLEEP
+        )
 
 
 @pytest.mark.parametrize(

--- a/sim/tests/test_vcpdu.py
+++ b/sim/tests/test_vcpdu.py
@@ -1,0 +1,127 @@
+import pytest
+
+from sim.models.controllers.vcpdu import Vn9008Channel
+from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
+
+
+def test_vcpdu_boots_and_cycles_to_glv_on(vcpdu_cluster):
+    VehicleState = vcpdu_cluster.vcpdu.can.enums.VehicleState
+    observed = []
+
+    def record_state():
+        return vcpdu_cluster.vcpdu.record_latest_vehicle_state(observed) == VehicleState.ON_GLV
+
+    vcpdu_cluster.run_until(
+        record_state,
+        timeout=500,
+        step=10,
+        message="vcpdu should boot to ON_GLV",
+    )
+
+    assert observed == [
+        VehicleState.INIT,
+        VehicleState.ON_GLV,
+    ]
+
+
+def test_vcpdu_sleeps_then_wakes_from_waking_controller_sleepable_states(
+    vcpdu_cluster,
+):
+    VehicleState = vcpdu_cluster.vcpdu.can.enums.VehicleState
+    SleepFollowerState = vcpdu_cluster.vcpdu.can.enums.SleepFollowerState
+    vcpdu = vcpdu_cluster.vcpdu
+    observed = []
+
+    controllers = vcpdu.waking_sleepable_controllers()
+    assert controllers == ("sws", "vcfront")
+
+    vcpdu_cluster.run_until(
+        lambda: vcpdu.record_latest_vehicle_state(observed) == VehicleState.ON_GLV,
+        timeout=500,
+        step=20,
+        message="vcpdu should boot to ON_GLV before it can sleep",
+    )
+
+    assert vcpdu.send_all_waking_controllers_sleepable(SleepFollowerState.OK_TO_SLEEP)
+    for controller, wake_state in (
+        ("sws", SleepFollowerState.SNA),
+        ("sws", SleepFollowerState.NOK_TO_SLEEP),
+        ("sws", SleepFollowerState.ALARM),
+        ("vcfront", SleepFollowerState.SNA),
+        ("vcfront", SleepFollowerState.NOK_TO_SLEEP),
+        ("vcfront", SleepFollowerState.ALARM),
+    ):
+        vcpdu_cluster.run_for(100)
+        assert vcpdu.latest_vehicle_state() == VehicleState.ON_GLV
+
+        vcpdu.allow_sleep()
+        vcpdu_cluster.run_until(
+            lambda: vcpdu.record_latest_vehicle_state(observed) == VehicleState.SLEEP,
+            timeout=500,
+            step=20,
+            message="vcpdu should enter SLEEP when all waking controllers are OK to sleep",
+        )
+
+        assert vcpdu.send_waking_controller_sleepable(controller, wake_state)
+        before_wake = len(observed)
+        vcpdu_cluster.run_until(
+            lambda: vcpdu.record_latest_vehicle_state(observed) == VehicleState.ON_GLV,
+            timeout=1000,
+            step=20,
+            message=f"vcpdu should wake from {controller} {wake_state.name}",
+        )
+
+        assert observed[before_wake:] == [
+            VehicleState.INIT,
+            VehicleState.ON_GLV,
+        ]
+        assert vcpdu.send_waking_controller_sleepable(controller, SleepFollowerState.OK_TO_SLEEP)
+
+
+@pytest.mark.parametrize(
+    "hsd_channel",
+    [
+        pytest.param(Vn9008Channel.PUMP, id="pump"),
+        pytest.param(Vn9008Channel.FAN, id="fan"),
+    ],
+)
+def test_driver_cooling_request_toggles_and_latches_load_current(
+    vcpdu_cluster,
+    hsd_channel,
+):
+    vcpdu = vcpdu_cluster.vcpdu
+
+    vcpdu_cluster.run_until(
+        lambda: vcpdu.latest_hsd_duty_cycle(hsd_channel) == 0
+        and vcpdu.latest_hsd_current(hsd_channel) == 0,
+        timeout=500,
+        step=20,
+        message="VCPDU HSD load should report off before a driver request",
+    )
+
+    assert vcpdu.request_test_hsd(hsd_channel, True)
+    vcpdu_cluster.run_until(
+        lambda: _positive(vcpdu.latest_hsd_duty_cycle(hsd_channel))
+        and _positive(vcpdu.latest_hsd_current(hsd_channel)),
+        timeout=1000,
+        step=20,
+        message="VCPDU HSD load should report non-zero current when requested on",
+    )
+
+    assert vcpdu.request_test_hsd(hsd_channel, False)
+    vcpdu_cluster.run_for(250)
+    assert _positive(vcpdu.latest_hsd_duty_cycle(hsd_channel))
+    assert _positive(vcpdu.latest_hsd_current(hsd_channel))
+
+    assert vcpdu.request_test_hsd(hsd_channel, True)
+    vcpdu_cluster.run_until(
+        lambda: vcpdu.latest_hsd_duty_cycle(hsd_channel) == 0
+        and vcpdu.latest_hsd_current(hsd_channel) == 0,
+        timeout=1000,
+        step=20,
+        message="VCPDU HSD load should report zero current after a second driver request toggles it off",
+    )
+
+
+def _positive(value: float | None) -> bool:
+    return value is not None and value > 0

--- a/sim/tests/test_vcrear.py
+++ b/sim/tests/test_vcrear.py
@@ -1,0 +1,65 @@
+import pytest
+
+from sim.models.controllers.vcrear.fixtures import vcrear_cluster
+
+
+def brake_light_state(vcrear):
+    return vcrear.can.latest_signal(
+        "VCREAR_outputState",
+        "VCREAR_brakeLightState",
+        bus="veh",
+    )
+
+
+def send_vcfront_brake_position(vcrear, brake_position: float) -> bool:
+    message = vcrear.can.message("VCFRONT_pedalPosition", bus="veh")
+    return vcrear.can.send(
+        message,
+        VCFRONT_brakePosition=brake_position,
+    )
+
+
+@pytest.mark.parametrize(
+    "brake_position,brake_light_on",
+    [
+        pytest.param(0, False, id="brake-light-off-at-zero-percent"),
+        pytest.param(10, False, id="brake-light-off-at-threshold"),
+        pytest.param(12, True, id="brake-light-on-above-threshold"),
+        pytest.param(100, True, id="brake-light-on-at-full-pedal"),
+    ],
+)
+def test_brake_light_follows_vcfront_brake_position_can(
+    vcrear_cluster,
+    brake_position,
+    brake_light_on,
+):
+    vcrear = vcrear_cluster.vcrear
+    BrakeLightState = vcrear.can.enums.BrakeLightState
+    expected_state = BrakeLightState.ON if brake_light_on else BrakeLightState.OFF
+
+    assert send_vcfront_brake_position(vcrear, brake_position)
+    vcrear_cluster.run_until(
+        lambda: brake_light_state(vcrear) == expected_state,
+        timeout=250,
+        message=f"vcrear brake light should become {expected_state.name}",
+    )
+
+
+def test_brake_light_faults_when_vcfront_pedal_position_goes_mia(vcrear_cluster):
+    vcrear = vcrear_cluster.vcrear
+    BrakeLightState = vcrear.can.enums.BrakeLightState
+
+    assert send_vcfront_brake_position(vcrear, 50)
+    vcrear_cluster.run_until(
+        lambda: brake_light_state(vcrear) == BrakeLightState.ON,
+        timeout=250,
+        message="vcrear brake light should turn on while vcfront pedal position is present",
+    )
+
+    vcrear_cluster.run_until(
+        lambda: brake_light_state(vcrear) == BrakeLightState.FAULT,
+        timeout=1200,
+        step=10,
+        message="vcrear brake light should fault after vcfront pedal position goes MIA",
+    )
+    assert brake_light_state(vcrear) == BrakeLightState.FAULT


### PR DESCRIPTION
### Reason for Change

Extend the sim from individual controller models to vehicle-level clusters and add vcpdu/DC-load coverage.

### Changes

1. Add vcrear vehicle cluster model support.
2. Add vcpdu and DC load models.
3. Integrate vcpdu into vehicle simulation.
4. Add the `sim-tests` CI target using Buckle/Buck and the project Buck2 installer.
5. Apply formatting fixes required by CI.

### Test Plan

- Local: `buckle test sim/tests/...`
- CI: Formatting
- CI: Build All Firmware, including `sim-tests`

### Stack

Depends on #648. Follow-ups: #651, #652.
