### PR TITLE
Start building vehicle behavior integration testing

### DIFF
--- a/components/bms_boss/BUCK
+++ b/components/bms_boss/BUCK
@@ -5,7 +5,7 @@ load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
 load("//drive-stack/ota-agent/defs.bzl", "ota_agent")
 load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
-load("//tools/yamcan/defs.bzl", "generate_code")
+load("//tools/yamcan/defs.bzl", "generate_c_library", "generate_code", "generate_resources")
 load("//tools/hextools/defs.bzl", "inject_crc")
 load(
     "//components/vehicle_platform:defs.bzl",
@@ -14,20 +14,19 @@ load(
     "platform_selected_codegen_srcs",
     "platform_selected_targets",
 )
+load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
 load(
     "//components/vehicle_platform:platforms.bzl",
     "PLATFORMS",
     "platform_output_name",
 )
+load("//components/bms_boss:platforms.bzl", "BMSB_PLATFORM_VARIANTS")
 
 TOOLCHAIN = "@toolchains//:gcc-14.2.rel1-arm-none-eabi"
 APP_START_ADDR = 0x08002000
 APP_NAME = "bmsb"
 
-platform_variants = [
-    (PLATFORMS.CFR25, 1),
-    (PLATFORMS.CFR26, 1),
-]
+platform_variants = BMSB_PLATFORM_VARIANTS
 
 compiler_flags = [
     "-std=c11",
@@ -150,6 +149,14 @@ prebuilt_cxx_library(
     exported_deps = platform_selected_targets(platform_variants),
 )
 
+prebuilt_cxx_library(
+    name = "sil-host-headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = remap_headers(["include/", "HW/include/"]),
+    visibility = ["//sim/models/controllers/bmsb/..."],
+)
+
 compiler_flags += ["-include", "BuildDefines.h"]
 
 generate_code(
@@ -165,6 +172,126 @@ generate_code(
         "//components/shared/code:headers",
         "//components/shared/code/RTOS:headers",
     ],
+)
+
+generate_resources(
+    name = "sil-yamcan",
+    network_dep = "//network:network",
+    node = APP_NAME,
+    rust_wrapper = True,
+    visibility = ["//sim/models/controllers/bmsb/..."],
+)
+
+generate_feature_tree(
+    name = "sil-features",
+    variant_id = 1,
+    srcs = {
+        "variants.yaml": "variants.yaml",
+        "BMS_FeatureSels.yaml": "//components/shared:FeatureSels/BMS_CFR25_FeatureSels.yaml",
+        "BMS_FeatureDefs.yaml": "//components/shared:FeatureDefs/BMS_FeatureDefs.yaml",
+        "STM32F105_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F105_FeatureSels.yaml",
+        "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",
+        "APP_V1_FeatureSels.yaml": "//components/shared:FeatureSels/APP_V1_FeatureSels.yaml",
+        "Application_FeatureDefs.yaml": "//components/shared:FeatureDefs/Application_FeatureDefs.yaml",
+        "NVM_FeatureDefs.yaml": "//components/shared:FeatureDefs/NVM_FeatureDefs.yaml",
+        "hw_FeatureDefs.yaml": "//components/shared/code:HW/hw_FeatureDefs.yaml",
+        "FeatureDefs.yaml": "FeatureDefs.yaml",
+        "FeatureSels.yaml": "FeatureSels.yaml",
+    },
+    feature_overrides = {
+        "app_variant_id": 1,
+    },
+    visibility = ["//sim/models/controllers/bmsb/..."],
+)
+
+generate_c_library(
+    name = "sil-yamcan-c",
+    codegen_target = ":sil-yamcan",
+    compiler_flags = [
+        "-fshort-enums",
+    ],
+    library_deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "sil-application",
+    srcs = [
+        "//components/shared/code:DRV/drv_hih.c",
+        "//components/shared/code:DRV/drv_inputAD.c",
+        "//components/shared/code:DRV/drv_io.c",
+        "//components/shared/code:DRV/drv_outputAD.c",
+        "//components/shared/code:DRV/drv_timer.c",
+        "//components/shared/code:DRV/drv_userInput.c",
+        "//components/shared/code:app/CAN/CANIO-rx.c",
+        "//components/shared/code:app/CAN/CANIO-tx.c",
+        "//components/shared/code:app/app_faultManager.c",
+        "//components/shared/code:libs/LIB_app.c",
+        "//components/shared/code:libs/lib_interpolation.c",
+        "//components/shared/code:libs/lib_nvm.c",
+        "//components/shared/code:libs/lib_simpleFilter.c",
+        "//components/shared/code:libs/lib_thermistors.c",
+        "//components/shared/code:libs/Utility.c",
+        "//components/shared/code/RTOS:Module.c",
+        "//embedded/libs:libcrc.c",
+        "//embedded/libs/cells:P42A.c",
+        "//embedded/libs:isotp-src[isotp.c]",
+        "//embedded/libs/uds:lib_udsServer.c",
+        "HW/drv_inputAD_componentSpecific.c",
+        "HW/drv_outputAD_componentSpecific.c",
+        "HW/drv_userInput_componentSpecific.c",
+        "src/BMS.c",
+        "src/CANIO_componentSpecific.c",
+        "src/ENV.c",
+        "src/IMD.c",
+        "src/Module_componentSpecific.c",
+        "src/batteryModel.c",
+        "src/lib_nvm_componentSpecific.c",
+        "src/uds_componentSpecific.c",
+    ],
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-Wno-missing-prototypes",
+        "-Wno-unused-function",
+        "-Wno-conversion",
+        "-fshort-enums",
+    ],
+    header_namespace = "",
+    headers = {
+        "isotp.h": "//embedded/libs:isotp-src[include/isotp.h]",
+        "isotp_config.h": "//embedded/libs:isotp-src[include/isotp_config.h]",
+        "isotp_defines.h": "//embedded/libs:isotp-src[include/isotp_defines.h]",
+        "isotp_user.h": "//embedded/libs:isotp-src[include/isotp_user.h]",
+        "lib_uds.h": "//embedded/libs/uds:lib_uds.h",
+        "libcrc.h": "//embedded/libs:libcrc.h",
+    },
+    deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        ":sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//embedded/libs/cells:cells",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["//sim/models/controllers/bmsb/..."],
 )
 
 cxx_library(

--- a/components/bms_boss/platforms.bzl
+++ b/components/bms_boss/platforms.bzl
@@ -1,0 +1,6 @@
+load("//components/vehicle_platform:platforms.bzl", "PLATFORMS")
+
+BMSB_PLATFORM_VARIANTS = [
+    (PLATFORMS.CFR25, 1),
+    (PLATFORMS.CFR26, 1),
+]

--- a/components/shared/code/app/app_vehicleState.c
+++ b/components/shared/code/app/app_vehicleState.c
@@ -207,7 +207,7 @@ void app_vehicleState_run100Hz(void)
             else if ((drv_inputAD_getDigitalActiveState(VEHICLESTATE_INPUTAD_RUN_BUTTON) == DRV_IO_ACTIVE) &&
                      ((VEHICLESTATE_CANRX_BRAKEPOSITION(&percentage) == CANRX_MESSAGE_VALID) &&
                       (percentage > 10.0f)) &&
-                     ((VEHICLESTATE_CANRX_CONTACTORSTATE(&contacts) == CANRX_MESSAGE_VALID) ||
+                     ((VEHICLESTATE_CANRX_CONTACTORSTATE(&contacts) == CANRX_MESSAGE_VALID) &&
                       (contacts == CAN_PRECHARGECONTACTORSTATE_HVP_CLOSED))
                      )
             {

--- a/components/sws/BUCK
+++ b/components/sws/BUCK
@@ -4,7 +4,7 @@ load("//drive-stack/conUDS/defs.bzl", "conUDS_download")
 load("//drive-stack/defs.bzl", "deployable_target")
 load("//embedded/openocd/defs.bzl", "openocd_run")
 load("//embedded/platforms/stm32/f1:defs.bzl", "stm32f1_hal")
-load("//tools/yamcan/defs.bzl", "generate_code")
+load("//tools/yamcan/defs.bzl", "generate_c_library", "generate_code", "generate_resources")
 load("//tools/hextools/defs.bzl", "inject_crc")
 load("//drive-stack/ota-agent/defs.bzl", "ota_agent")
 load(
@@ -15,15 +15,14 @@ load(
     "platform_selected_targets",
 )
 load("//components/vehicle_platform:platforms.bzl", "PLATFORMS", "platform_output_name")
+load("//tools/feature-tree/defs.bzl", "generate_feature_tree")
+load("//components/sws:platforms.bzl", "SWS_PLATFORM_VARIANTS")
 
 TOOLCHAIN = "@toolchains//:gcc-14.2.rel1-arm-none-eabi"
 APP_START_ADDR = 0x08002000
 APP_NAME = "sws"
 
-platform_variants = [
-    (PLATFORMS.CFR25, 0),
-    (PLATFORMS.CFR26, 0),
-]
+platform_variants = SWS_PLATFORM_VARIANTS
 
 compiler_flags = [
     "-std=c11",
@@ -143,6 +142,14 @@ prebuilt_cxx_library(
     exported_deps = platform_selected_targets(platform_variants),
 )
 
+prebuilt_cxx_library(
+    name = "sil-host-headers",
+    header_only = True,
+    header_namespace = "",
+    exported_headers = remap_headers(["include/", "include/HW/"]),
+    visibility = ["//sim/models/controllers/sws/..."],
+)
+
 compiler_flags += ["-include", "BuildDefines.h"]
 
 generate_code(
@@ -159,6 +166,116 @@ generate_code(
         "//components/shared/code/RTOS:headers",
         "//components/vc/shared:headers",
     ],
+)
+
+generate_resources(
+    name = "sil-yamcan",
+    network_dep = "//network:network",
+    node = APP_NAME,
+    rust_wrapper = True,
+    visibility = ["//sim/models/controllers/sws/..."],
+)
+
+generate_feature_tree(
+    name = "sil-features",
+    variant_id = 0,
+    srcs = {
+        "variants.yaml": "variants.yaml",
+        "STM32F103xB_FeatureSels.yaml": "//components/shared:FeatureSels/STM32F103xB_FeatureSels.yaml",
+        "Controller_FeatureDefs.yaml": "//components/shared:FeatureDefs/Controller_FeatureDefs.yaml",
+        "APP_V1_FeatureSels.yaml": "//components/shared:FeatureSels/APP_V1_FeatureSels.yaml",
+        "Application_FeatureDefs.yaml": "//components/shared:FeatureDefs/Application_FeatureDefs.yaml",
+        "SharedApp_FeatureDefs.yaml": "//components/shared/code:SharedApp_FeatureDefs.yaml",
+        "NVM_FeatureDefs.yaml": "//components/shared:FeatureDefs/NVM_FeatureDefs.yaml",
+        "FeatureDefs.yaml": "FeatureDefs.yaml",
+        "FeatureSels.yaml": "FeatureSels.yaml",
+    },
+    feature_overrides = {
+        "app_variant_id": 0,
+    },
+    visibility = ["//sim/models/controllers/sws/..."],
+)
+
+generate_c_library(
+    name = "sil-yamcan-c",
+    codegen_target = ":sil-yamcan",
+    compiler_flags = [
+        "-fshort-enums",
+    ],
+    library_deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "sil-application",
+    srcs = [
+        "//components/shared/code:DRV/drv_inputAD.c",
+        "//components/shared/code:DRV/drv_io.c",
+        "//components/shared/code:DRV/drv_outputAD.c",
+        "//components/shared/code:DRV/drv_timer.c",
+        "//components/shared/code:DRV/drv_userInput.c",
+        "//components/shared/code:app/CAN/CANIO-rx.c",
+        "//components/shared/code:app/CAN/CANIO-tx.c",
+        "//components/shared/code:app/app_faultManager.c",
+        "//components/shared/code:app/app_vehicleState.c",
+        "//components/shared/code:libs/LIB_app.c",
+        "//components/shared/code:libs/lib_simpleFilter.c",
+        "//components/shared/code:libs/Utility.c",
+        "//components/shared/code/RTOS:Module.c",
+        "//embedded/libs:isotp-src[isotp.c]",
+        "//embedded/libs/uds:lib_udsServer.c",
+        "src/CANIO_componentSpecific.c",
+        "src/HW/drv_inputAD_componentSpecific.c",
+        "src/HW/drv_outputAD_componentSpecific.c",
+        "src/HW/drv_userInput_componentSpecific.c",
+        "src/Module_componentSpecific.c",
+        "src/driverInput.c",
+        "src/screenManager.c",
+        "src/uds_componentSpecific.c",
+    ],
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-Wno-missing-prototypes",
+        "-Wno-unused-function",
+        "-Wno-conversion",
+        "-fshort-enums",
+    ],
+    header_namespace = "",
+    headers = {
+        "isotp.h": "//embedded/libs:isotp-src[include/isotp.h]",
+        "isotp_config.h": "//embedded/libs:isotp-src[include/isotp_config.h]",
+        "isotp_defines.h": "//embedded/libs:isotp-src[include/isotp_defines.h]",
+        "isotp_user.h": "//embedded/libs:isotp-src[include/isotp_user.h]",
+        "lib_uds.h": "//embedded/libs/uds:lib_uds.h",
+    },
+    deps = [
+        ":sil-features",
+        ":sil-host-headers",
+        ":sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    preferred_linkage = "static",
+    visibility = ["//sim/models/controllers/sws/..."],
 )
 
 cxx_library(

--- a/components/sws/platforms.bzl
+++ b/components/sws/platforms.bzl
@@ -1,0 +1,6 @@
+load("//components/vehicle_platform:platforms.bzl", "PLATFORMS")
+
+SWS_PLATFORM_VARIANTS = [
+    (PLATFORMS.CFR25, 0),
+    (PLATFORMS.CFR26, 0),
+]

--- a/sim/models/controllers/BUCK
+++ b/sim/models/controllers/BUCK
@@ -5,6 +5,7 @@ rig_model_python(
         "__init__.py",
         "fixtures.py",
         "variants.py",
+        "//sim/models/controllers/bmsb:python",
         "//sim/models/controllers/sws:python",
     ],
     visibility = ["PUBLIC"],

--- a/sim/models/controllers/bmsb/BUCK
+++ b/sim/models/controllers/bmsb/BUCK
@@ -1,0 +1,193 @@
+load("//components/bms_boss:platforms.bzl", "BMSB_PLATFORM_VARIANTS")
+load("//sim/infra:defs.bzl", "rig_bindgen", "rig_embedded_rust_model", "rig_embedded_rust_model_platform_aliases", "rig_feature_consts", "rig_model_c_support", "rig_model_python", "rig_platforms_from_variants", "rig_python_enums", "rig_python_model", "rig_runtime_srcs")
+
+BMSB_SIM_PLATFORMS = rig_platforms_from_variants(BMSB_PLATFORM_VARIANTS)
+
+rig_python_model(
+    name = "bmsb-py",
+    out = "bmsb.py",
+    rust_source = ":rust-wrapper-src",
+    class_name = "BmsbModel",
+    symbol_prefix = "bmsb_sim",
+    buck_target = "//sim/models/controllers/bmsb:sil-so",
+    env_var = "BMSB_SIM_LIB",
+    enum_env_var = "BMSB_ENUMS_PY",
+    enum_target = "//sim/models/controllers/bmsb:enums-py",
+    visibility = ["PUBLIC"],
+)
+
+rig_model_python(
+    srcs = [
+        "__init__.py",
+        "fixtures.py",
+        "simple.py",
+        "variants.py",
+        ":bmsb-py",
+        ":enums-py",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_model_c_support(
+    srcs = rig_runtime_srcs(["can", "core", "faults", "flash", "i2c", "io", "swi", "system", "time", "uart"]),
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-fshort-enums",
+    ],
+    headers = {
+        "runtime_state.h": "//sim/infra/runtime:c/src/runtime_state.h",
+    },
+    deps = [
+        "//components/bms_boss:sil-features",
+        "//components/bms_boss:sil-host-headers",
+        "//components/bms_boss:sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+)
+
+rig_feature_consts(
+    name = "features-rs",
+    out = "features.rs",
+    deps = [
+        "//components/bms_boss:sil-features",
+    ],
+    allowlist_vars = [
+        "APP_COMPONENT_ID",
+        "APP_VARIANT_ID",
+        "NVM_BLOCK_SIZE",
+        "NVM_FLASH_BACKED",
+        "NVM_LIB_ENABLED",
+    ],
+)
+
+rig_bindgen(
+    name = "bindings-rs",
+    out = "bindings.rs",
+    include_headers = [
+        "Module.h",
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD.h",
+        "drv_outputAD_componentSpecific.h",
+        "YamcanShared.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/bms_boss:sil-features",
+        "//components/bms_boss:sil-host-headers",
+        "//components/bms_boss:sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    allowlist_types = [
+        "drv_inputAD_channelAnalog_E",
+        "drv_inputAD_channelDigital_E",
+        "drv_outputAD_channelDigital_E",
+        "HW_GPIO_pinmux_E",
+        "HW_TIM_channel_E",
+        "HW_TIM_port_E",
+        "CAN_data_T",
+        "YamcanShared",
+    ],
+    allowlist_functions = [
+        "Module_Init",
+        "Module_1kHz_TSK",
+        "Module_100Hz_TSK",
+        "Module_10Hz_TSK",
+        "Module_1Hz_TSK",
+        "drv_outputAD_toggleDigitalState",
+        "YAMCAN_shared_init_static",
+    ],
+    allowlist_vars = [
+        "g_yamcan",
+    ],
+    bindgen_flags = [
+        "--no-layout-tests",
+        "--default-enum-style rust",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+)
+
+rig_python_enums(
+    name = "enums-py",
+    out = "enums.py",
+    include_headers = [
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD_componentSpecific.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/bms_boss:sil-features",
+        "//components/bms_boss:sil-host-headers",
+        "//components/bms_boss:sil-yamcan-c",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    c_enums = [
+        "drv_inputAD_channelAnalog_E:AnalogInput:DRV_INPUTAD_ANALOG_::upper",
+        "drv_inputAD_channelDigital_E:DigitalInput:DRV_INPUTAD_DIGITAL_::upper",
+        "HW_GPIO_pinmux_E:DigitalIo:HW_GPIO_::upper",
+        "drv_outputAD_channelDigital_E:DigitalOutput:DRV_OUTPUTAD_DIGITAL_::upper",
+        "HW_TIM_port_E:TimerPort:HW_TIM_PORT_::upper",
+        "HW_TIM_channel_E:TimerChannel:HW_TIM_CHANNEL_::upper",
+    ],
+    rust_sources = [
+        "//components/bms_boss:sil-yamcan[rust_faults_generated.rs]",
+    ],
+    rust_enums = [
+        "FmFault:Fault:Bmsb:Fault:camel",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model(
+    name = "sil-so",
+    crate = "bmsb_sim",
+    out = "libbmsb_sim.so",
+    link_deps = [
+        "//components/bms_boss:sil-application",
+        ":model-c-support",
+        "//components/bms_boss:sil-yamcan-c",
+        "//components/bms_boss:sil-application",
+    ],
+    rust_env = {
+        "BMSB_BINDINGS_RS": ":bindings-rs",
+        "BMSB_FEATURES_RS": ":features-rs",
+        "BMSB_YAMCAN_DECODE_RS": "//components/bms_boss:sil-yamcan[rust_decode_generated.rs]",
+        "BMSB_YAMCAN_MODEL_RS": "//components/bms_boss:sil-yamcan[rust_model_generated.rs]",
+        "BMSB_YAMCAN_RS": "//components/bms_boss:sil-yamcan[yamcan.rs]",
+    },
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model_platform_aliases(
+    name = "sil-so",
+    actual = ":sil-so",
+    platforms = BMSB_SIM_PLATFORMS,
+    visibility = ["PUBLIC"],
+)

--- a/sim/models/controllers/bmsb/__init__.py
+++ b/sim/models/controllers/bmsb/__init__.py
@@ -1,0 +1,77 @@
+from sim.infra.rig import TimerInterface, extend_model_class, load_generated_module
+
+from .simple import BmsbSimpleModel
+
+
+def _load_generated() -> None:
+    if "BmsbModel" in globals():
+        return
+
+    model = load_generated_module(
+        "BMSB_MODEL_PY",
+        "//sim/models/controllers/bmsb:bmsb-py",
+        "bmsb_generated_model",
+    )
+    enums = load_generated_module(
+        "BMSB_ENUMS_PY",
+        "//sim/models/controllers/bmsb:enums-py",
+        "bmsb_generated_enums",
+    )
+
+    globals()["AnalogInput"] = enums.AnalogInput
+    globals()["DigitalInput"] = enums.DigitalInput
+    globals()["DigitalIo"] = enums.DigitalIo
+    globals()["DigitalOutput"] = enums.DigitalOutput
+    globals()["Fault"] = enums.Fault
+    globals()["TimerChannel"] = enums.TimerChannel
+    globals()["TimerPort"] = enums.TimerPort
+
+    class BmsbModel(extend_model_class(model.BmsbModel)):
+        timer = TimerInterface(enums.TimerPort, enums.TimerChannel)
+
+    globals()["BmsbModel"] = BmsbModel
+
+
+def __getattr__(name: str):
+    if name == "PLATFORM_VARIANTS":
+        from sim.models.platforms import PLATFORM_VARIANTS
+
+        globals()["PLATFORM_VARIANTS"] = PLATFORM_VARIANTS
+        return PLATFORM_VARIANTS
+    if name == "BMSB_CLUSTERS":
+        from .variants import BMSB_CLUSTERS
+
+        globals()["BMSB_CLUSTERS"] = BMSB_CLUSTERS
+        return BMSB_CLUSTERS
+    if name in _GENERATED_EXPORTS:
+        _load_generated()
+        return globals()[name]
+    raise AttributeError(name)
+
+
+_GENERATED_EXPORTS = {
+    "AnalogInput",
+    "DigitalInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "Fault",
+    "TimerChannel",
+    "TimerPort",
+    "BmsbModel",
+    "BMSB_CLUSTERS",
+    "PLATFORM_VARIANTS",
+}
+
+__all__ = [
+    "AnalogInput",
+    "DigitalInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "Fault",
+    "TimerChannel",
+    "TimerPort",
+    "PLATFORM_VARIANTS",
+    "BMSB_CLUSTERS",
+    "BmsbSimpleModel",
+    "BmsbModel",
+]

--- a/sim/models/controllers/bmsb/fixtures.py
+++ b/sim/models/controllers/bmsb/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import BMSB_CLUSTERS
+
+bmsb_cluster = cluster_rig_fixture(BMSB_CLUSTERS)

--- a/sim/models/controllers/bmsb/simple.py
+++ b/sim/models/controllers/bmsb/simple.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+from sim.infra.rig import (
+    CanInterface,
+    PeriodicCanMessage,
+    SimpleCanComponent,
+    SimpleNodeRig,
+)
+
+
+class BmsbSimpleModel(SimpleNodeRig):
+    """Python-only BMSB CAN source for tests that do not need BMSB firmware."""
+
+    def __init__(self, can: CanInterface, *, buses: tuple[str, ...] = ("veh",)):
+        self.can_component = SimpleCanComponent(can, buses=buses)
+        super().__init__(self.can_component)
+
+    def periodic_critical_data(
+        self,
+        *,
+        period: int | float = 10,
+        bus: str = "veh",
+        **signals: float | int | IntEnum,
+    ) -> PeriodicCanMessage:
+        return self.can_component.periodic_send(
+            "BMSB_criticalData",
+            bus=bus,
+            period=period,
+            **signals,
+        )
+
+    def send_critical_data(
+        self,
+        *,
+        bus: str = "veh",
+        **signals: float | int | IntEnum,
+    ) -> bool:
+        return self.can_component.send(
+            "BMSB_criticalData",
+            bus=bus,
+            **signals,
+        )
+
+    def periodic_pack_contactor_state(
+        self,
+        state: IntEnum,
+        *,
+        period: int | float = 100,
+        bus: str = "veh",
+    ) -> PeriodicCanMessage:
+        return self.can_component.periodic_send(
+            "BMSB_information",
+            bus=bus,
+            period=period,
+            BMSB_packContactorState=state,
+        )
+
+    def send_pack_contactor_state(
+        self,
+        state: IntEnum,
+        *,
+        bus: str = "veh",
+    ) -> bool:
+        return self.can_component.send(
+            "BMSB_information",
+            bus=bus,
+            BMSB_packContactorState=state,
+        )
+
+    def periodic_io_status(
+        self,
+        *,
+        period: int | float = 50,
+        bus: str = "veh",
+        **signals: float | int | IntEnum,
+    ) -> PeriodicCanMessage:
+        return self.can_component.periodic_send(
+            "BMSB_ioStatus",
+            bus=bus,
+            period=period,
+            enum_defaults={"digitalStatus": "OFF"},
+            **signals,
+        )
+
+    def send_io_status(
+        self,
+        *,
+        bus: str = "veh",
+        **signals: float | int | IntEnum,
+    ) -> bool:
+        return self.can_component.send(
+            "BMSB_ioStatus",
+            bus=bus,
+            enum_defaults={"digitalStatus": "OFF"},
+            **signals,
+        )

--- a/sim/models/controllers/bmsb/src/lib.rs
+++ b/sim/models/controllers/bmsb/src/lib.rs
@@ -1,0 +1,121 @@
+mod rig_runtime {
+    include!(env!("RIG_RUNTIME_RS"));
+}
+
+mod bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("BMSB_BINDINGS_RS"));
+}
+
+mod features {
+    #![allow(non_upper_case_globals)]
+    include!(env!("BMSB_FEATURES_RS"));
+}
+
+mod yamcan {
+    include!(env!("BMSB_YAMCAN_RS"));
+}
+
+pub use yamcan::SignalMeasurement;
+
+mod rust_model_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("BMSB_YAMCAN_MODEL_RS"));
+}
+
+mod rust_decode_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("BMSB_YAMCAN_DECODE_RS"));
+}
+
+use bindings::drv_inputAD_channelAnalog_E::DRV_INPUTAD_ANALOG_CS;
+use bindings::drv_inputAD_channelDigital_E::{
+    DRV_INPUTAD_DIGITAL_BMS_IMD_RESET, DRV_INPUTAD_DIGITAL_BMS_STATUS_MEM,
+    DRV_INPUTAD_DIGITAL_IMD_STATUS_MEM, DRV_INPUTAD_DIGITAL_OK_HS, DRV_INPUTAD_DIGITAL_TSMS_CHG,
+};
+use bindings::drv_outputAD_channelDigital_E::DRV_OUTPUTAD_DIGITAL_LED;
+use rig_runtime::nvm::ControllerNvm;
+use rig_runtime::{AppDesc, ModuleDesc, NodeModel, NodeTarget, RTController};
+use std::sync::Mutex;
+
+const BMSB_APP_START: u32 = 0x0800_2000;
+const BMSB_APP_END: u32 = 0x0802_0000;
+const BMSB_APP_CRC_LOCATION: u32 = 0x0801_FFF0;
+
+rig_rt_controller_nvm_storage!(ControllerNvm<
+    { features::NVM_BLOCK_SIZE as usize },
+    { features::NVM_LIB_ENABLED },
+    { features::NVM_FLASH_BACKED },
+>);
+
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static appDesc: AppDesc = AppDesc::new(
+    BMSB_APP_START,
+    BMSB_APP_END,
+    BMSB_APP_CRC_LOCATION,
+    features::APP_COMPONENT_ID as u16,
+    features::APP_VARIANT_ID as u16,
+);
+
+unsafe extern "C" fn bmsb_sys_1hz() {
+    unsafe { bindings::drv_outputAD_toggleDigitalState(DRV_OUTPUTAD_DIGITAL_LED) };
+}
+
+#[unsafe(no_mangle)]
+pub static SYS_desc: ModuleDesc = ModuleDesc::new(None, None, None, None, Some(bmsb_sys_1hz));
+
+struct Bmsb {
+    nvm: ControllerNvm<
+        { features::NVM_BLOCK_SIZE as usize },
+        { features::NVM_LIB_ENABLED },
+        { features::NVM_FLASH_BACKED },
+    >,
+}
+
+impl Bmsb {
+    const fn new() -> Self {
+        Self {
+            nvm: ControllerNvm::<
+                { features::NVM_BLOCK_SIZE as usize },
+                { features::NVM_LIB_ENABLED },
+                { features::NVM_FLASH_BACKED },
+            >::new(),
+        }
+    }
+}
+
+impl NodeTarget for Bmsb {
+    unsafe fn reset_node(&mut self, controller: &mut RTController) {
+        self.nvm.reset();
+        rig_runtime::can::configure_network(BMSB_CAN_NETWORK);
+        unsafe { bindings::YAMCAN_shared_init_static() };
+        controller.set_analog_input(DRV_INPUTAD_ANALOG_CS as i32, 0.0);
+        controller.set_digital(DRV_INPUTAD_DIGITAL_TSMS_CHG as i32, false);
+        controller.set_digital(DRV_INPUTAD_DIGITAL_OK_HS as i32, false);
+        controller.set_digital(DRV_INPUTAD_DIGITAL_BMS_IMD_RESET as i32, false);
+        controller.set_digital(DRV_INPUTAD_DIGITAL_IMD_STATUS_MEM as i32, false);
+        controller.set_digital(DRV_INPUTAD_DIGITAL_BMS_STATUS_MEM as i32, false);
+    }
+}
+
+static BMSB: Mutex<NodeModel<Bmsb>> = Mutex::new(NodeModel::new(
+    RTController::new_embedded_module(),
+    Bmsb::new(),
+));
+
+rig_model_abi!(BMSB);
+rig_model_fault_abi!();
+
+rig_yamcan_network!(
+    BMSB_CAN_NETWORK,
+    rust_model_generated,
+    rust_decode_generated,
+    yamcan
+);

--- a/sim/models/controllers/bmsb/variants.py
+++ b/sim/models/controllers/bmsb/variants.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec, NodeSpec, PowerControlPath
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from . import BmsbModel
+
+
+def bmsb_node(
+    hardware: str | None = None, *, power_input: PowerControlPath | None = None
+) -> NodeSpec:
+    return NodeSpec("bmsb", BmsbModel, hardware=hardware, power_input=power_input)
+
+
+def bmsb_cluster_spec(hardware: str | None = None) -> ClusterSpec:
+    prefix = f"{hardware}-" if hardware is not None else ""
+    return ClusterSpec(
+        name=f"{prefix}bmsb-cluster",
+        hardware=hardware,
+        nodes=(bmsb_node(hardware),),
+    )
+
+
+BMSB_CLUSTERS = ClusterCatalog(
+    *(bmsb_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/controllers/sws/BUCK
+++ b/sim/models/controllers/sws/BUCK
@@ -1,9 +1,187 @@
-load("//sim/infra:defs.bzl", "rig_model_python")
+load("//components/sws:platforms.bzl", "SWS_PLATFORM_VARIANTS")
+load("//sim/infra:defs.bzl", "rig_bindgen", "rig_embedded_rust_model", "rig_embedded_rust_model_platform_aliases", "rig_feature_consts", "rig_model_c_support", "rig_model_python", "rig_platforms_from_variants", "rig_python_enums", "rig_python_model", "rig_runtime_srcs")
+
+SWS_SIM_PLATFORMS = rig_platforms_from_variants(SWS_PLATFORM_VARIANTS)
+
+rig_python_model(
+    name = "sws-py",
+    out = "sws.py",
+    rust_source = ":rust-wrapper-src",
+    class_name = "SwsModel",
+    symbol_prefix = "sws_sim",
+    buck_target = "//sim/models/controllers/sws:sil-so",
+    env_var = "SWS_SIM_LIB",
+    enum_env_var = "SWS_ENUMS_PY",
+    enum_target = "//sim/models/controllers/sws:enums-py",
+    visibility = ["PUBLIC"],
+)
 
 rig_model_python(
     srcs = [
         "__init__.py",
+        "fixtures.py",
         "simple.py",
+        "variants.py",
+        ":sws-py",
+        ":enums-py",
     ],
+    visibility = ["PUBLIC"],
+)
+
+rig_model_c_support(
+    srcs = rig_runtime_srcs(["can", "core", "flash", "io", "swi", "system", "time", "uart"]),
+    compiler_flags = [
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-include",
+        "BuildDefines.h",
+        "-include",
+        "Utility.h",
+        "-include",
+        "string.h",
+        "-Wno-unused-parameter",
+        "-fshort-enums",
+    ],
+    headers = {
+        "runtime_state.h": "//sim/infra/runtime:c/src/runtime_state.h",
+    },
+    deps = [
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/sws:sil-features",
+        "//components/sws:sil-host-headers",
+        "//components/sws:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+)
+
+rig_feature_consts(
+    name = "features-rs",
+    out = "features.rs",
+    deps = [
+        "//components/sws:sil-features",
+    ],
+    allowlist_vars = [
+        "APP_COMPONENT_ID",
+        "APP_VARIANT_ID",
+        "NVM_BLOCK_SIZE",
+        "NVM_FLASH_BACKED",
+        "NVM_LIB_ENABLED",
+    ],
+)
+
+rig_bindgen(
+    name = "bindings-rs",
+    out = "bindings.rs",
+    include_headers = [
+        "Module.h",
+        "HW_gpio_componentSpecific.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD.h",
+        "drv_outputAD_componentSpecific.h",
+        "YamcanShared.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/sws:sil-features",
+        "//components/sws:sil-host-headers",
+        "//components/sws:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    allowlist_types = [
+        "drv_inputAD_channelAnalog_E",
+        "drv_inputAD_channelDigital_E",
+        "drv_outputAD_channelDigital_E",
+        "HW_GPIO_pinmux_E",
+        "CAN_data_T",
+        "YamcanShared",
+    ],
+    allowlist_functions = [
+        "Module_Init",
+        "Module_1kHz_TSK",
+        "Module_100Hz_TSK",
+        "Module_10Hz_TSK",
+        "Module_1Hz_TSK",
+        "drv_outputAD_toggleDigitalState",
+        "YAMCAN_shared_init_static",
+    ],
+    allowlist_vars = [
+        "g_yamcan",
+    ],
+    bindgen_flags = [
+        "--no-layout-tests",
+        "--default-enum-style rust",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+)
+
+rig_python_enums(
+    name = "enums-py",
+    out = "enums.py",
+    include_headers = [
+        "HW_gpio_componentSpecific.h",
+        "HW_tim.h",
+        "drv_inputAD_componentSpecific.h",
+        "drv_outputAD_componentSpecific.h",
+    ],
+    deps = [
+        ":model-c-support",
+        "//components/shared/code:headers",
+        "//components/shared/code/RTOS:headers",
+        "//components/sws:sil-features",
+        "//components/sws:sil-host-headers",
+        "//components/sws:sil-yamcan-c",
+        "//components/vc/shared:headers",
+        "//sim/infra/runtime:headers",
+    ],
+    c_enums = [
+        "drv_inputAD_channelAnalog_E:AnalogInput:DRV_INPUTAD_ANALOG_::upper",
+        "drv_inputAD_channelDigital_E:DigitalInput:DRV_INPUTAD_DIGITAL_::upper",
+        "HW_GPIO_pinmux_E:DigitalIo:HW_GPIO_::upper",
+        "drv_outputAD_channelDigital_E:DigitalOutput:DRV_OUTPUTAD_DIGITAL_::upper",
+        "HW_TIM_port_E:TimerPort:HW_TIM_PORT_::upper",
+        "HW_TIM_channel_E:TimerChannel:HW_TIM_CHANNEL_::upper",
+    ],
+    clang_flags = [
+        "-include",
+        "BuildDefines.h",
+        "-fshort-enums",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model(
+    name = "sil-so",
+    crate = "sws_sim",
+    out = "libsws_sim.so",
+    link_deps = [
+        "//components/sws:sil-application",
+        ":model-c-support",
+        "//components/sws:sil-yamcan-c",
+        "//components/sws:sil-application",
+    ],
+    rust_env = {
+        "SWS_BINDINGS_RS": ":bindings-rs",
+        "SWS_FEATURES_RS": ":features-rs",
+        "SWS_YAMCAN_DECODE_RS": "//components/sws:sil-yamcan[rust_decode_generated.rs]",
+        "SWS_YAMCAN_MODEL_RS": "//components/sws:sil-yamcan[rust_model_generated.rs]",
+        "SWS_YAMCAN_RS": "//components/sws:sil-yamcan[yamcan.rs]",
+    },
+    visibility = ["PUBLIC"],
+)
+
+rig_embedded_rust_model_platform_aliases(
+    name = "sil-so",
+    actual = ":sil-so",
+    platforms = SWS_SIM_PLATFORMS,
     visibility = ["PUBLIC"],
 )

--- a/sim/models/controllers/sws/__init__.py
+++ b/sim/models/controllers/sws/__init__.py
@@ -1,8 +1,74 @@
-from __future__ import annotations
+from sim.infra.rig import TimerInterface, extend_model_class, load_generated_module
 
 from .simple import SwsSimpleModel
 
 
+def _load_generated() -> None:
+    if "SwsModel" in globals():
+        return
+
+    model = load_generated_module(
+        "SWS_MODEL_PY",
+        "//sim/models/controllers/sws:sws-py",
+        "sws_generated_model",
+    )
+    enums = load_generated_module(
+        "SWS_ENUMS_PY",
+        "//sim/models/controllers/sws:enums-py",
+        "sws_generated_enums",
+    )
+
+    globals()["AnalogInput"] = enums.AnalogInput
+    globals()["DigitalInput"] = enums.DigitalInput
+    globals()["DigitalIo"] = enums.DigitalIo
+    globals()["DigitalOutput"] = enums.DigitalOutput
+    globals()["TimerChannel"] = enums.TimerChannel
+    globals()["TimerPort"] = enums.TimerPort
+
+    class SwsModel(extend_model_class(model.SwsModel)):
+        timer = TimerInterface(enums.TimerPort, enums.TimerChannel)
+
+    globals()["SwsModel"] = SwsModel
+
+
+def __getattr__(name: str):
+    if name == "PLATFORM_VARIANTS":
+        from sim.models.platforms import PLATFORM_VARIANTS
+
+        globals()["PLATFORM_VARIANTS"] = PLATFORM_VARIANTS
+        return PLATFORM_VARIANTS
+    if name == "SWS_CLUSTERS":
+        from .variants import SWS_CLUSTERS
+
+        globals()["SWS_CLUSTERS"] = SWS_CLUSTERS
+        return SWS_CLUSTERS
+    if name in _GENERATED_EXPORTS:
+        _load_generated()
+        return globals()[name]
+    raise AttributeError(name)
+
+
+_GENERATED_EXPORTS = {
+    "AnalogInput",
+    "DigitalInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "TimerChannel",
+    "TimerPort",
+    "SwsModel",
+    "SWS_CLUSTERS",
+    "PLATFORM_VARIANTS",
+}
+
 __all__ = [
+    "AnalogInput",
+    "DigitalInput",
+    "DigitalIo",
+    "DigitalOutput",
+    "TimerChannel",
+    "TimerPort",
+    "PLATFORM_VARIANTS",
+    "SWS_CLUSTERS",
     "SwsSimpleModel",
+    "SwsModel",
 ]

--- a/sim/models/controllers/sws/fixtures.py
+++ b/sim/models/controllers/sws/fixtures.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sim.infra.rig import cluster_rig_fixture
+
+from .variants import SWS_CLUSTERS
+
+sws_cluster = cluster_rig_fixture(SWS_CLUSTERS)

--- a/sim/models/controllers/sws/src/lib.rs
+++ b/sim/models/controllers/sws/src/lib.rs
@@ -1,0 +1,104 @@
+mod rig_runtime {
+    include!(env!("RIG_RUNTIME_RS"));
+}
+
+mod bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("SWS_BINDINGS_RS"));
+}
+
+mod features {
+    #![allow(non_upper_case_globals)]
+    include!(env!("SWS_FEATURES_RS"));
+}
+
+mod yamcan {
+    include!(env!("SWS_YAMCAN_RS"));
+}
+
+pub use yamcan::SignalMeasurement;
+
+mod rust_model_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("SWS_YAMCAN_MODEL_RS"));
+}
+
+mod rust_decode_generated {
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    include!(env!("SWS_YAMCAN_DECODE_RS"));
+}
+
+use bindings::drv_outputAD_channelDigital_E::DRV_OUTPUTAD_DIGITAL_LED;
+use rig_runtime::nvm::ControllerNvm;
+use rig_runtime::{AppDesc, ModuleDesc, NodeModel, NodeTarget, RTController};
+use std::sync::Mutex;
+
+const SWS_APP_START: u32 = 0x0800_2000;
+const SWS_APP_END: u32 = 0x0801_0000;
+const SWS_APP_CRC_LOCATION: u32 = 0x0800_FFF0;
+
+rig_rt_controller_nvm_storage!(ControllerNvm<
+    { features::NVM_BLOCK_SIZE as usize },
+    { features::NVM_LIB_ENABLED },
+    { features::NVM_FLASH_BACKED },
+>);
+
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static appDesc: AppDesc = AppDesc::new(
+    SWS_APP_START,
+    SWS_APP_END,
+    SWS_APP_CRC_LOCATION,
+    features::APP_COMPONENT_ID as u16,
+    features::APP_VARIANT_ID as u16,
+);
+
+unsafe extern "C" fn sws_sys_1hz() {
+    unsafe { bindings::drv_outputAD_toggleDigitalState(DRV_OUTPUTAD_DIGITAL_LED) };
+}
+
+#[unsafe(no_mangle)]
+pub static sys_desc: ModuleDesc = ModuleDesc::new(None, None, None, None, Some(sws_sys_1hz));
+
+struct Sws {
+    nvm: ControllerNvm<
+        { features::NVM_BLOCK_SIZE as usize },
+        { features::NVM_LIB_ENABLED },
+        { features::NVM_FLASH_BACKED },
+    >,
+}
+
+impl Sws {
+    const fn new() -> Self {
+        Self {
+            nvm: ControllerNvm::<
+                { features::NVM_BLOCK_SIZE as usize },
+                { features::NVM_LIB_ENABLED },
+                { features::NVM_FLASH_BACKED },
+            >::new(),
+        }
+    }
+}
+
+impl NodeTarget for Sws {
+    unsafe fn reset_node(&mut self, _controller: &mut RTController) {
+        self.nvm.reset();
+        rig_runtime::can::configure_network(SWS_CAN_NETWORK);
+        unsafe { bindings::YAMCAN_shared_init_static() };
+    }
+}
+
+static SWS: Mutex<NodeModel<Sws>> = Mutex::new(NodeModel::new(
+    RTController::new_embedded_module(),
+    Sws::new(),
+));
+
+rig_model_abi!(SWS);
+
+rig_yamcan_network!(SWS_CAN_NETWORK, rust_model_generated, rust_decode_generated, yamcan);

--- a/sim/models/controllers/sws/variants.py
+++ b/sim/models/controllers/sws/variants.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sim.infra.rig import ClusterCatalog, ClusterSpec, NodeSpec, PowerControlPath
+from sim.models.platforms import PLATFORM_VARIANTS
+
+from . import SwsModel
+
+
+def sws_node(
+    hardware: str | None = None, *, power_input: PowerControlPath | None = None
+) -> NodeSpec:
+    return NodeSpec("sws", SwsModel, hardware=hardware, power_input=power_input)
+
+
+def sws_cluster_spec(hardware: str | None = None) -> ClusterSpec:
+    prefix = f"{hardware}-" if hardware is not None else ""
+    return ClusterSpec(
+        name=f"{prefix}sws-cluster",
+        hardware=hardware,
+        nodes=(sws_node(hardware),),
+    )
+
+
+SWS_CLUSTERS = ClusterCatalog(
+    *(sws_cluster_spec(hardware) for hardware in PLATFORM_VARIANTS),
+)

--- a/sim/models/controllers/variants.py
+++ b/sim/models/controllers/variants.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from sim.infra.rig import ClusterCatalog
+from sim.models.controllers.bmsb.variants import BMSB_CLUSTERS
 from sim.models.controllers.vcfront.variants import VCFRONT_CLUSTERS
 from sim.models.controllers.vcpdu.variants import VCPDU_CLUSTERS
 from sim.models.controllers.vcrear.variants import VCREAR_CLUSTERS
 
 CONTROLLER_CLUSTERS = ClusterCatalog(
-    *(VCFRONT_CLUSTERS.clusters + VCPDU_CLUSTERS.clusters + VCREAR_CLUSTERS.clusters),
+    *(
+        BMSB_CLUSTERS.clusters
+        + VCFRONT_CLUSTERS.clusters
+        + VCPDU_CLUSTERS.clusters
+        + VCREAR_CLUSTERS.clusters
+    ),
 )

--- a/sim/models/controllers/variants.py
+++ b/sim/models/controllers/variants.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sim.infra.rig import ClusterCatalog
 from sim.models.controllers.bmsb.variants import BMSB_CLUSTERS
+from sim.models.controllers.sws.variants import SWS_CLUSTERS
 from sim.models.controllers.vcfront.variants import VCFRONT_CLUSTERS
 from sim.models.controllers.vcpdu.variants import VCPDU_CLUSTERS
 from sim.models.controllers.vcrear.variants import VCREAR_CLUSTERS
@@ -9,6 +10,7 @@ from sim.models.controllers.vcrear.variants import VCREAR_CLUSTERS
 CONTROLLER_CLUSTERS = ClusterCatalog(
     *(
         BMSB_CLUSTERS.clusters
+        + SWS_CLUSTERS.clusters
         + VCFRONT_CLUSTERS.clusters
         + VCPDU_CLUSTERS.clusters
         + VCREAR_CLUSTERS.clusters

--- a/sim/models/controllers/vcfront/extensions.py
+++ b/sim/models/controllers/vcfront/extensions.py
@@ -82,6 +82,12 @@ class VcfrontPytestHelpers:
             self._voltage_for_position(position_percent, self._APPS2_POINTS),
         )
 
+    def latest_torque_request(self):
+        torque = self.can.latest("VCFRONT_torqueManager", bus="veh")
+        if torque is None:
+            return None
+        return torque.VCFRONT_torqueRequest
+
     def _voltage_for_position(
         self, position_percent: float, points: tuple[tuple[float, float], ...]
     ) -> float:

--- a/sim/models/controllers/vcpdu/extensions.py
+++ b/sim/models/controllers/vcpdu/extensions.py
@@ -40,6 +40,12 @@ class VcpduModelExtensions:
             bus="veh",
         )
 
+    def latest_vehicle_state_message(self):
+        return self.can.latest(
+            "VCPDU_vehicleState",
+            bus="veh",
+        )
+
     def record_latest_vehicle_state(self, observed: list) -> object | None:
         state = self.latest_vehicle_state()
         if state is not None and (not observed or observed[-1] != state):

--- a/sim/tests/BUCK
+++ b/sim/tests/BUCK
@@ -5,6 +5,7 @@ VCFRONT_MODEL = "//sim/models/controllers/vcfront"
 VCPDU_MODEL = "//sim/models/controllers/vcpdu"
 VCREAR_MODEL = "//sim/models/controllers/vcrear"
 BMSB_MODEL = "//sim/models/controllers/bmsb"
+SWS_MODEL = "//sim/models/controllers/sws"
 
 rig_pytest(
     name = "rig_infra",
@@ -50,6 +51,9 @@ rig_pytest(
         "BMSB_ENUMS_PY": "$(location {}:enums-py)".format(BMSB_MODEL),
         "BMSB_MODEL_PY": "$(location {}:bmsb-py)".format(BMSB_MODEL),
         "BMSB_SIM_LIB": "$(location {}:sil-so)".format(BMSB_MODEL),
+        "SWS_ENUMS_PY": "$(location {}:enums-py)".format(SWS_MODEL),
+        "SWS_MODEL_PY": "$(location {}:sws-py)".format(SWS_MODEL),
+        "SWS_SIM_LIB": "$(location {}:sil-so)".format(SWS_MODEL),
         "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
         "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
         "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
@@ -62,6 +66,7 @@ rig_pytest(
     } |
     rig_platform_variants_env(ALL_PLATFORMS) |
     rig_platform_sim_lib_env("BMSB", BMSB_MODEL, ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("SWS", SWS_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCPDU", VCPDU_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCREAR", VCREAR_MODEL, ALL_PLATFORMS),
@@ -69,6 +74,9 @@ rig_pytest(
         "{}:enums-py".format(BMSB_MODEL),
         "{}:bmsb-py".format(BMSB_MODEL),
         "{}:sil-so".format(BMSB_MODEL),
+        "{}:enums-py".format(SWS_MODEL),
+        "{}:sws-py".format(SWS_MODEL),
+        "{}:sil-so".format(SWS_MODEL),
         "{}:enums-py".format(VCFRONT_MODEL),
         "{}:vcfront-py".format(VCFRONT_MODEL),
         "{}:sil-so".format(VCFRONT_MODEL),
@@ -83,6 +91,7 @@ rig_pytest(
         "//sim/models/components/dc_load:python",
     ] +
     rig_platform_sim_lib_resources(BMSB_MODEL, ALL_PLATFORMS) +
+    rig_platform_sim_lib_resources(SWS_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCPDU_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),

--- a/sim/tests/BUCK
+++ b/sim/tests/BUCK
@@ -4,6 +4,7 @@ load("//sim/infra:defs.bzl", "rig_platform_sim_lib_env", "rig_platform_sim_lib_r
 VCFRONT_MODEL = "//sim/models/controllers/vcfront"
 VCPDU_MODEL = "//sim/models/controllers/vcpdu"
 VCREAR_MODEL = "//sim/models/controllers/vcrear"
+BMSB_MODEL = "//sim/models/controllers/bmsb"
 
 rig_pytest(
     name = "rig_infra",
@@ -46,6 +47,9 @@ rig_pytest(
     name = "component",
     test_file = "sim/tests/test_component.py",
     env = {
+        "BMSB_ENUMS_PY": "$(location {}:enums-py)".format(BMSB_MODEL),
+        "BMSB_MODEL_PY": "$(location {}:bmsb-py)".format(BMSB_MODEL),
+        "BMSB_SIM_LIB": "$(location {}:sil-so)".format(BMSB_MODEL),
         "VCFRONT_ENUMS_PY": "$(location {}:enums-py)".format(VCFRONT_MODEL),
         "VCFRONT_MODEL_PY": "$(location {}:vcfront-py)".format(VCFRONT_MODEL),
         "VCFRONT_SIM_LIB": "$(location {}:sil-so)".format(VCFRONT_MODEL),
@@ -57,10 +61,14 @@ rig_pytest(
         "VCREAR_SIM_LIB": "$(location {}:sil-so)".format(VCREAR_MODEL),
     } |
     rig_platform_variants_env(ALL_PLATFORMS) |
+    rig_platform_sim_lib_env("BMSB", BMSB_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCFRONT", VCFRONT_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCPDU", VCPDU_MODEL, ALL_PLATFORMS) |
     rig_platform_sim_lib_env("VCREAR", VCREAR_MODEL, ALL_PLATFORMS),
     resources = [
+        "{}:enums-py".format(BMSB_MODEL),
+        "{}:bmsb-py".format(BMSB_MODEL),
+        "{}:sil-so".format(BMSB_MODEL),
         "{}:enums-py".format(VCFRONT_MODEL),
         "{}:vcfront-py".format(VCFRONT_MODEL),
         "{}:sil-so".format(VCFRONT_MODEL),
@@ -74,6 +82,7 @@ rig_pytest(
         "//sim/models/components/asm330:python",
         "//sim/models/components/dc_load:python",
     ] +
+    rig_platform_sim_lib_resources(BMSB_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCFRONT_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCPDU_MODEL, ALL_PLATFORMS) +
     rig_platform_sim_lib_resources(VCREAR_MODEL, ALL_PLATFORMS),

--- a/sim/tests/test_component.py
+++ b/sim/tests/test_component.py
@@ -1,6 +1,7 @@
 from sim.infra.rig import DataPath
 from sim.models.controllers.bmsb import BmsbSimpleModel
 from sim.models.controllers.bmsb.fixtures import bmsb_cluster
+from sim.models.controllers.sws.fixtures import sws_cluster
 from sim.models.controllers.vcfront.fixtures import vcfront_cluster
 from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
 from sim.models.controllers.vcrear.fixtures import vcrear_cluster
@@ -88,6 +89,18 @@ def test_bmsb_can_tx_streams_emit_packets_on_every_bus(bmsb_cluster):
 
 def test_bmsb_can_rx_stream_consumes_injected_packet(bmsb_cluster):
     check_can_rx_stream_consumes_injected_packet(bmsb_cluster)
+
+
+def test_sws_can_tx_streams_emit_controller_heartbeat(sws_cluster):
+    check_can_tx_streams_emit_controller_heartbeat(sws_cluster)
+
+
+def test_sws_can_tx_streams_emit_packets_on_every_bus(sws_cluster):
+    check_can_tx_streams_emit_packets_on_every_bus(sws_cluster)
+
+
+def test_sws_can_rx_stream_consumes_injected_packet(sws_cluster):
+    check_can_rx_stream_consumes_injected_packet(sws_cluster)
 
 
 def test_vcpdu_can_tx_streams_emit_controller_heartbeat(vcpdu_cluster):

--- a/sim/tests/test_component.py
+++ b/sim/tests/test_component.py
@@ -1,3 +1,6 @@
+from sim.infra.rig import DataPath
+from sim.models.controllers.bmsb import BmsbSimpleModel
+from sim.models.controllers.bmsb.fixtures import bmsb_cluster
 from sim.models.controllers.vcfront.fixtures import vcfront_cluster
 from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
 from sim.models.controllers.vcrear.fixtures import vcrear_cluster
@@ -73,6 +76,18 @@ def test_vcfront_can_tx_streams_emit_packets_on_every_bus(vcfront_cluster):
 
 def test_vcfront_can_rx_stream_consumes_injected_packet(vcfront_cluster):
     check_can_rx_stream_consumes_injected_packet(vcfront_cluster)
+
+
+def test_bmsb_can_tx_streams_emit_controller_heartbeat(bmsb_cluster):
+    check_can_tx_streams_emit_controller_heartbeat(bmsb_cluster)
+
+
+def test_bmsb_can_tx_streams_emit_packets_on_every_bus(bmsb_cluster):
+    check_can_tx_streams_emit_packets_on_every_bus(bmsb_cluster)
+
+
+def test_bmsb_can_rx_stream_consumes_injected_packet(bmsb_cluster):
+    check_can_rx_stream_consumes_injected_packet(bmsb_cluster)
 
 
 def test_vcpdu_can_tx_streams_emit_controller_heartbeat(vcpdu_cluster):

--- a/sim/tests/test_vcfront.py
+++ b/sim/tests/test_vcfront.py
@@ -94,19 +94,17 @@ def test_pedal_position_sensors_report_on_can(
 
 
 @pytest.mark.parametrize(
-    "vehicle_state,torque_command_enabled",
+    "vehicle_state",
     [
-        pytest.param("INIT", False, id="init"),
-        pytest.param("ON_GLV", False, id="on-glv"),
-        pytest.param("ON_HV", False, id="on-hv"),
-        pytest.param("TS_RUN", True, id="ts-run"),
-        pytest.param("SLEEP", False, id="sleep"),
+        pytest.param("INIT", id="init"),
+        pytest.param("ON_GLV", id="on-glv"),
+        pytest.param("ON_HV", id="on-hv"),
+        pytest.param("SLEEP", id="sleep"),
     ],
 )
-def test_torque_request_requires_ts_run_but_driver_input_follows_pedal(
+def test_torque_request_stays_zero_when_accelerator_is_pressed_outside_ts_run(
     vcfront_cluster,
     vehicle_state,
-    torque_command_enabled,
 ):
     vcfront = vcfront_cluster.vcfront
     VehicleState = vcfront.can.enums.VehicleState
@@ -128,11 +126,40 @@ def test_torque_request_requires_ts_run_but_driver_input_follows_pedal(
     assert torque is not None
     assert debug is not None
     assert debug.VCFRONT_torqueDriverInput > 0
+    assert vcfront.latest_torque_request() == 0
 
-    if torque_command_enabled:
-        assert torque.VCFRONT_torqueRequest > 0
-    else:
-        assert torque.VCFRONT_torqueRequest == 0
+
+def test_torque_request_follows_accelerator_in_ts_run(vcfront_cluster):
+    vcfront = vcfront_cluster.vcfront
+    VehicleState = vcfront.can.enums.VehicleState
+    vcpdu = VcpduSimpleModel(vcfront.can)
+    vcpdu.periodic_vehicle_state(VehicleState.TS_RUN, period=20)
+    vcfront_cluster.add_component(vcpdu)
+
+    vcfront.set_brake_position(0)
+    vcfront.set_accelerator_position(0)
+    vcfront_cluster.run_until(
+        lambda: vcfront.latest_torque_request() == 0,
+        timeout=500,
+        step=20,
+        message="VCFRONT torque request should start at zero in TS_RUN",
+    )
+
+    vcfront.set_accelerator_position(50)
+    vcfront_cluster.run_until(
+        lambda: _positive(vcfront.latest_torque_request()),
+        timeout=500,
+        step=20,
+        message="VCFRONT torque request should become non-zero when accelerator is pressed in TS_RUN",
+    )
+
+    vcfront.set_accelerator_position(0)
+    vcfront_cluster.run_until(
+        lambda: vcfront.latest_torque_request() == 0,
+        timeout=500,
+        step=20,
+        message="VCFRONT torque request should return to zero when accelerator is released",
+    )
 
 
 @pytest.mark.parametrize(
@@ -231,3 +258,7 @@ def test_bppc_fault_latches_until_accelerator_is_released(vcfront_cluster):
     assert status.VCFRONT_acceleratorState == AppsState.OK
     assert status.VCFRONT_acceleratorPosition == 0
     assert status.VCFRONT_bppcState == BppcState.OK
+
+
+def _positive(value):
+    return value is not None and value > 0

--- a/sim/tests/test_vcpdu.py
+++ b/sim/tests/test_vcpdu.py
@@ -1,4 +1,5 @@
 import pytest
+from dataclasses import dataclass
 
 from sim.models.controllers.sws import SwsSimpleModel
 from sim.models.controllers.vcfront import VcfrontSimpleModel
@@ -11,11 +12,268 @@ def test_vcpdu_boots_and_cycles_to_glv_on(vcpdu_cluster):
     VehicleState = vcpdu_cluster.vcpdu.can.enums.VehicleState
     observed = []
 
-    def record_state():
-        return (
-            vcpdu_cluster.vcpdu.record_latest_vehicle_state(observed)
-            == VehicleState.ON_GLV
+    _run_vcpdu_to_glv_on(vcpdu_cluster, observed)
+
+    assert observed == [
+        VehicleState.INIT,
+        VehicleState.ON_GLV,
+    ]
+
+
+@dataclass
+class VcpduHvOnSetup:
+    cluster: object
+    vcpdu: object
+    tsms_status: object
+
+
+@dataclass
+class VcpduTsRunSetup:
+    cluster: object
+    vcpdu: object
+    tsms_status: object
+    contactor_state: object
+    run_request: object
+    brake_position: object
+
+
+@pytest.fixture
+def vcpdu_hv_on(vcpdu_cluster):
+    vcpdu = vcpdu_cluster.vcpdu
+    bmsb = BmsbSimpleModel(vcpdu.can)
+    DigitalStatus = bmsb.can.enums.DigitalStatus
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    tsms_status = bmsb.periodic_io_status(
+        period=10,
+        BMSB_tsmsChg=DigitalStatus.OFF,
+    )
+    vcpdu_cluster.add_component(bmsb)
+
+    _run_vcpdu_to_glv_on(vcpdu_cluster)
+
+    tsms_status.set(BMSB_tsmsChg=DigitalStatus.ON)
+    vcpdu_cluster.run_until(
+        lambda: vcpdu.latest_vehicle_state() == VehicleState.ON_HV,
+        timeout=500,
+        step=20,
+        message="vcpdu should enter ON_HV when TSMS closes",
+    )
+    return VcpduHvOnSetup(vcpdu_cluster, vcpdu, tsms_status)
+
+
+def test_vcpdu_enters_hv_on_when_tsms_closes(vcpdu_hv_on):
+    vcpdu = vcpdu_hv_on.vcpdu
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+
+def test_vcpdu_exits_hv_when_tsms_opens(vcpdu_hv_on):
+    vcpdu_cluster = vcpdu_hv_on.cluster
+    tsms_status = vcpdu_hv_on.tsms_status
+    vcpdu = vcpdu_hv_on.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    tsms_status.set(BMSB_tsmsChg=DigitalStatus.OFF)
+    vcpdu_cluster.run_for(100)
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_GLV
+
+
+@pytest.fixture
+def vcpdu_ts_run_inputs(vcpdu_cluster):
+    vcpdu = vcpdu_cluster.vcpdu
+    bmsb = BmsbSimpleModel(vcpdu.can)
+    sws = SwsSimpleModel(vcpdu.can)
+    vcfront = VcfrontSimpleModel(vcpdu.can)
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    PrechargeContactorState = vcpdu.can.enums.PrechargeContactorState
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    tsms_status = bmsb.periodic_io_status(
+        period=10,
+        BMSB_tsmsChg=DigitalStatus.OFF,
+    )
+    contactor_state = bmsb.periodic_pack_contactor_state(
+        PrechargeContactorState.HVP_CLOSED,
+        period=10,
+    )
+    run_request = sws.periodic_driver_request(
+        period=10,
+        SWS_requestRun=DigitalStatus.OFF,
+    )
+    brake_position = vcfront.periodic_pedal_position(
+        period=10,
+        VCFRONT_brakePosition=0,
+    )
+    vcpdu_cluster.add_components(bmsb, sws, vcfront)
+
+    _run_vcpdu_to_glv_on(vcpdu_cluster)
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_GLV
+
+    tsms_status.set(BMSB_tsmsChg=DigitalStatus.ON)
+    vcpdu.run_until_vehicle_state(
+        VehicleState.ON_HV,
+        timeout=500,
+        step=20,
+        message="vcpdu should enter ON_HV before TS_RUN inputs are applied",
+    )
+
+    return VcpduTsRunSetup(
+        vcpdu_cluster,
+        vcpdu,
+        tsms_status,
+        contactor_state,
+        run_request,
+        brake_position,
+    )
+
+
+@pytest.mark.parametrize(
+    ("brake_position", "expected_ts_run"),
+    [
+        pytest.param(0, False, id="run-request-without-brake"),
+        pytest.param(12, True, id="run-request-with-brake"),
+    ],
+)
+def test_vcpdu_enters_ts_run_only_when_driver_requests_run_with_brake_applied(
+    vcpdu_ts_run_inputs,
+    brake_position,
+    expected_ts_run,
+):
+    setup = vcpdu_ts_run_inputs
+    vcpdu = setup.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    setup.brake_position.set(VCFRONT_brakePosition=brake_position)
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+
+    if expected_ts_run:
+        vcpdu.run_until_vehicle_state(
+            VehicleState.TS_RUN,
+            timeout=500,
+            step=20,
+            message="vcpdu should enter TS_RUN with run request and brake applied",
         )
+    else:
+        setup.cluster.run_for(250)
+        assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    setup.run_request.set(SWS_requestRun=DigitalStatus.OFF)
+    setup.brake_position.set(VCFRONT_brakePosition=0)
+    setup.cluster.run_for(250)
+    expected_state = VehicleState.TS_RUN if expected_ts_run else VehicleState.ON_HV
+    assert vcpdu.latest_vehicle_state() == expected_state
+
+
+def test_vcpdu_exits_ts_run_when_tsms_opens(vcpdu_ts_run_inputs):
+    setup = vcpdu_ts_run_inputs
+    vcpdu = setup.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    setup.brake_position.set(VCFRONT_brakePosition=12)
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+    vcpdu.run_until_vehicle_state(
+        VehicleState.TS_RUN,
+        timeout=500,
+        step=20,
+        message="vcpdu should enter TS_RUN before testing TSMS exit",
+    )
+
+    setup.tsms_status.set(BMSB_tsmsChg=DigitalStatus.OFF)
+    vcpdu.run_until_vehicle_state(
+        VehicleState.ON_GLV,
+        timeout=500,
+        step=20,
+        message="vcpdu should exit TS_RUN when TSMS opens",
+    )
+
+
+def test_vcpdu_enters_ts_run_only_after_contactors_close(vcpdu_ts_run_inputs):
+    setup = vcpdu_ts_run_inputs
+    vcpdu = setup.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    PrechargeContactorState = vcpdu.can.enums.PrechargeContactorState
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    setup.contactor_state.set(
+        BMSB_packContactorState=PrechargeContactorState.OPEN,
+    )
+    setup.brake_position.set(VCFRONT_brakePosition=12)
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+
+    setup.cluster.run_for(250)
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    setup.contactor_state.set(
+        BMSB_packContactorState=PrechargeContactorState.HVP_CLOSED,
+    )
+    vcpdu.run_until_vehicle_state(
+        VehicleState.TS_RUN,
+        timeout=500,
+        step=20,
+        message="vcpdu should enter TS_RUN once contactors close",
+    )
+
+
+@pytest.mark.parametrize(
+    "brake_position",
+    [
+        pytest.param(0, id="brake-released"),
+        pytest.param(12, id="brake-applied"),
+    ],
+)
+def test_vcpdu_stays_in_ts_run_after_additional_driver_run_request(
+    vcpdu_ts_run_inputs,
+    brake_position,
+):
+    setup = vcpdu_ts_run_inputs
+    vcpdu = setup.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    VehicleState = vcpdu.can.enums.VehicleState
+
+    setup.brake_position.set(VCFRONT_brakePosition=12)
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+    vcpdu.run_until_vehicle_state(
+        VehicleState.TS_RUN,
+        timeout=500,
+        step=20,
+        message="vcpdu should enter TS_RUN before additional driver run request",
+    )
+    setup.cluster.run_for(100)
+    assert vcpdu.latest_vehicle_state() == VehicleState.TS_RUN
+
+    setup.run_request.set(SWS_requestRun=DigitalStatus.OFF)
+    setup.brake_position.set(VCFRONT_brakePosition=brake_position)
+    setup.cluster.run_for(100)
+    assert vcpdu.latest_vehicle_state() == VehicleState.TS_RUN
+
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+    setup.cluster.run_for(100)
+    assert vcpdu.latest_vehicle_state() == VehicleState.TS_RUN
+
+
+def _run_vcpdu_to_glv_on(vcpdu_cluster, observed: list | None = None) -> None:
+    VehicleState = vcpdu_cluster.vcpdu.can.enums.VehicleState
+
+    def record_state():
+        state = vcpdu_cluster.vcpdu.latest_vehicle_state()
+        if (
+            observed is not None
+            and state is not None
+            and (not observed or observed[-1] != state)
+        ):
+            observed.append(state)
+        return state == VehicleState.ON_GLV
 
     vcpdu_cluster.run_until(
         record_state,
@@ -23,11 +281,6 @@ def test_vcpdu_boots_and_cycles_to_glv_on(vcpdu_cluster):
         step=10,
         message="vcpdu should boot to ON_GLV",
     )
-
-    assert observed == [
-        VehicleState.INIT,
-        VehicleState.ON_GLV,
-    ]
 
 
 @pytest.mark.parametrize(
@@ -148,6 +401,7 @@ def test_driver_cooling_request_toggles_and_latches_load_current(
         message="VCPDU HSD load should report zero current after a second driver request toggles it off",
     )
 
+
 @pytest.mark.parametrize(
     ("bms_safety_enabled", "imd_safety_enabled"),
     [
@@ -185,10 +439,8 @@ def test_bmsb_faults_sets_safety_fault(
     def safety_status_matches_expected():
         status = vcpdu.latest_vehicle_state_message()
         return status is not None and (
-            status.VCPDU_bmsbSafetyStatus
-            == expected_status[bms_safety_enabled]
-            and status.VCPDU_imdSafetyStatus
-            == expected_status[imd_safety_enabled]
+            status.VCPDU_bmsbSafetyStatus == expected_status[bms_safety_enabled]
+            and status.VCPDU_imdSafetyStatus == expected_status[imd_safety_enabled]
         )
 
     vcpdu_cluster.run_until(

--- a/sim/tests/test_vcpdu.py
+++ b/sim/tests/test_vcpdu.py
@@ -226,6 +226,42 @@ def test_vcpdu_enters_ts_run_only_after_contactors_close(vcpdu_ts_run_inputs):
 
 
 @pytest.mark.parametrize(
+    "contactor_state_name",
+    [
+        pytest.param("SNA", id="sna"),
+        pytest.param("OPEN", id="open"),
+        pytest.param("PRECHARGE_CLOSED", id="precharge-closed"),
+        pytest.param("PRECHARGE_HVP_CLOSED", id="precharge-hvp-closed"),
+    ],
+)
+def test_vcpdu_does_not_cycle_from_hv_on_to_ts_run_without_hvp_contactors_closed(
+    vcpdu_ts_run_inputs,
+    contactor_state_name,
+):
+    setup = vcpdu_ts_run_inputs
+    vcpdu = setup.vcpdu
+    DigitalStatus = vcpdu.can.enums.DigitalStatus
+    PrechargeContactorState = vcpdu.can.enums.PrechargeContactorState
+    VehicleState = vcpdu.can.enums.VehicleState
+    observed = []
+
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+    setup.contactor_state.set(
+        BMSB_packContactorState=getattr(PrechargeContactorState, contactor_state_name),
+    )
+    setup.brake_position.set(VCFRONT_brakePosition=12)
+    setup.run_request.set(SWS_requestRun=DigitalStatus.ON)
+
+    for _ in range(50):
+        setup.cluster.run_for(10)
+        vcpdu.record_latest_vehicle_state(observed)
+
+    assert VehicleState.TS_RUN not in observed
+    assert vcpdu.latest_vehicle_state() == VehicleState.ON_HV
+
+
+@pytest.mark.parametrize(
     "brake_position",
     [
         pytest.param(0, id="brake-released"),

--- a/sim/tests/test_vcpdu.py
+++ b/sim/tests/test_vcpdu.py
@@ -2,6 +2,7 @@ import pytest
 
 from sim.models.controllers.sws import SwsSimpleModel
 from sim.models.controllers.vcfront import VcfrontSimpleModel
+from sim.models.controllers.bmsb import BmsbSimpleModel
 from sim.models.controllers.vcpdu import Vn9008Channel
 from sim.models.controllers.vcpdu.fixtures import vcpdu_cluster
 
@@ -146,6 +147,61 @@ def test_driver_cooling_request_toggles_and_latches_load_current(
         step=20,
         message="VCPDU HSD load should report zero current after a second driver request toggles it off",
     )
+
+@pytest.mark.parametrize(
+    ("bms_safety_enabled", "imd_safety_enabled"),
+    [
+        pytest.param(True, True, id="no-fault"),
+        pytest.param(True, False, id="imd-fault"),
+        pytest.param(False, True, id="bms-fault"),
+    ],
+)
+def test_bmsb_faults_sets_safety_fault(
+    vcpdu_cluster,
+    bms_safety_enabled,
+    imd_safety_enabled,
+):
+    vcpdu = vcpdu_cluster.vcpdu
+    bmsb = BmsbSimpleModel(vcpdu.can)
+    ShutdownCircuitStatus = bmsb.can.enums.ShutdownCircuitStatus
+    DigitalStatus = bmsb.can.enums.DigitalStatus
+    enabled_status = {
+        True: DigitalStatus.ON,
+        False: DigitalStatus.OFF,
+    }
+    expected_status = {
+        True: ShutdownCircuitStatus.CLOSED,
+        False: ShutdownCircuitStatus.OPEN,
+    }
+
+    bmsb.periodic_io_status(
+        period=10,
+        BMSB_bmsStatusMem=enabled_status[bms_safety_enabled],
+        BMSB_imdStatusMem=enabled_status[imd_safety_enabled],
+    )
+
+    vcpdu_cluster.add_component(bmsb)
+
+    def safety_status_matches_expected():
+        status = vcpdu.latest_vehicle_state_message()
+        return status is not None and (
+            status.VCPDU_bmsbSafetyStatus
+            == expected_status[bms_safety_enabled]
+            and status.VCPDU_imdSafetyStatus
+            == expected_status[imd_safety_enabled]
+        )
+
+    vcpdu_cluster.run_until(
+        safety_status_matches_expected,
+        timeout=1000,
+        step=20,
+        message="vcpdu should report BMSB safety status from BMSB_ioStatus",
+    )
+
+    status = vcpdu.latest_vehicle_state_message()
+
+    assert status.VCPDU_bmsbSafetyStatus == expected_status[bms_safety_enabled]
+    assert status.VCPDU_imdSafetyStatus == expected_status[imd_safety_enabled]
 
 
 def _driver_request_signal(vcpdu, hsd_channel) -> str:


### PR DESCRIPTION
### Reason for Change

Start building vehicle level integration testing.

### Changes

1. Add vehicle state test coverage
2. Add torque request test coverage
3. Fix bug in vehicle state that cycles between TS_RUN and HV_ON and GLV_ON

### Test Plan

- Successful sim CI
